### PR TITLE
ignore .markdownlint.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@
 .env.production.local
 
 .vscode/
-
+.markdownlint.json
 .env
 
 npm-debug.log*


### PR DESCRIPTION
Updates `.gitignore` with a file used to reign in my markdown linter.