### PR TITLE
Correct the config variables

### DIFF
--- a/content/docs/identity-providers/google.mdx
+++ b/content/docs/identity-providers/google.mdx
@@ -60,9 +60,9 @@ Edit `config.yaml` or set  your [environment variables] to connect Pomerium to G
 <TabItem value="config.yaml" label="config.yaml">
 
 ```yaml title=/etc/pomerium/config.yaml
-idp-provider: "google"
-idp-client-id: "yyyy.apps.googleusercontent.com"
-idp-client-secret: "xxxxxx"
+idp_provider: "google"
+idp_client_id: "yyyy.apps.googleusercontent.com"
+idp_client_secret: "xxxxxx"
 ```
 
 </TabItem>


### PR DESCRIPTION
The variables in `config.yaml` use `_` instead of `-`