### PR TITLE
Update "From Source" installation

### DIFF
--- a/content/docs/install/from-source.mdx
+++ b/content/docs/install/from-source.mdx
@@ -50,6 +50,8 @@ make
 
 [Make] will run all the tests, some code linters, then build the binary. If all is good, you should now have a freshly built Pomerium binary for your architecture and operating system in the `pomerium/bin` directory.
 
+If you don't have the prerequisites for the tests (Docker, Redis, etc) locally, you can instead run `make build` to just create the binary.
+
 ## Configure
 
 Pomerium supports setting [configuration variables] using both environmental variables and using a configuration file.
@@ -65,7 +67,7 @@ Create a config file (`config.yaml`). This file will be use to determine Pomeriu
 Finally, run Pomerium specifying the configuration file `config.yaml`.
 
 ```bash
-make && ./bin/pomerium -config config.yaml
+./bin/pomerium -config config.yaml
 ```
 
 ### Navigate

--- a/content/examples/config/config.minimal.yaml.md
+++ b/content/examples/config/config.minimal.yaml.md
@@ -1,15 +1,18 @@
 ```yaml
 # See detailed configuration settings : https://www.pomerium.com/docs/reference/
 
-
 # this is the domain the identity provider will callback after a user authenticates
 authenticate_service_url: https://authenticate.localhost.pomerium.io
 
 # certificate settings:  https://www.pomerium.com/docs/reference/certificates.html
 autocert: true
-
 # REMOVE FOR PRODUCTION
 autocert_use_staging: true
+
+# If you're using mkcert to test Pomerium locally, comment the autocert keys and uncomment
+# the keys below, adjusting for your mkcert path:
+# certificate_file: /home/user/.local/share/mkcert/rootCA.pem
+# certificate_key_file: /user/alex/.local/share/mkcert/rootCA-key.pem
 
 # identity provider settings : https://www.pomerium.com/docs/identity-providers.html
 idp_provider: google


### PR DESCRIPTION
Minor updates to our "From Source" install doc.

- Reference `make build` to skip tests.
- remove redundant `make` when running
- Update example minimal config with optional keys for mkcert-based local install.