### PR TITLE
exclude examples dir from sitemap

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -41,7 +41,8 @@ const config = {
           trackingID: process.env.GA
         },
         sitemap: {
-          filename: 'docs/sitemap.xml'
+          filename: 'docs/sitemap.xml',
+          ignorePatterns: ['/docs/examples/**']
         },
       },
     ],


### PR DESCRIPTION
Excludes the `examples` directory from the sitemap. The contents of that directory are used as embedded example content, but not displayed directly.