### PR TITLE
crosslink static and dynamic header ref pages

### DIFF
--- a/content/docs/reference/jwt-claim-headers.md
+++ b/content/docs/reference/jwt-claim-headers.md
@@ -6,12 +6,11 @@ description: |
 keywords:
 - reference
 - JWT Claim Headers
+- jwt_claim_headers
 pagination_prev: null
 pagination_next: null
 ---
 
-
-# JWT Claim Headers
 - Environmental Variable: `JWT_CLAIMS_HEADERS`
 - Config File Key: `jwt_claims_headers`
 - Type: slice of `string`
@@ -37,3 +36,4 @@ Will add an `X-Email` header with a value of the `email` claim.
 
 Use this option if you previously relied on `x-pomerium-authenticated-user-{email|user-id|groups}`.
 
+To pass static values as request headers to the upstream service, see [Set Request Headers](./routes/set-request-headers).

--- a/content/docs/reference/routes/set-request-headers.md
+++ b/content/docs/reference/routes/set-request-headers.md
@@ -4,12 +4,11 @@ title: Set Request Headers
 keywords:
 - reference
 - Set Request Headers
+- set_request_headers
 pagination_prev: null
 pagination_next: null
 ---
 
-
-# Set Request Headers
 - Config File Key: `set_request_headers`
 - Type: map of `strings` key value pairs
 - Optional
@@ -30,9 +29,11 @@ Set Request Headers allows you to set static values for given request headers. T
     Authorization: Basic cm9vdDpodW50ZXI0Mg==
     X-Your-favorite-authenticating-Proxy: "Pomerium"
 ```
+
 :::warning
 
 Neither `:-prefixed` pseudo-headers nor the `Host:` header may be modified via this mechanism. Those headers may instead be modified via mechanisms such as `prefix_rewrite`, `regex_rewrite`, and `host_rewrite`.
 
 :::
 
+To pass dynamic values from the user's OIDC claim to the upstream service, see [JWT Claim Headers](../jwt-claim-headers).


### PR DESCRIPTION
Might resolve https://github.com/pomerium/pomerium/issues/3424

Crosslinks reference pages for `set_request_headers` and `jwt_claim_headers`.