### PR TITLE
Docs: fixes troubleshooting redirect

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -89,6 +89,7 @@
 /docs/k8s /docs/deploying/k8s/quickstart
 
 /docs/FAQ.html /docs/troubleshooting
+/docs/troubleshooting /docs/internals/troubleshooting
 
 /docs/glossary.html /docs/overview/glossary
 /docs/overview/glossary /docs/internals/glossary


### PR DESCRIPTION
Troubleshooting page was 404ing. This redirect should fix the link.