### PR TITLE
docs: redirects 10 links

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -47,6 +47,7 @@
 /docs/topics/getting-users-identity /docs/concepts/getting-users-identity
 /docs/reference/production-deployment.html /docs/topics/production-deployment
 /docs/topics/production-deployment /docs/deploying/production-deployment
+/docs/topics/production-deployment.html /docs/deploying/production-deployment
 /docs/reference/programmatic-access.html /docs/topics/programmatic-access
 /docs/topics/programmatic-access /docs/concepts/programmatic-access
 /docs/concepts/programmatic-access /docs/capabilities/programmatic-access
@@ -75,6 +76,7 @@
 /docs/quick-start/helm.html /docs/k8s/helm
 /docs/k8s/helm /docs/guides/helm
 /docs/quick-start/from-source.html /docs/install/from-source
+/docs/install/quickstart /docs/quickstart
 /docs/quick-start/synology.html /docs/guides/synology
 /docs/enterprise/concepts /docs/capabilities/
 /docs/enterprise/reference/manage /docs/capabilities/
@@ -88,6 +90,11 @@
 /docs/tcp /docs/capabilities/tcp
 /docs/tcp/rdp.html /docs/capabilities/tcp/examples/rdp
 /docs/tcp/rdp /docs/capabilities/tcp/examples/rdp
+/docs/tcp/redis.html /docs/capabilities/tcp/examples/redis
+/docs/tcp/redis /docs/capabilities/tcp/examples/redis
+/docs/tcp/git.html /docs/capabilities/tcp/examples/git
+/docs/tcp/git /docs/capabilities/tcp/examples/git
+
 /docs/install/helm.html /docs/k8s/helm
 /docs/k8s/helm /docs/guides/helm
 /docs/k8s/helm.html /docs/guides/helm
@@ -109,6 +116,7 @@
 /docs/background.html /docs/overview/background
 /docs/overview/background /docs/concepts/zero-trust
 /docs/upgrading.html /docs/overview/upgrading
+/docs/upgrading /docs/releases/upgrading
 /docs/changelog.html /docs/overview/changelog
 
 /reference/ /docs/reference/

--- a/static/_redirects
+++ b/static/_redirects
@@ -15,6 +15,7 @@
 /community/security /docs/internals/security
 /community/security.html /docs/internals/security
 /docs/community/security /docs/internals/security
+/docs/security /docs/internals/security
 
 /guide/ /docs/quick-start/
 /guide/kubernetes.html /docs/k8s
@@ -45,6 +46,7 @@
 /docs/reference/getting-users-identity.html /docs/topics/getting-users-identity
 /docs/topics/getting-users-identity /docs/concepts/getting-users-identity
 /docs/reference/production-deployment.html /docs/topics/production-deployment
+/docs/topics/production-deployment /docs/deploying/production-deployment
 /docs/reference/programmatic-access.html /docs/topics/programmatic-access
 /docs/topics/programmatic-access /docs/concepts/programmatic-access
 /docs/concepts/programmatic-access /docs/capabilities/programmatic-access
@@ -63,6 +65,7 @@
 /enterprise/service-accounts/ /docs/capabilities/service-accounts
 /enterprise/service-accounts.html /docs/capabilities/service-accounts
 /enterprise/prometheus.html /docs/capabilities/metrics
+/enterprise/prometheus /docs/capabilities/metrics
 /docs/enterprise/reference/ /docs/concepts/
 /docs/installation.html /docs/install
 /docs/installation /docs/install
@@ -83,13 +86,18 @@
 /docs/client.html /docs/tcp/client
 /docs/topics/tcp-support.html /docs/tcp/
 /docs/tcp /docs/capabilities/tcp
+/docs/tcp/rdp.html /docs/capabilities/tcp/examples/rdp
+/docs/tcp/rdp /docs/capabilities/tcp/examples/rdp
 /docs/install/helm.html /docs/k8s/helm
 /docs/k8s/helm /docs/guides/helm
+/docs/k8s/helm.html /docs/guides/helm
 /docs/topics/kubernetes-integration.html /docs/k8s/
 /docs/k8s /docs/deploying/k8s/quickstart
+/docs/topics/kubernetes-integration /docs/deploying/k8s/quickstart
 
 /docs/FAQ.html /docs/troubleshooting
 /docs/troubleshooting /docs/internals/troubleshooting
+/docs/faq /docs/internals/troubleshooting
 
 /docs/glossary.html /docs/overview/glossary
 /docs/overview/glossary /docs/internals/glossary
@@ -97,6 +105,7 @@
 /docs/overview/releases /docs/releases
 /docs/architecture.html /docs/overview/architecture
 /docs/overview/architecture /docs/internals/architecture
+/docs/architecture /docs/internals/architecture
 /docs/background.html /docs/overview/background
 /docs/overview/background /docs/concepts/zero-trust
 /docs/upgrading.html /docs/overview/upgrading
@@ -104,6 +113,7 @@
 
 /reference/ /docs/reference/
 /reference/* /docs/reference/:splat
+/docs/reference/identity-provider-service-account /docs/releases/upgrading
 
 /guides/ /docs/guides
 /guides/* /docs/guides/:splat


### PR DESCRIPTION
Redirects links from issues submitted under [pomerium/internals](https://github.com/pomerium/internal/issues/1075)

Fixes:
- [1147](https://github.com/pomerium/internal/issues/1147)
- [1156](https://github.com/pomerium/internal/issues/1156)
- [1158](https://github.com/pomerium/internal/issues/1158)
- [1160](https://github.com/pomerium/internal/issues/1160)
- [1162](https://github.com/pomerium/internal/issues/1162)
- [1164](https://github.com/pomerium/internal/issues/1164)
- [1166](https://github.com/pomerium/internal/issues/1166)
- [1185](https://github.com/pomerium/internal/issues/1185)
- [1172](https://github.com/pomerium/internal/issues/1172)
- [1174](https://github.com/pomerium/internal/issues/1174)
- [1176](https://github.com/pomerium/internal/issues/1176)
- [1184](https://github.com/pomerium/internal/issues/1184)
- [1187](https://github.com/pomerium/internal/issues/1187)
- [1189](https://github.com/pomerium/internal/issues/1189)
- [1190](https://github.com/pomerium/internal/issues/1190)
- [1192](https://github.com/pomerium/internal/issues/1192)
- [1193](https://github.com/pomerium/internal/issues/1193)