### PR TITLE
Docs: trims .md file extensions from links redirects file

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,51 +1,51 @@
 # redirects will process the first matching rule it finds, reading from top to bottom.
 # https://docs.netlify.com/routing/redirects/
 /docs/reference/reference /docs/reference
-/docs/reference/reference.html /docs/reference
+/docs/reference/reference /docs/reference
 /docs/configuration/ /docs/reference
-/docs/config-reference.html /docs/reference
+/docs/config-reference /docs/reference
 /configuration/ /docs/reference
 
 /community/ /docs/community/
-/community/index.html /docs/community/
+/community/index /docs/community/
 /community/contributing /docs/community/contributing
-/community/contributing.html /docs/community/contributing
+/community/contributing /docs/community/contributing
 /community/code-of-conduct /docs/community/code-of-conduct
-/community/code-of-conduct.html /docs/community/code-of-conduct
+/community/code-of-conduct /docs/community/code-of-conduct
 /community/security /docs/internals/security
-/community/security.html /docs/internals/security
+/community/security /docs/internals/security
 /docs/community/security /docs/internals/security
 
 /guide/ /docs/quick-start/
-/guide/kubernetes.html /docs/k8s
+/guide/kubernetes /docs/k8s
 /guide/kubernetes /docs/k8s
 /docs/k8s /docs/deploying/k8s/quickstart
 /guide/synology /docs/guides/synology
-/guide/synology.html /docs/guides/synology
-/docs/examples.html /docs/guides
+/guide/synology /docs/guides/synology
+/docs/examples /docs/guides
 /docs/examples /docs/guides
 
 /recipes/ /docs/guides
-/recipes/ad-guard.html /docs/guides/ad-guard
-/recipes/argo.html /docs/guides/argo
-/recipes/cloud-run.html /docs/guides/cloud-run
-/recipes/istio.html /docs/guides/istio
-/recipes/kubernetes.html /docs/guides/kubernetes
-/recipes/local-oidc.html /docs/guides/local-oidc
-/recipes/mtls.html /docs/guides/mtls
-/recipes/vs-code-server.html /docs/guides/code-server
-/guides/vs-code-server.html /docs/guides/code-server
+/recipes/ad-guard /docs/guides/ad-guard
+/recipes/argo /docs/guides/argo
+/recipes/cloud-run /docs/guides/cloud-run
+/recipes/istio /docs/guides/istio
+/recipes/kubernetes /docs/guides/kubernetes
+/recipes/local-oidc /docs/guides/local-oidc
+/recipes/mtls /docs/guides/mtls
+/recipes/vs-code-server /docs/guides/code-server
+/guides/vs-code-server /docs/guides/code-server
 
-/docs/reference/readme.html /docs/
-/docs/reference/certificates.html /docs/topics/certificates
+/docs/reference/readme /docs/
+/docs/reference/certificates /docs/topics/certificates
 /docs/topics/certificates /docs/concepts/certificates
-/docs/reference/data-storage.html /docs/topics/data-storage
+/docs/reference/data-storage /docs/topics/data-storage
 /docs/topics/data-storage /docs/concepts/data-storage
 /docs/topics/data-storage#backends /docs/concepts/data-storage#backends
-/docs/reference/getting-users-identity.html /docs/topics/getting-users-identity
+/docs/reference/getting-users-identity /docs/topics/getting-users-identity
 /docs/topics/getting-users-identity /docs/concepts/getting-users-identity
-/docs/reference/production-deployment.html /docs/topics/production-deployment
-/docs/reference/programmatic-access.html /docs/topics/programmatic-access
+/docs/reference/production-deployment /docs/topics/production-deployment
+/docs/reference/programmatic-access /docs/topics/programmatic-access
 /docs/topics/programmatic-access /docs/concepts/programmatic-access
 /docs/concepts/programmatic-access /docs/capabilities/programmatic-access
 
@@ -54,25 +54,25 @@
 /posts/2020/04/16/release-0-7/ /blog/announcing-pomerium-0-7/
 
 /jobs/ /careers/
