### PR TITLE
Docs: zpain8464/fix docs typos

### DIFF
--- a/content/docs/deploying/k8s/quickstart.mdx
+++ b/content/docs/deploying/k8s/quickstart.mdx
@@ -72,14 +72,14 @@ job.batch/pomerium-gen-secrets created
 ingressclass.networking.k8s.io/pomerium created
 ```
 
-1. Add the certificate [created earlier](#certificates) and key to the cluster as a Secret:
+2. Add the certificate [created earlier](#certificates) and key to the cluster as a Secret:
 
 ```sh
 kubectl create secret tls pomerium-wildcard-tls --namespace=pomerium \
   --cert=./_wildcard.localhost.pomerium.io.pem --key=./_wildcard.localhost.pomerium.io-key.pem
 ```
 
-1. Define a Kubernetes secret to hold identity provider (**IdP**) credentials:
+3. Define a Kubernetes secret to hold identity provider (**IdP**) credentials:
 
 ```yaml title=idp-secret.yaml
 apiVersion: v1
@@ -95,7 +95,7 @@ stringData:
 
 The data required in this secret will depend on your [identity provider]. See the [Kubernetes Reference](/docs/identity-providers) page for all available keys, and cross-reference it with the requirements of your IdP.
 
-1. Provide this secret to the cluster:
+4. Provide this secret to the cluster:
 
 ```sh
 kubectl apply -f idp-secret.yaml
@@ -112,13 +112,11 @@ pomerium-controller-token-cckv5    kubernetes.io/service-account-token   3      
 pomerium-gen-secrets-token-4pdkd   kubernetes.io/service-account-token   3      99m
 ```
 
-1. Define the global Pomerium settings:
-
-{' '}
+5. Define the global Pomerium settings:
 
 <GlobalExample />
 
-1. Apply the global settings:
+6. Apply the global settings:
 
 ```sh
 kubectl apply -f pomerium.yaml
@@ -186,7 +184,7 @@ spec:
 
 Deploy it with `kubectl apply -f verify-service.yaml`
 
-1. Define an Ingress for the new service:
+2. Define an Ingress for the new service:
 
 ```yaml title=verify-ingress.yaml
 apiVersion: networking.k8s.io/v1

--- a/content/docs/identity-providers/google.mdx
+++ b/content/docs/identity-providers/google.mdx
@@ -72,7 +72,7 @@ Edit `config.yaml` or set your [environment variables] to connect Pomerium to Go
 
 ```yaml title=/etc/pomerium/config.yaml
 idp_provider: 'google'
-idp_client-id: 'yyyy.apps.googleusercontent.com'
+idp_client_id: 'yyyy.apps.googleusercontent.com'
 idp_client-secret: 'xxxxxx'
 ```
 

--- a/content/docs/identity-providers/google.mdx
+++ b/content/docs/identity-providers/google.mdx
@@ -73,7 +73,7 @@ Edit `config.yaml` or set your [environment variables] to connect Pomerium to Go
 ```yaml title=/etc/pomerium/config.yaml
 idp_provider: 'google'
 idp_client_id: 'yyyy.apps.googleusercontent.com'
-idp_client-secret: 'xxxxxx'
+idp_client_secret: 'xxxxxx'
 ```
 
 </TabItem>

--- a/content/docs/identity-providers/google.mdx
+++ b/content/docs/identity-providers/google.mdx
@@ -71,9 +71,9 @@ Edit `config.yaml` or set your [environment variables] to connect Pomerium to Go
 <TabItem value="config.yaml" label="config.yaml">
 
 ```yaml title=/etc/pomerium/config.yaml
-idp-provider: 'google'
-idp-client-id: 'yyyy.apps.googleusercontent.com'
-idp-client-secret: 'xxxxxx'
+idp_provider: 'google'
+idp_client-id: 'yyyy.apps.googleusercontent.com'
+idp_client-secret: 'xxxxxx'
 ```
 
 </TabItem>

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -26,7 +26,7 @@ Pomerium is an identity-aware proxy that enables secure access to internal appli
 Pomerium can be used to:
 
 - **authenticate**: provide a **single-sign-on** and **verifiable user identity** to internal applications.
-- **authroize**: enforce dynamic access policy based on **context**, **identity**, and **device identity**.
+- **authorize**: enforce dynamic access policy based on **context**, **identity**, and **device identity**.
 - **audit**: aggregate access logs and telemetry data.
 - perform delegated user authorization for service-based authorization systems
 - add unified access and identity to [custom, on-prem, and hosted apps and services](https://www.pomerium.com/integrations/)

--- a/content/docs/releases/core.mdx
+++ b/content/docs/releases/core.mdx
@@ -1,7 +1,7 @@
 ---
 title: Pomerium Core (server)
 lang: en-US
-sidebar_label: pomerium (server)
+sidebar_label: Pomerium (Server)
 pagination_prev: null
 pagination_next: null
 description: How to get Pomerium's CLI which be used to proxy TCP services and kubernetes commands

--- a/content/docs/releases/pomerium-cli.mdx
+++ b/content/docs/releases/pomerium-cli.mdx
@@ -14,7 +14,7 @@ keywords:
     tcp,
     tcp over http,
   ]
-sidebar_label: pomerium-cli (client)
+sidebar_label: Pomerium-CLI (Client)
 sidebar_position: 3
 ---
 

--- a/content/docs/releases/pomerium-desktop.mdx
+++ b/content/docs/releases/pomerium-desktop.mdx
@@ -1,7 +1,7 @@
 ---
 title: Pomerium Desktop
 lang: en-US
-sidebar_label: pomerium-desktop (client)
+sidebar_label: Pomerium-Desktop (Client)
 pagination_prev: null
 pagination_next: null
 description: How to get Pomerium's CLI which be used to proxy TCP services and kubernetes commands


### PR DESCRIPTION
Updates several typos and syntax errors across Pomerium docs, including:
- K8s quickstart 
- Google IdP guide
- Sidebar > Releases
- What is Pomerium? 

Fixes #166 