### PR TITLE
Docs: Fixes Quick-Start typos and missing config file after re-org

### DIFF
--- a/content/docs/quickstart.mdx
+++ b/content/docs/quickstart.mdx
@@ -32,17 +32,17 @@ In this quick-start document, we'll create a minimal but complete environment fo
 
 ## Configure
 
-1. Create a [configuration file] (e.g. `config.yaml`) for defining Pomerium's configuration settings, routes, and access policies. Consider the following example:
+Create a [configuration file] (e.g. `config.yaml`) for defining Pomerium's configuration settings, routes, and access policies. Consider the following example:
 
-Create a [configuration file] (e.g `config.yaml`) for defining Pomerium's configuration settings, routes, and access policies. Consider the following example:
+<ConfigDocker />
 
-Keep track of the path to this file, relative to the `docker-compose.yaml` file created in the next step. `docker-compose.yaml` will need the correct relative path to your `config.yaml`.
-
-1. Create or copy the following `docker-compose.yaml` file and modify it to match your configuration, including the correct paths to your `config.yaml` and certificate files:
+:::tip **Note**
 
 Keep track of the path to this file, relative to the `docker-compose.yml` file created in the next step. `docker-compose.yml` will need the correct relative path to your `config.yaml`.
 
-Create or copy the following `docker-compose.yml` file and modify it to match your configuration, including the correct paths to your `config.yaml` and certificate files:
+:::
+
+Create or copy the following `docker-compose.yaml` file and modify it to match your configuration, including the correct paths to your `config.yaml` and certificate files:
 
 <DockerCompose />
 


### PR DESCRIPTION
After the re-org merge, the Core Quick-Start page was modified to the extent that it was unusable for users. For example, the `ConfigDocker` sample file is missing and steps are duplicated and out of order:

![SCR-20221213-dhv](https://user-images.githubusercontent.com/60552605/207363817-54320eec-031f-433a-91e2-fcb9a7fda531.png)

This PR resolves these issues. 