### PR TITLE
chore: update docVersions.json to use netlify domain

### DIFF
--- a/src/components/docVersions.json
+++ b/src/components/docVersions.json
@@ -5,30 +5,30 @@
   },
   "0.16.0": {
     "id": "v0.16.x",
-    "link": "https://0-16-0.docs.pomerium.io/docs"
+    "link": "https://0-16-0--pomerium-docs.netlify.app/docs/"
   },
   "0.15.0": {
     "id": "v0.15.x",
-    "link": "https://0-15-0.docs.pomerium.io/docs"
+    "link": "https://0-15-0--pomerium-docs.netlify.app/docs/"
   },
   "0.14.0": {
     "id": "v0.14.x",
-    "link": "https://0-14-0.docs.pomerium.io/docs"
+    "link": "https://0-14-0--pomerium-docs.netlify.app/docs/"
   },
   "0.13.0": {
     "id": "v0.13.x",
-    "link": "https://0-13-0.docs.pomerium.io/docs"
+    "link": "https://0-13-0--pomerium-docs.netlify.app/docs/"
   },
   "0.12.0": {
     "id": "v0.12.x",
-    "link": "https://0-12-0.docs.pomerium.io/docs"
+    "link": "https://0-12-0--pomerium-docs.netlify.app/docs/"
   },
   "0.11.0": {
     "id": "v0.11.x",
-    "link": "https://0-11-0.docs.pomerium.io/docs"
+    "link": "https://0-11-0--pomerium-docs.netlify.app/docs/"
   },
   "0.10.0": {
     "id": "v0.10.x",
-    "link": "https://0-10-0.docs.pomerium.io/docs"
+    "link": "https://0-10-0--pomerium-docs.netlify.app/docs/"
   }
 }


### PR DESCRIPTION
We need to migrate the pomerium.io domain to be an alias to pomerium.com in Netlify. Unfortunately, this means losing "vanity" urls for archived versions of pomerium docs. 