### PR TITLE
docs: fixes a few more issues from broken re-org links

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -70,8 +70,11 @@
 /posts/2020/04/16/release-0-7/ /blog/announcing-pomerium-0-7/
 
 # Redirects /blog/tag urls to /blog
-/blog/tag/* /blog
-/blog/author/* /blog
+/blog/tag/releases /blog
+/blog/tag/tcp /blog
+/blog/tag/kubernetes /blog
+/blog/tag/istio /blog
+/blog/author/pomerium/feed /blog
 
 /jobs/ /careers/
 /jobs/Frontend-Engineer.html /careers/frontend-engineer/
@@ -204,8 +207,8 @@
 /docs/topics/device-identity /docs/concepts/device-identity
 /docs/topics/mutual-auth /docs/concepts/mutual-auth
 /docs/topics/original-request-context /docs/concepts/original-request-context
-/docs/concepts/original-request-context /docs/deploying/production-deployment
-/docs/topics/original-request-context.html /docs/capabilities/original-request-context
+/docs/concepts/original-request-context /docs/capabilities/original-request-context
+/docs/topics/original-request-context.html /docs/concepts/original-request-context
 /docs/concepts/original-request-context /docs/capabilities/original-request-context
 /docs/topics/ppl /docs/concepts/ppl
 /docs/concepts/ppl /docs/capabilities/ppl


### PR DESCRIPTION
The blog redirects and `original-request-context` links still 404. Hopefully, this will fix those links. 