### PR TITLE
docs: fix references to v17

### DIFF
--- a/content/docs/troubleshooting.mdx
+++ b/content/docs/troubleshooting.mdx
@@ -6,9 +6,9 @@ lang: en-US
 keywords: [pomerium, troubleshooting, faq, frequently asked questions]
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import GenerateRecoveryToken from '@site/content/_generate-recovery-token.md'
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import GenerateRecoveryToken from "@site/content/_generate-recovery-token.md";
 
 This article provides troubleshooting information for various tools and features in Pomerium.
 
@@ -40,33 +40,33 @@ For upstream applications that can use a local signing key file, you can circumv
 
 1. Download the `jwks.json` file from the authenticate server:
 
-    <Tabs>
-    <TabItem value="curl" label="curl">
+   <Tabs>
+<TabItem value="curl" label="curl">
 
-    ```bash
-    curl https://authenticate.localhost.pomerium.io/.well-known/pomerium/jwks.json > /etc/grafana/jwks.json
-    ```
+   ```bash
+   curl https://authenticate.localhost.pomerium.io/.well-known/pomerium/jwks.json > /etc/grafana/jwks.json
+   ```
 
-    </TabItem>
-    <TabItem value="wget" label="wget">
+   </TabItem>
+<TabItem value="wget" label="wget">
 
-    ```bash
-    wget -O /etc/grafana/jwks.json https://authenticate.localhost.pomerium.io/.well-known/pomerium/jwks.json
-    ```
+   ```bash
+   wget -O /etc/grafana/jwks.json https://authenticate.localhost.pomerium.io/.well-known/pomerium/jwks.json
+   ```
 
-    </TabItem>
-    </Tabs>
+   </TabItem>
+</Tabs>
 
 1. Edit the upstream service configuration to use the local key to verify tokens:
 
-    ```ini
-    [auth.jwt]
-    enabled = true
-    header_name = X-Pomerium-Jwt-Assertion
-    email_claim = email
-    jwk_set_file = /etc/grafana/jwks.json
-    cache_ttl = 60m
-    ```
+   ```ini
+   [auth.jwt]
+   enabled = true
+   header_name = X-Pomerium-Jwt-Assertion
+   email_claim = email
+   jwk_set_file = /etc/grafana/jwks.json
+   cache_ttl = 60m
+   ```
 
 ### Kubernetes Ingress Controller
 
@@ -136,7 +136,7 @@ Update the [shared secret](/docs/reference/shared-secret) across all Pomerium se
 #### Redis Secret Mismatch
 
 :::caution
-The use of Redis as the databroker storage type has been deprecated in favor of Postgres. See [Previous Versions](https://0-17-0.docs.pomerium.com/docs/troubleshooting#redis-secret-mismatch) of this page for information regarding Redis.
+The use of Redis as the databroker storage type has been deprecated in favor of Postgres. See [Previous Versions](https://v17.docs.pomerium.com/docs/troubleshooting#redis-secret-mismatch) of this page for information regarding Redis.
 :::
 
 ### RPC Errors
@@ -161,17 +161,18 @@ Ensure that the Proxy service knows about and trusts the certificate authority t
 - Add the certificate authority to the system's underlying trust store.
 - Replace your system / docker image certificate bundle.
 
-    For Docker:
+  For Docker:
 
-    ```docker
-    COPY --from=builder /etc/ssl/certs/your-cert-bundle.crt /etc/ssl/certs/ca-certificates.crt
-    ```
+  ```docker
+  COPY --from=builder /etc/ssl/certs/your-cert-bundle.crt /etc/ssl/certs/ca-certificates.crt
+  ```
+
 - Finally, ensure that you aren't being man-in-the-middle'd or that some eager router isn't injecting its own certificate along the way. Use openssl to verify that your Proxy service is getting the certificate you think its getting.
 
-    ```bash
-    openssl s_client -servername pomerium.io -connect pomerium.io:443 </dev/null \
-    | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'
-    ```
+  ```bash
+  openssl s_client -servername pomerium.io -connect pomerium.io:443 </dev/null \
+  | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'
+  ```
 
 #### rpc error: code = DeadlineExceeded
 
@@ -193,7 +194,7 @@ Usually, this is the result of either a routing issue or a configuration error. 
 
 ### Generate Recovery Token
 
-<GenerateRecoveryToken/>
+<GenerateRecoveryToken />
 
 ## Miscellaneous
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -38,24 +38,24 @@ const config = {
           customCss: require.resolve("./src/css/custom.css"),
         },
         googleAnalytics: {
-          trackingID: process.env.GA
+          trackingID: process.env.GA,
         },
         sitemap: {
-          filename: 'docs/sitemap.xml',
-          ignorePatterns: ['/docs/examples/**']
+          filename: "docs/sitemap.xml",
+          ignorePatterns: ["/docs/examples/**"],
         },
       },
     ],
   ],
 
   themeConfig: {
-    image: 'docs/img/logo.svg',
+    image: "docs/img/logo.svg",
     algolia: {
       appId: process.env.ALGOALIA_APPID,
       apiKey: process.env.ALGOLIA_APIKEY,
       indexName: process.env.INDEX_NAME,
       contextualSearch: false,
-      searchPagePath: false
+      searchPagePath: false,
     },
     navbar: {
       title: "",
@@ -63,7 +63,7 @@ const config = {
         alt: "Pomerium Logo",
         src: "img/logo.svg",
         href: "https://www.pomerium.com",
-        target: "_self"
+        target: "_self",
       },
       items: [
         {
@@ -107,14 +107,14 @@ const config = {
           items: [
             {
               label: "v17",
-              href: "https://0-17-0.docs.pomerium.io/docs"
+              href: "https://v17.docs.pomerium.com/docs",
             },
             {
-              type: 'doc',
-              label: 'Archived Versions',
-              docId: 'docs/versions'
-            }
-          ]
+              type: "doc",
+              label: "Archived Versions",
+              docId: "docs/versions",
+            },
+          ],
         },
       ],
     },
@@ -188,12 +188,12 @@ const config = {
   ],
   plugins: [
     [
-      require.resolve('docusaurus-gtm-plugin'),
+      require.resolve("docusaurus-gtm-plugin"),
       {
-        id: process.env.GTM
-      }
-    ]
-  ]
+        id: process.env.GTM,
+      },
+    ],
+  ],
 };
 
 if (!process.env.ALGOALIA_APPID) {
@@ -201,7 +201,7 @@ if (!process.env.ALGOALIA_APPID) {
 }
 
 if (!process.env.GA) {
-  delete config.presets[0][1].googleAnalytics
+  delete config.presets[0][1].googleAnalytics;
 }
 
 module.exports = config;

--- a/src/components/docVersions.json
+++ b/src/components/docVersions.json
@@ -1,7 +1,7 @@
 {
   "0.17.0": {
     "id": "v0.17.x",
-    "link": "https://17.docs.pomerium.com/docs"
+    "link": "https://v17.docs.pomerium.com/docs"
   },
   "0.16.0": {
     "id": "v0.16.x",

--- a/src/components/docVersions.json
+++ b/src/components/docVersions.json
@@ -1,7 +1,7 @@
 {
   "0.17.0": {
     "id": "v0.17.x",
-    "link": "https://0-17-0.docs.pomerium.com/docs"
+    "link": "https://17.docs.pomerium.com/docs"
   },
   "0.16.0": {
     "id": "v0.16.x",


### PR DESCRIPTION
v17 was being referred to in several different ways including .io / .com domains. 

Updated references to use the `v17` subdomain to match the corresponding branch name. 