### PR TITLE
docs: more re-org redirects

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -17,6 +17,7 @@
 /docs/community/security /docs/internals/security
 /docs/security /docs/internals/security
 /docs/security.html /docs/internals/security
+/docs/community/security.html /docs/internals/security
 
 /guide/ /docs/quick-start/
 /guide/kubernetes.html /docs/k8s
@@ -36,8 +37,11 @@
 /recipes/kubernetes.html /docs/guides/kubernetes
 /recipes/local-oidc.html /docs/guides/local-oidc
 /recipes/mtls.html /docs/guides/mtls
+/docs/guides/mtls /docs/capabilities/mtls-clients
+/docs/guides/mtls.html /docs/capabilities/mtls-clients
 /recipes/vs-code-server.html /docs/guides/code-server
 /guides/vs-code-server.html /docs/guides/code-server
+/docs/guides/upstream-mtls /docs/capabilities/mtls-services
 
 /docs/reference/readme.html /docs/
 /docs/reference/certificates.html /docs/topics/certificates
@@ -51,9 +55,11 @@
 /docs/topics/production-deployment /docs/deploying/production-deployment
 /docs/topics/production-deployment.html /docs/deploying/production-deployment
 /docs/production-deployment /docs/deploying/production-deployment
+/docs/production-deployment.html /docs/deploying/production-deployment
 /docs/reference/programmatic-access.html /docs/topics/programmatic-access
 /docs/topics/programmatic-access /docs/concepts/programmatic-access
 /docs/concepts/programmatic-access /docs/capabilities/programmatic-access
+/docs/topics/programmatic-access.html /docs/capabilities/programmatic-access
 
 /posts/2020/06/01/release-0-9/ /blog/posts-2020-06-01-release-0-9/
 /posts/2020/05/11/release-0-8/ /blog/announcing-pomerium-0-8/
@@ -74,7 +80,9 @@
 /docs/enterprise/reference/configure /docs/releases/enterprise/configure
 /docs/enterprise/reference/configure.html /docs/releases/enterprise/configure
 /docs/enterprise/reference/config /docs/releases/enterprise/configure
+/docs/enterprise/reference/config.html /docs/releases/enterprise/configure
 /enterprise/reference/configure.html /docs/releases/enterprise/configure
+/enterprise/reference/config.html /docs/releases/enterprise/configure
 /docs/installation.html /docs/install
 /docs/installation /docs/install
 /docs/quick-start /docs/install
@@ -94,8 +102,11 @@
 /docs/enterprise/branding /docs/capabilities/branding
 /docs/enterprise/api.html /docs/capabilities/enterprise-api
 /docs/enterprise/api /docs/capabilities/enterprise-api
-/enterprise/install/ /docs/releases/enterprise/install/quickstart
 /docs/enterprise/install /docs/releases/enterprise/install/quickstart
+/docs/enterprise/external-data/ip-ranges /docs/integrations/ip-ranges
+/docs/enterprise/external-data/geoip /docs/integrations/geoip
+/enterprise/install/ /docs/releases/enterprise/install/quickstart
+/docs/enterprise/identity-providers/ping /docs/identity-providers/ping
 
 # Integrations redirects -- found on pomerium.com/integrations/
 /docs/enterprise/external-data/zenefits /docs/integrations/zenefits
@@ -136,9 +147,12 @@
 /docs/topics/kubernetes-integration.html /docs/k8s/
 /docs/k8s /docs/deploying/k8s/quickstart
 /docs/topics/kubernetes-integration /docs/deploying/k8s/quickstart
+/docs/guides/tcp /docs/guides/securing-tcp
+/docs/guides/tcp.html /docs/guides/securing-tcp
 
 /docs/FAQ.html /docs/troubleshooting
 /docs/troubleshooting /docs/internals/troubleshooting
+/docs/troubleshooting.html /docs/internals/troubleshooting
 /docs/faq /docs/internals/troubleshooting
 
 /docs/glossary.html /docs/overview/glossary
@@ -169,6 +183,8 @@
 
 #redirects from /topics to /capabilities
 /docs/topics/auth-logs /docs/capabilities/audit-logs
