### PR TITLE
Fix Algolia Config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -46,7 +46,8 @@ const config = {
       appId: process.env.ALGOALIA_APPID,
       apiKey: process.env.ALGOLIA_APIKEY,
       indexName: process.env.INDEX_NAME,
-      contextualSearch: false
+      contextualSearch: false,
+      searchPagePath: false
     },
     navbar: {
       title: "",


### PR DESCRIPTION
- Until we start splitting out content within Docusaurus by either language or version, `contextualizeSearch` must be set to `false` in order to display search results.
- The Search results page shows no results. This may be resolved once the docusaurus site matches the crawled data, but we'll remove it for now since it's not working.