### PR TITLE
Document autostart for common desktops

### DIFF
--- a/content/docs/tcp/client.mdx
+++ b/content/docs/tcp/client.mdx
@@ -61,6 +61,50 @@ Download the latest release from [GitHub](https://github.com/pomerium/desktop-cl
 - **Linux**: We provide Linux binaries as `.AppImage` files, which can be executed in place or managed with a tool like [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher). Interact with the client from the system tray icon.
 - **macOS**: Open the `dmg` and move the binary to **Applications**. Interact with the client from the system tray icon.
 
+<details>
+<summary>Autostart Pomerium Desktop</summary>
+
+If you want Pomerium Desktop to start automatically when you log in to your computer, follow the steps below for your operating system.
+
+<Tabs>
+<TabItem value="windows" label="Windows">
+
+#### Autostart for all users
+
+Copy the shortcut for the Pomerium Desktop app into `C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Startup`. 
+
+#### Autostart for your user
+
+Copy the shortcut for the Pomerium Desktop app into `C:\Users\username\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup`, replacing `username` with your user name.
+
+---
+
+Windows 11 also offers a GUI method, documented by [windowscentral.com](https://www.windowscentral.com/how-launch-apps-automatically-during-login-windows-11)
+
+</TabItem>
+<TabItem value="mac" label="MacOS">
+
+1. From **System Preferences**, select **Users & Groups**.
+
+1. Click **Login Items** near the top, then the **+** button towards the bottom of the window.
+
+1. Select Pomerium Desktop from the Applications folder.
+
+</TabItem>
+<TabItem value="gnome" label="Linux (Gnome)">
+
+The easiest way to autostart user applications in the Gnome Desktop Environment is by using the Tweaks application. Gnome documents this process well, so we won't replicate it here. See [Gnome's documentation](https://help.gnome.org/users/gnome-help/stable/shell-apps-auto-start.html) for more information.
+
+</TabItem>
+<TabItem value="kde" label="Linux (KDE)">
+
+KDE's documentation covers autostarting applications well: see [System Settings/Autostart](https://userbase.kde.org/System_Settings/Autostart) from the KDE UsersBase Wiki for more information. 
+
+</TabItem>
+</Tabs>
+
+</details>
+
 ### Add a Connection
 
 ![A new connection to an SSH gateway](examples/img/desktop/demo-new-connection.png)

--- a/content/docs/tcp/client.mdx
+++ b/content/docs/tcp/client.mdx
@@ -75,7 +75,7 @@ Copy the shortcut for the Pomerium Desktop app into `C:\ProgramData\Microsoft\Wi
 
 #### Autostart for your user
 
-Copy the shortcut for the Pomerium Desktop app into `C:\Users\username\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup`, replacing `username` with your user name.
+Copy the shortcut for the Pomerium Desktop app into `C:\Users\username\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup`, replacing `username` with your username.
 
 ---
 


### PR DESCRIPTION
Describes how to add Pomerium Desktop to autostart for Windows, MacOS, Gnome and KDE (linux).

This would resolve https://github.com/pomerium/internal/issues/873.