+/docs/topics/single-sign-out.html /docs/capabilities/single-sign-out
+/docs/topics/single-sign-out /docs/capabilities/single-sign-out
 
 #redirects topics
 /docs/topics/original-request-context.html /docs/deploying/production-deployment
@@ -184,11 +200,14 @@
 # redirects k8s links
 /docs/k8s/reference /docs/deploying/k8s/reference
 /docs/k8s/ingress /docs/deploying/k8s/ingress
+/docs/k8s/ingress.html /docs/deploying/k8s/ingress
+/docs/k8s/install /docs/deploying/k8s/install
 
 # flattened the changelog, and upgrading guide
 /docs/overview/upgrading/archive  /docs/overview/upgrading
 /docs/overview/changelog/archive  /docs/overview/upgrading
 /docs/overview/upgrading /docs/releases/upgrading
+/docs/changelog /docs/releases/changelog
 
 # domain
 # redirect all the `.io` domains to `com` for latest docs

--- a/static/_redirects
+++ b/static/_redirects
@@ -95,6 +95,7 @@
 /docs/enterprise/api.html /docs/capabilities/enterprise-api
 /docs/enterprise/api /docs/capabilities/enterprise-api
 /enterprise/install/ /docs/releases/enterprise/install/quickstart
+/docs/enterprise/install /docs/releases/enterprise/install/quickstart
 
 # Integrations redirects -- found on pomerium.com/integrations/
 /docs/enterprise/external-data/zenefits /docs/integrations/zenefits

--- a/static/_redirects
+++ b/static/_redirects
@@ -169,13 +169,13 @@
 #redirects from /topics to /capabilities
 /docs/topics/auth-logs /docs/capabilities/audit-logs
 
-#redirect all the topics to concepts
+#redirects topics
+/docs/topics/original-request-context.html /docs/deploying/production-deployment
 /docs/topics/* /docs/concepts/:splat 301!
 /docs/topics/device-identity /docs/concepts/device-identity
 /docs/topics/mutual-auth /docs/concepts/mutual-auth
 /docs/topics/original-request-context /docs/concepts/original-request-context
 /docs/concepts/original-request-context /docs/deploying/production-deployment
-/docs/topics/original-request-context.html /docs/deploying/production-deployment
 /docs/topics/ppl /docs/concepts/ppl
 /docs/topics/load-balancing /docs/concepts/load-balancing
 /docs/topics/certificates /docs/concepts/certificates

--- a/static/_redirects
+++ b/static/_redirects
@@ -165,6 +165,9 @@
 /docs/k8s/helm /docs/k8s/quickstart
 /docs/k8s/quickstart /docs/deploying/k8s/quickstart
 
+#redirects from /topics to /capabilities
+/docs/topics/auth-logs /docs/capabilities/audit-logs
+
 #redirect all the topics to concepts
 /docs/topics/* /docs/concepts/:splat 301!
 /docs/topics/device-identity /docs/concepts/device-identity
@@ -175,7 +178,6 @@
 /docs/topics/ppl /docs/concepts/ppl
 /docs/topics/load-balancing /docs/concepts/load-balancing
 /docs/topics/certificates /docs/concepts/certificates
-/docs/topics/auth-logs /docs/capabilities/audit-logs
 
 # redirects k8s links
 /docs/k8s/reference /docs/deploying/k8s/reference

--- a/static/_redirects
+++ b/static/_redirects
@@ -124,6 +124,7 @@
 
 /docs/tcp/ms-sql.html /docs/capabilities/tcp/examples/ms-sql
 /docs/tcp/ms-sql /docs/capabilities/tcp/examples/ms-sql
+/docs/tcp/examples/ms-sql /docs/capabilities/tcp/examples/ms-sql
 /docs/tcp/mysql.html /docs/capabilities/tcp/examples/mysql
 /docs/tcp/mysql /docs/capabilities/tcp/examples/mysql
 /docs/tcp/examples/ssh /docs/capabilities/tcp/examples/ssh


### PR DESCRIPTION
Fixes a slew of redirects from re-org, and fixes closed issues that continued to 404 after merging. 