### PR TITLE
Update Auth0 Doc

### DIFF
--- a/content/docs/identity-providers/auth0.mdx
+++ b/content/docs/identity-providers/auth0.mdx
@@ -104,6 +104,10 @@ IDP_SERVICE_ACCOUNT="REPLACE_ME" # built from the machine-to-machine application
 </TabItem>
 </Tabs>
 
+:::tip
+Remember to prepend the provider URL from Auth0 with `https://`.
+:::
+
 [Auth0]: https://auth0.com/
 [authenticate service url]: /docs/reference/authenticate-service-url
 [environmental variables]: https://en.wikipedia.org/wiki/Environment_variable


### PR DESCRIPTION
I re-ran this guide and found it to still work completely. Added a callout since I got bit by not having `https` on the provider URL.

Closes https://github.com/pomerium/docs/issues/75