### PR TITLE
docs: redirects 404ing blog urls

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -70,8 +70,8 @@
 /posts/2020/04/16/release-0-7/ /blog/announcing-pomerium-0-7/
 
 # Redirects /blog/tag urls to /blog
-/blog/tag/* /blog/:splat
-/blog/author/* /blog/:splat
+/blog/tag/* /blog
+/blog/author/* /blog
 
 /jobs/ /careers/
 /jobs/Frontend-Engineer.html /careers/frontend-engineer/

--- a/static/_redirects
+++ b/static/_redirects
@@ -69,6 +69,10 @@
 /posts/2020/05/11/release-0-8/ /blog/announcing-pomerium-0-8/
 /posts/2020/04/16/release-0-7/ /blog/announcing-pomerium-0-7/
 
+# Redirects /blog/tag urls to /blog
+/blog/tag/* /blog/:splat
+/blog/author/* /blog/:splat
+
 /jobs/ /careers/
 /jobs/Frontend-Engineer.html /careers/frontend-engineer/
 /jobs/Backend-Engineer.html /careers/backend-engineer/


### PR DESCRIPTION
Fixes: 
- https://github.com/pomerium/internal/issues/1127
- https://github.com/pomerium/internal/issues/1178
- https://github.com/pomerium/internal/issues/1180
- https://github.com/pomerium/internal/issues/1182
- https://github.com/pomerium/internal/issues/1177