### PR TITLE
Docs: redirects branding page

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -78,6 +78,7 @@
 /docs/enterprise/reference/reports /docs/capabilities/reports
 /docs/enterprise/external-data /docs/integrations/
 /docs/enterprise/install/helm /docs/guides/helm
+/docs/enterprise/branding /docs/capabilities/branding
 
 /docs/client.html /docs/tcp/client
 /docs/topics/tcp-support.html /docs/tcp/


### PR DESCRIPTION
Redirects branding page from /docs/enterprise/branding to /docs/capabilities/branding