### PR TITLE
updates redirects to fix 404 links

### DIFF
--- a/content/docs/capabilities/tcp.mdx
+++ b/content/docs/capabilities/tcp.mdx
@@ -20,7 +20,7 @@ keywords:
 
 # TCP over HTTP Support
 
-In addition to managing HTTP based applications, Pomerium can be used to protect non-HTTP systems with the same consistent authorization policy. This is achieved by tunneling TCP over HTTP with the help of a client side command built into [`pomerium-cli`](docs/releases/pomerium-cli).
+In addition to managing HTTP based applications, Pomerium can be used to protect non-HTTP systems with the same consistent authorization policy. This is achieved by tunneling TCP over HTTP with the help of a client side command built into [`pomerium-cli`](/docs/releases/pomerium-cli).
 
 Operations and engineering teams frequently require access to lower level administrative and data protocols such as SSH, RDP, Postgres, MySQL, Redis, etc.
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -19,6 +19,7 @@
 /guide/ /docs/quick-start/
 /guide/kubernetes.html /docs/k8s
 /guide/kubernetes /docs/k8s
+/docs/k8s /docs/deploying/k8s/quickstart
 /guide/synology /docs/guides/synology
 /guide/synology.html /docs/guides/synology
 /docs/examples.html /docs/guides
@@ -46,6 +47,7 @@
 /docs/reference/production-deployment.html /docs/topics/production-deployment
 /docs/reference/programmatic-access.html /docs/topics/programmatic-access
 /docs/topics/programmatic-access /docs/concepts/programmatic-access
+/docs/concepts/programmatic-access /docs/capabilities/programmatic-access
 
 /posts/2020/06/01/release-0-9/ /blog/posts-2020-06-01-release-0-9/
 /posts/2020/05/11/release-0-8/ /blog/announcing-pomerium-0-8/
@@ -57,8 +59,8 @@
 
 # Redirects enterprise links
 /enterprise/ /docs/enterprise
+/docs/enterprise /docs/releases/enterprise
 /enterprise/service-accounts/ /docs/capabilities/service-accounts
-/enterprise/service-accounts /docs/capabilities/service-accounts
 /enterprise/service-accounts.html /docs/capabilities/service-accounts
 /enterprise/prometheus.html /docs/capabilities/metrics
 /docs/enterprise/reference/ /docs/concepts/
@@ -68,18 +70,22 @@
 /docs/quick-start/binary.html /docs/install/binary
 /docs/install/binary /docs/releases/core
 /docs/quick-start/helm.html /docs/k8s/helm
+/docs/k8s/helm /docs/guides/helm
 /docs/quick-start/from-source.html /docs/install/from-source
 /docs/quick-start/synology.html /docs/guides/synology
 /docs/enterprise/concepts /docs/capabilities/
 /docs/enterprise/reference/manage /docs/capabilities/
 /docs/enterprise/reference/reports /docs/capabilities/reports
 /docs/enterprise/external-data /docs/integrations/
+/docs/enterprise/install/helm /docs/guides/helm
 
 /docs/client.html /docs/tcp/client
 /docs/topics/tcp-support.html /docs/tcp/
 /docs/tcp /docs/capabilities/tcp
 /docs/install/helm.html /docs/k8s/helm
+/docs/k8s/helm /docs/guides/helm
 /docs/topics/kubernetes-integration.html /docs/k8s/
+/docs/k8s /docs/deploying/k8s/quickstart
 
 /docs/FAQ.html /docs/troubleshooting
 
@@ -104,6 +110,7 @@
 /enterprise/* /docs/enterprise/:splat
 
 /docs/k8s/helm /docs/k8s/quickstart
+/docs/k8s/quickstart /docs/deploying/k8s/quickstart
 
 #redirect all the topics to concepts
 /docs/topics/* /docs/concepts/:splat 301!


### PR DESCRIPTION
Fixes 404 redirect links, specifically for /docs/k8s and /enterprise/ links.  