-/jobs/Frontend-Engineer.html /careers/frontend-engineer/
-/jobs/Backend-Engineer.html /careers/backend-engineer/
+/jobs/Frontend-Engineer /careers/frontend-engineer/
+/jobs/Backend-Engineer /careers/backend-engineer/
 
 # Redirects enterprise links
 /enterprise/ /docs/enterprise
 /docs/enterprise /docs/releases/enterprise
 /enterprise/service-accounts/ /docs/capabilities/service-accounts
-/enterprise/service-accounts.html /docs/capabilities/service-accounts
-/enterprise/prometheus.html /docs/capabilities/metrics
+/enterprise/service-accounts /docs/capabilities/service-accounts
+/enterprise/prometheus /docs/capabilities/metrics
 /docs/enterprise/reference/ /docs/concepts/
-/docs/installation.html /docs/install
+/docs/installation /docs/install
 /docs/installation /docs/install
 /docs/quick-start /docs/install
-/docs/quick-start/binary.html /docs/install/binary
+/docs/quick-start/binary /docs/install/binary
 /docs/install/binary /docs/releases/core
-/docs/quick-start/helm.html /docs/k8s/helm
+/docs/quick-start/helm /docs/k8s/helm
 /docs/k8s/helm /docs/guides/helm
-/docs/quick-start/from-source.html /docs/install/from-source
-/docs/quick-start/synology.html /docs/guides/synology
+/docs/quick-start/from-source /docs/install/from-source
+/docs/quick-start/synology /docs/guides/synology
 /docs/enterprise/concepts /docs/capabilities/
 /docs/enterprise/reference/manage /docs/capabilities/
 /docs/enterprise/reference/reports /docs/capabilities/reports
@@ -80,27 +80,27 @@
 /docs/enterprise/install/helm /docs/guides/helm
 /docs/enterprise/branding /docs/capabilities/branding
 
-/docs/client.html /docs/tcp/client
-/docs/topics/tcp-support.html /docs/tcp/
+/docs/client /docs/tcp/client
+/docs/topics/tcp-support /docs/tcp/
 /docs/tcp /docs/capabilities/tcp
-/docs/install/helm.html /docs/k8s/helm
+/docs/install/helm /docs/k8s/helm
 /docs/k8s/helm /docs/guides/helm
-/docs/topics/kubernetes-integration.html /docs/k8s/
+/docs/topics/kubernetes-integration /docs/k8s/
 /docs/k8s /docs/deploying/k8s/quickstart
 
-/docs/FAQ.html /docs/troubleshooting
+/docs/FAQ /docs/troubleshooting
 /docs/troubleshooting /docs/internals/troubleshooting
 
-/docs/glossary.html /docs/overview/glossary
+/docs/glossary /docs/overview/glossary
 /docs/overview/glossary /docs/internals/glossary
-/docs/releases.html /docs/overview/releases
+/docs/releases /docs/overview/releases
 /docs/overview/releases /docs/releases
-/docs/architecture.html /docs/overview/architecture
+/docs/architecture /docs/overview/architecture
 /docs/overview/architecture /docs/internals/architecture
-/docs/background.html /docs/overview/background
+/docs/background /docs/overview/background
 /docs/overview/background /docs/concepts/zero-trust
