### PR TITLE
remove shortdocs for ent certs

### DIFF
--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -810,22 +810,19 @@
     "title": "TLS Client Certificate",
     "path": "/routes/tls-client-certificate",
     "services": ["proxy"],
-    "short_description": "Base64 encoded string or relative file location",
     "type": "string"
   },
   "tls-custom-certificate-authority": {
     "id": "tls-custom-certificate-authority",
     "title": "TLS Custom Certificate Authority",
     "path": "/routes/tls-custom-certificate-authority",
-    "services": ["proxy"],
-    "short_description": "Base64 encoded string or relative file location"
+    "services": ["proxy"]
   },
   "tls-downstream-client-certificate-authority": {
     "id": "tls-downstream-client-certificate-authority",
     "title": "TLS Downstream Client Certificate Authority",
     "path": "/routes/tls-downstream-client-certificate-authority",
-    "services": ["proxy"],
-    "short_description": "Base64 encoded string or relative file location"
+    "services": ["proxy"]
   },
   "tls-skip-verification": {
     "id": "tls-skip-verification",

--- a/src/pages/markdown-page.md
+++ b/src/pages/markdown-page.md
@@ -1,7 +1,0 @@
----
-title: Markdown page example
----
-
-# Markdown page example
-
-You don't need React to write simple standalone pages.


### PR DESCRIPTION
Doesn't apply in Console, where certificate fields are drop downs.

Will resolve https://github.com/pomerium/pomerium-console/issues/2596 once merged and console pulls the changes.