### PR TITLE
autocert: update documentation

### DIFF
--- a/content/docs/reference/autocert/readme.md
+++ b/content/docs/reference/autocert/readme.md
@@ -4,8 +4,8 @@ title: Autocert
 description: |
   Turning on autocert allows Pomerium to automatically retrieve, manage, and renew public facing TLS certificates from Lets Encrypt.
 keywords:
-- reference
-- Autocert
+  - reference
+  - Autocert
 pagination_prev: null
 pagination_next: null
 ---
@@ -15,13 +15,13 @@ pagination_next: null
 - Type: `bool`
 - Optional
 
-Turning on autocert allows Pomerium to automatically retrieve, manage, and renew public facing TLS certificates from [Let's Encrypt][letsencrypt] which includes managed routes and the authenticate service.  [Autocert Directory](/docs/reference/autocert/autocert-directory) must be used with Autocert must have a place to persist, and share certificate data between services. Note that autocert also provides [OCSP stapling](https://en.wikipedia.org/wiki/OCSP_stapling).
+Turning on autocert allows Pomerium to automatically retrieve, manage, and renew public facing TLS certificates from [Let's Encrypt][letsencrypt] which includes managed routes and the authenticate service. [Autocert Directory](/docs/reference/autocert/autocert-directory) must be used with Autocert must have a place to persist, and share certificate data between services. Note that autocert also provides [OCSP stapling](https://en.wikipedia.org/wiki/OCSP_stapling).
 
 This setting can be useful in situations where you may not have Pomerium behind a TLS terminating ingress or proxy that is already handling your public certificates on your behalf.
 
 Autocert will incorporate certificates available in the system trust store and those set manually in the Pomerium configuration, and they will take precedence over generated certificates when applicable to configured routes.
 
-Autocert will attempt `HTTP01`and `TLS-ALPN-01` challenges. It does not support `DNS-01` challenges, required to generate wildcard certificates.
+Autocert will attempt `HTTP-01`and `TLS-ALPN-01` challenges. It does not support `DNS-01` challenges, required to generate wildcard certificates.
 
 :::warning
 
@@ -31,7 +31,7 @@ By using autocert, you agree to the [Let's Encrypt Subscriber Agreement](https:/
 
 :::warning
 
-Autocert requires that ports `80`/`443` be accessible from the internet in order to complete a [TLS-ALPN-01 challenge](https://letsencrypt.org/docs/challenge-types/#tls-alpn-01).
+Autocert requires that port `443` be accessible from the internet in order to complete a [TLS-ALPN-01 challenge](https://letsencrypt.org/docs/challenge-types/#tls-alpn-01) or port `80` in order to complete an [HTTP-01 challenge](https://letsencrypt.org/docs/challenge-types/#http-01-challenge) (https://letsencrypt.org/docs/challenge-types/#tls-alpn-01).
 
 :::
 


### PR DESCRIPTION
Update the documentation for autocert to reflect what TLS-ALPN-01 will require.