### PR TITLE
Disable auto-open browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "start": "docusaurus start --no-open",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",


### PR DESCRIPTION
By default, when the dev server starts it opens the default browser. This is undesired behavior for those using alternate browsers for development. It's especially annoying when using Linux on Chrome, where it will open the Linux default browser. 

This adds the [--no-open](https://docusaurus.io/docs/cli) flag to the start command to avoid this nuisance. 