### PR TITLE
Fix links on routes page

### DIFF
--- a/content/docs/concepts/routes.mdx
+++ b/content/docs/concepts/routes.mdx
@@ -17,7 +17,7 @@ keywords:
 
 Routes define the connection pathway and configuration from the internet to your internal service. As a very basic level, a route sends traffic from `external-address.company.com` to `internalService-address.localdomain`, restricted by the policies associated with it, and encrypted by your TLS certificates. But more advanced configurations allow identity header pass-through, path and prefix rewrites, request and response header modification, load balancer services, and other full featured ingress capabilities.
 
-For more information, see [Reference: Routes]
+For more information, see [Reference: Routes](#reference-routes)
 
 ## Protected Endpoints
 
@@ -25,6 +25,7 @@ This term refers to the system or service the route provides or restricts access
 
 ## Moving Routes
 
-When moving a Route from one [Namespace](#namespaces) to another, enforced policies will automatically be removed or applied. Optional policies available in the source Namespace but not the target will prevent the move. This is intentional to prevent unassociated policies.
+When moving a Route from one [Namespace](#namespace) to another, enforced policies will automatically be removed or applied. Optional policies available in the source Namespace but not the target will prevent the move. This is intentional to prevent unassociated policies.
 
 [namespace]: /docs/concepts/namespacing
+[reference-routes]: /docs/reference/routes


### PR DESCRIPTION
The [routes page](https://www.pomerium.com/docs/concepts/routes) has two broken links:
- An attempted link to Reference: Routes goes nowhere.
- the link to Namepaces just goes back to the same page with a non-existent anchor

I'm not sure how these anchor-thingies work and have no way of testing it, but I think this PR fixed both.