### PR TITLE
Adjust path for Autocert

### DIFF
--- a/content/docs/reference/autocert/autocert-directory.md
+++ b/content/docs/reference/autocert/autocert-directory.md
@@ -15,7 +15,7 @@ pagination_next: null
 - Environmental Variable: either `AUTOCERT_DIR`
 - Config File Key: `autocert_dir`
 - Type: `string` pointing to the path of the directory
-- Required if using [Autocert](/docs/reference/autocert/autocert) setting
+- Required if using [Autocert](/docs/reference/autocert) setting
 - Default:
 
   - `/data/autocert` in published Pomerium docker images

--- a/content/docs/reference/autocert/autocert-must-staple.md
+++ b/content/docs/reference/autocert/autocert-must-staple.md
@@ -15,7 +15,7 @@ pagination_next: null
 - Type: `bool`
 - Optional
 
-If true, force autocert to request a certificate with the `status_request` extension (commonly called `Must-Staple`). This allows the TLS client (_id est_ the browser) to fail immediately if the TLS handshake doesn't include OCSP stapling information. This setting is only used when [Autocert](/docs/reference/autocert/autocert) is true.
+If true, force autocert to request a certificate with the `status_request` extension (commonly called `Must-Staple`). This allows the TLS client (_id est_ the browser) to fail immediately if the TLS handshake doesn't include OCSP stapling information. This setting is only used when [Autocert](/docs/reference/autocert) is true.
 
 :::tip
 

--- a/content/docs/reference/autocert/readme.md
+++ b/content/docs/reference/autocert/readme.md
@@ -1,7 +1,6 @@
 ---
 id: autocert
 title: Autocert
-slug: /docs/reference/autocert/autocert
 description: |
   Turning on autocert allows Pomerium to automatically retrieve, manage, and renew public facing TLS certificates from Lets Encrypt.
 keywords:

--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -19,7 +19,7 @@
   },
   "autocert": {
     "id": "autocert",
-    "path": "/autocert/autocert",
+    "path": "/autocert",
     "title": "Autocert",
     "description": "Turning on autocert allows Pomerium to automatically retrieve, manage, and renew public facing TLS certificates from Lets Encrypt.",
     "short_description": "",

--- a/content/docs/topics/certificates.mdx
+++ b/content/docs/topics/certificates.mdx
@@ -122,7 +122,7 @@ Certificates, TLS, and Public Key Cryptography is a vast subject we cannot adequ
 - [Use TLS](https://smallstep.com/blog/use-tls.html) covers why TLS should be used everywhere; not just for securing typical internet traffic but for securing service communication in both "trusted" and adversarial situations.
 - [Everything you should know about certificates and PKI but are too afraid to ask](https://smallstep.com/blog/everything-pki.html)
 
-[autocert]: /docs/reference/autocert/autocert
+[autocert]: /docs/reference/autocert
 [autocert directory]: /docs/reference/autocert/autocert-directory
 [certificate]: /docs/reference/certificates
 [certificate_authority]: /docs/reference/certificate-authority


### PR DESCRIPTION
With this change, the reference page behaves the way routes does, as an index for the section.