### PR TITLE
adjust sitemap path

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -52,6 +52,9 @@ const config = {
       contextualSearch: false,
       searchPagePath: false
     },
+    sitemap: {
+      filename: 'docs/sitemap.xml'
+    },
     navbar: {
       title: "",
       logo: {


### PR DESCRIPTION
Adjust the [sitemap plugin](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-sitemap) to place the sitemap under `/docs`.