-/docs/upgrading.html /docs/overview/upgrading
-/docs/changelog.html /docs/overview/changelog
+/docs/upgrading /docs/overview/upgrading
+/docs/changelog /docs/overview/changelog
 
 /reference/ /docs/reference/
 /reference/* /docs/reference/:splat
@@ -108,7 +108,7 @@
 /guides/ /docs/guides
 /guides/* /docs/guides/:splat
 /enterprise/ /docs/enterprise/about
-/docs/enterprise/about /docs/releases/enterprise.md
+/docs/enterprise/about /docs/releases/enterprise
 /enterprise/* /docs/enterprise/:splat
 
 /docs/k8s/helm /docs/k8s/quickstart
@@ -116,8 +116,8 @@
 
 #redirect all the topics to concepts
 /docs/topics/* /docs/concepts/:splat 301!
-/docs/topics/device-identity.md /docs/concepts/device-identity
-/docs/topics/mutual-auth.md /docs/concepts/mutual-auth
+/docs/topics/device-identity /docs/concepts/device-identity
+/docs/topics/mutual-auth /docs/concepts/mutual-auth
 /docs/topics/original-request-context /docs/concepts/original-request-context
 /docs/topics/ppl /docs/concepts/ppl
 /docs/topics/load-balancing /docs/concepts/load-balancing
@@ -125,7 +125,7 @@
 
 # redirects k8s links
 /docs/k8s/reference /docs/deploying/k8s/reference
-/docs/k8s/ingress.md /docs/deploying/k8s/ingress
+/docs/k8s/ingress /docs/deploying/k8s/ingress
 
 # flattened the changelog, and upgrading guide
 /docs/overview/upgrading/archive  /docs/overview/upgrading

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,51 +1,51 @@
 # redirects will process the first matching rule it finds, reading from top to bottom.
 # https://docs.netlify.com/routing/redirects/
 /docs/reference/reference /docs/reference
-/docs/reference/reference /docs/reference
+/docs/reference/reference.html /docs/reference
 /docs/configuration/ /docs/reference
-/docs/config-reference /docs/reference
+/docs/config-reference.html /docs/reference
 /configuration/ /docs/reference
 
 /community/ /docs/community/
-/community/index /docs/community/
+/community/index.html /docs/community/
 /community/contributing /docs/community/contributing
-/community/contributing /docs/community/contributing
+/community/contributing.html /docs/community/contributing
 /community/code-of-conduct /docs/community/code-of-conduct
-/community/code-of-conduct /docs/community/code-of-conduct
+/community/code-of-conduct.html /docs/community/code-of-conduct
 /community/security /docs/internals/security
-/community/security /docs/internals/security
+/community/security.html /docs/internals/security
 /docs/community/security /docs/internals/security
 
 /guide/ /docs/quick-start/
-/guide/kubernetes /docs/k8s
+/guide/kubernetes.html /docs/k8s
 /guide/kubernetes /docs/k8s
 /docs/k8s /docs/deploying/k8s/quickstart
 /guide/synology /docs/guides/synology
-/guide/synology /docs/guides/synology
-/docs/examples /docs/guides
+/guide/synology.html /docs/guides/synology
+/docs/examples.html /docs/guides
 /docs/examples /docs/guides
 
 /recipes/ /docs/guides
-/recipes/ad-guard /docs/guides/ad-guard
-/recipes/argo /docs/guides/argo
-/recipes/cloud-run /docs/guides/cloud-run
-/recipes/istio /docs/guides/istio
-/recipes/kubernetes /docs/guides/kubernetes
-/recipes/local-oidc /docs/guides/local-oidc
-/recipes/mtls /docs/guides/mtls
-/recipes/vs-code-server /docs/guides/code-server
-/guides/vs-code-server /docs/guides/code-server
+/recipes/ad-guard.html /docs/guides/ad-guard
+/recipes/argo.html /docs/guides/argo
+/recipes/cloud-run.html /docs/guides/cloud-run
+/recipes/istio.html /docs/guides/istio
+/recipes/kubernetes.html /docs/guides/kubernetes
+/recipes/local-oidc.html /docs/guides/local-oidc
+/recipes/mtls.html /docs/guides/mtls
+/recipes/vs-code-server.html /docs/guides/code-server
+/guides/vs-code-server.html /docs/guides/code-server
 
-/docs/reference/readme /docs/
-/docs/reference/certificates /docs/topics/certificates
+/docs/reference/readme.html /docs/
+/docs/reference/certificates.html /docs/topics/certificates
 /docs/topics/certificates /docs/concepts/certificates
-/docs/reference/data-storage /docs/topics/data-storage
+/docs/reference/data-storage.html /docs/topics/data-storage
 /docs/topics/data-storage /docs/concepts/data-storage
 /docs/topics/data-storage#backends /docs/concepts/data-storage#backends
-/docs/reference/getting-users-identity /docs/topics/getting-users-identity
+/docs/reference/getting-users-identity.html /docs/topics/getting-users-identity
 /docs/topics/getting-users-identity /docs/concepts/getting-users-identity
-/docs/reference/production-deployment /docs/topics/production-deployment
-/docs/reference/programmatic-access /docs/topics/programmatic-access
+/docs/reference/production-deployment.html /docs/topics/production-deployment
+/docs/reference/programmatic-access.html /docs/topics/programmatic-access
 /docs/topics/programmatic-access /docs/concepts/programmatic-access
 /docs/concepts/programmatic-access /docs/capabilities/programmatic-access
 
@@ -54,25 +54,25 @@
 /posts/2020/04/16/release-0-7/ /blog/announcing-pomerium-0-7/
 
 /jobs/ /careers/
-/jobs/Frontend-Engineer /careers/frontend-engineer/
-/jobs/Backend-Engineer /careers/backend-engineer/
+/jobs/Frontend-Engineer.html /careers/frontend-engineer/
+/jobs/Backend-Engineer.html /careers/backend-engineer/
 
 # Redirects enterprise links
 /enterprise/ /docs/enterprise
 /docs/enterprise /docs/releases/enterprise
 /enterprise/service-accounts/ /docs/capabilities/service-accounts
-/enterprise/service-accounts /docs/capabilities/service-accounts
-/enterprise/prometheus /docs/capabilities/metrics
+/enterprise/service-accounts.html /docs/capabilities/service-accounts
+/enterprise/prometheus.html /docs/capabilities/metrics
 /docs/enterprise/reference/ /docs/concepts/
-/docs/installation /docs/install
+/docs/installation.html /docs/install
 /docs/installation /docs/install
 /docs/quick-start /docs/install
-/docs/quick-start/binary /docs/install/binary
+/docs/quick-start/binary.html /docs/install/binary
 /docs/install/binary /docs/releases/core
-/docs/quick-start/helm /docs/k8s/helm
+/docs/quick-start/helm.html /docs/k8s/helm
 /docs/k8s/helm /docs/guides/helm
-/docs/quick-start/from-source /docs/install/from-source
-/docs/quick-start/synology /docs/guides/synology
+/docs/quick-start/from-source.html /docs/install/from-source
+/docs/quick-start/synology.html /docs/guides/synology
 /docs/enterprise/concepts /docs/capabilities/
 /docs/enterprise/reference/manage /docs/capabilities/
 /docs/enterprise/reference/reports /docs/capabilities/reports
@@ -80,27 +80,27 @@
 /docs/enterprise/install/helm /docs/guides/helm
 /docs/enterprise/branding /docs/capabilities/branding
 
-/docs/client /docs/tcp/client
-/docs/topics/tcp-support /docs/tcp/
+/docs/client.html /docs/tcp/client
+/docs/topics/tcp-support.html /docs/tcp/
 /docs/tcp /docs/capabilities/tcp
-/docs/install/helm /docs/k8s/helm
+/docs/install/helm.html /docs/k8s/helm
 /docs/k8s/helm /docs/guides/helm
-/docs/topics/kubernetes-integration /docs/k8s/
+/docs/topics/kubernetes-integration.html /docs/k8s/
 /docs/k8s /docs/deploying/k8s/quickstart
 
-/docs/FAQ /docs/troubleshooting
+/docs/FAQ.html /docs/troubleshooting
 /docs/troubleshooting /docs/internals/troubleshooting
 
-/docs/glossary /docs/overview/glossary
+/docs/glossary.html /docs/overview/glossary
 /docs/overview/glossary /docs/internals/glossary
-/docs/releases /docs/overview/releases
+/docs/releases.html /docs/overview/releases
 /docs/overview/releases /docs/releases
-/docs/architecture /docs/overview/architecture
+/docs/architecture.html /docs/overview/architecture
 /docs/overview/architecture /docs/internals/architecture
-/docs/background /docs/overview/background
+/docs/background.html /docs/overview/background
 /docs/overview/background /docs/concepts/zero-trust
-/docs/upgrading /docs/overview/upgrading
-/docs/changelog /docs/overview/changelog
+/docs/upgrading.html /docs/overview/upgrading
+/docs/changelog.html /docs/overview/changelog
 
 /reference/ /docs/reference/
 /reference/* /docs/reference/:splat


### PR DESCRIPTION
**Problem:** Redirected links with a `.md` file extension still 404. 

For example: 
`/docs/k8s/ingress.md /docs/deploying/k8s/ingress` still 404s.

**Solution:** Removing the `.md` file extension from the link redirects the link as it should. 

For example:
`/docs/k8s/ingress /docs/deploying/k8s/ingress`

Links with an `html` file extension don't seem to 404. 