### PR TITLE
Docs: adds redirects for 404 links on /integrations/ page

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -80,7 +80,21 @@
 /docs/enterprise/install/helm /docs/guides/helm
 /docs/enterprise/branding /docs/capabilities/branding
 
+# Integrations redirects -- found on pomerium.com/integrations/
+/docs/enterprise/external-data/zenefits /docs/integrations/zenefits
+/docs/enterprise/external-data/tor-exit-nodes /docs/integrations/tor-exit-nodes
+/docs/enterprise/external-data/bamboohr /docs/integrations/bamboohr
+/docs/tcp/git.html /docs/capabilities/tcp/examples/git
+/docs/enterprise/metrics.html /docs/capabilities/metrics
+/docs/tcp/rdp.html /docs/capabilities/tcp/examples/rdp
+/docs/tcp/ssh.html /docs/capabilities/tcp/examples/ssh
+/docs/tcp/mysql.html /docs/capabilities/tcp/examples/mysql
+/docs/tcp/redis.html /docs/capabilities/tcp/examples/redis
+/docs/install/binary.html /docs/releases/enterprise/install/quickstart
+/docs/install/ /docs/quickstart
+
 /docs/client.html /docs/tcp/client
+/docs/tcp/client /docs/capabilities/tcp/client
 /docs/topics/tcp-support.html /docs/tcp/
 /docs/tcp /docs/capabilities/tcp
 /docs/install/helm.html /docs/k8s/helm


### PR DESCRIPTION
Redirects broken/404ing links on `pomerium.com/integrations`. 

Some integrations, like Fedora and CentOS, don't have a page to redirect to.

Others, like Argo and Cloud Run, should include links to the corresponding guide.