### PR TITLE
remove trailing slash

### DIFF
--- a/content/docs/install/index.mdx
+++ b/content/docs/install/index.mdx
@@ -4,8 +4,8 @@ pagination_prev: null
 pagination_next: null
 ---
 
-There are many ways to install Pomerium. Check out our [Quickstart](quickstart) page to get a proof-of-concept container up and running quickly, or see one of the other options below:
+There are many ways to install Pomerium. Check out our [Quickstart](install/quickstart) page to get a proof-of-concept container up and running quickly, or see one of the other options below:
 
-- [Binaries](./binary) covers installing Pomerium as a system service from a repository.
-- [From Source](./from-source) details how to build Pomerium Core from the source code.
+- [Binaries](install/binary) covers installing Pomerium as a system service from a repository.
+- [From Source](install/from-source) details how to build Pomerium Core from the source code.
 - For Kubernetes environments, see [Helm](/docs/k8s/helm) to set up Pomerium and the Pomerium Ingress Controller.

--- a/content/docs/tcp/index.md
+++ b/content/docs/tcp/index.md
@@ -47,7 +47,7 @@ When creating TCP routes, note the following:
 
 ## Connect to TCP Routes
 
-While HTTP routes can be consumed with just a normal browser, `pomerium-cli` or Pomerium Desktop must serve as a proxy for TCP routes. See [Pomerium Desktop and CLI Clients](./client) for more information.
+While HTTP routes can be consumed with just a normal browser, `pomerium-cli` or Pomerium Desktop must serve as a proxy for TCP routes. See [Pomerium Desktop and CLI Clients](tcp/client) for more information.
 
 To connect, you normally need just the external hostname and port of your TCP route:
 
@@ -73,7 +73,7 @@ localhost:52046>
 
 You may specify an optional address and port for the `tcp` command to listen on.
 
-`-` specifies that STDIN and STDOUT should be directly attached to the remote TCP connection.  This is useful for [SSH](examples/ssh#tunnel-and-connect-simultaneously) or for sending data through a shell pipe.
+`-` specifies that STDIN and STDOUT should be directly attached to the remote TCP connection.  This is useful for [SSH](tcp/examples/ssh#tunnel-and-connect-simultaneously) or for sending data through a shell pipe.
 
 ### Custom URL
 
@@ -89,9 +89,9 @@ The command above connects to `https://pomerium.corp.example.com:8443` and then 
 
 We've outlined how to use a TCP tunnel through Pomerium for several popular services that use TCP connections:
 
-- [Git](examples/git)
-- [Microsoft SQL](examples/ms-sql)
-- [MySQL and MariaDB](examples/mysql)
-- [RDP](examples/rdp)
-- [Redis](examples/redis)
-- [SSH](examples/ssh)
+- [Git](tcp/examples/git)
+- [Microsoft SQL](tcp/examples/ms-sql)
+- [MySQL and MariaDB](tcp/examples/mysql)
+- [RDP](tcp/examples/rdp)
+- [Redis](tcp/examples/redis)
+- [SSH](tcp/examples/ssh)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -17,6 +17,7 @@ const config = {
   favicon: "img/favicon.ico",
   organizationName: "pomerium",
   projectName: "documentation",
+  trailingSlash: false,
 
   customFields: {
     xgridKey: process.env.XGRID_KEY,


### PR DESCRIPTION
This makes category index page URLs consistent with other pages, and should also reduce our search index size by removing dupes.