### PR TITLE
Add Google Tag Manager

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -186,6 +186,14 @@ const config = {
     "https://fonts.googleapis.com/icon?family=Material+Icons",
     "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/css/brands.min.css",
   ],
+  plugins: [
+    [
+      require.resolve('docusaurus-gtm-plugin'),
+      {
+        id: process.env.GTM
+      }
+    ]
+  ]
 };
 
 if (!process.env.ALGOALIA_APPID) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@mui/x-data-grid": "^5.10.0",
     "@mui/x-data-grid-pro": "^5.10.0",
     "clsx": "^1.1.1",
+    "docusaurus-gtm-plugin": "^0.0.2",
     "dotenv": "^16.0.1",
     "mdx-mermaid": "^1.2.2",
     "mermaid": "^9.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4862,6 +4862,11 @@ dns-packet@^5.2.2:
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
 
+docusaurus-gtm-plugin@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/docusaurus-gtm-plugin/-/docusaurus-gtm-plugin-0.0.2.tgz#f39864b54ca594e3281902c23b6df0763761602b"
+  integrity sha512-Xx/df0Ppd5SultlzUj9qlQk2lX9mNVfTb41juyBUPZ1Nc/5dNx+uN0VuLyF4JEObkDRrUY1EFo9fEUDo8I6QOQ==
+
 dom-converter@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.2.0.tgz#6721a9daee2e293682955b6afe416771627bb768"


### PR DESCRIPTION
Adds `docusaurus-gtm-plugin`. The GTM ID has been set in Netlify's environment variables.