### PR TITLE
Remove the reference to vals-entrypoint

### DIFF
--- a/content/docs/guides/cloud-run.mdx
+++ b/content/docs/guides/cloud-run.mdx
@@ -38,9 +38,9 @@ This guide assumes you have Editor access to a Google Cloud project which can be
 
 To deploy Pomerium to Cloud Run securely and easily, a special [image](https://console.cloud.google.com/gcr/images/pomerium-io/GLOBAL/pomerium) is available at `gcr.io/pomerium-io/pomerium:[version]-cloudrun`. It allows sourcing configuration from GCP Secrets Manager, and sets some defaults for Cloud Run to keep configuration minimal. We will be leveraging it in this example to store IdP credentials. Our policy contains no secrets so we can place it directly in an ENV var.
 
-[Dockerfile](https://github.com/pomerium/pomerium/blob/main/.github/Dockerfile-cloudrun) Based on [vals-entrypoint](https://github.com/pomerium/vals-entrypoint)
+[Dockerfile](https://github.com/pomerium/pomerium/blob/main/.github/Dockerfile-cloudrun)
 
-The image expects a config file at `/pomerium/config.yaml`. Set `VALS_FILES=[secretref]:/pomerium/config.yaml` and set any other Pomerium Environment Variables directly or with secret refs such as `ref+gcpsecrets://PROJECT/SECRET(#/key])`.
+The image expects a config file at `/pomerium/config.yaml`. Set any Pomerium Environment Variables directly or with secret refs such as `ref+gcpsecrets://PROJECT/SECRET(#/key])`.
 
 ### Config
 
@@ -51,6 +51,8 @@ Set up a `config.yaml` file to contain your IdP credentials and secrets:
 Substitute `cloudrun.pomerium.io` for your own subdomain and your e-mail domain if appropriate:
 
 <PolicyTemplate/>
+
+Save the content to Secret Manager and mount it as `/pomerium/config.yaml` in Cloud Run.
 
 ### DNS
 


### PR DESCRIPTION
the cloud run image in the latest (v0.19.1) does not use vals-entrypoint and the configuration through `VALS_FILES` does not work. The reference to the entrypoint needs to be removed and the instruction to add the config in cloud-run needs to be updated.