### PR TITLE
tcp: update advanced docs for new URL format

### DIFF
--- a/content/docs/capabilities/tcp.mdx
+++ b/content/docs/capabilities/tcp.mdx
@@ -90,15 +90,21 @@ You may specify an optional address and port for the `tcp` command to listen on.
 
 `-` specifies that STDIN and STDOUT should be directly attached to the remote TCP connection. This is useful for [SSH](tcp/examples/ssh#tunnel-and-connect-simultaneously) or for sending data through a shell pipe.
 
-### Custom URL
+### Bastion Host
 
-If the Pomerium proxy is not reachable through port `443` or the route is not in external DNS, you can specify a custom URL:
+If the Pomerium proxy is not reachable through port `443` or the route is not in external DNS, you can use Pomerium as a bastion host using the extended TCP URL syntax in your route definition:
 
-```bash
-pomerium-cli tcp --pomerium-url https://pomerium.corp.example.com:8443 redis.corp.example.com:6379
+```yaml
+from: tcp+https://proxy.corp.example.com:8443/redis.internal.example.com:6379
 ```
 
-The command above connects to `https://pomerium.corp.example.com:8443` and then requests the TCP route for `redis.corp.example.com:6379`.
+And then using the same URL in the pomerium-cli command invocation:
+
+```bash
+pomerium-cli tcp tcp+https://proxy.corp.example.com:8443/redis.internal.example.com:6379
+```
+
+The command above connects to `https://pomerium.corp.example.com:8443` and then requests the TCP route for `redis.internal.example.com:6379`.
 
 ## Service-Specific Documentation
 

--- a/content/docs/capabilities/tcp/client.mdx
+++ b/content/docs/capabilities/tcp/client.mdx
@@ -184,10 +184,8 @@ For more examples and detailed usage information, see [TCP Support](/docs/capabi
 
 ## Advanced Configuration
 
-If Pomerium is listening on a port other than `443` (set with the [`address` key](/docs/reference/address)), the `pomerium-url` flag (CLI) or "Pomerium URL" field (GUI) is required. This specifies the address and port for the client to communicate over, while the standard URL defines the port assignment for the specific route. For example:
+If Pomerium is listening on a port other than `443` (set with the [`address` key](/docs/reference/address)), the full TCP URL can be specified with a bastion host:
 
 ```bash
-pomerium-cli tcp ssh.localhost:pomerium.io:2222 \
-   --pomerium-url https://ssh.localhost.pomerium.io:8443 \
-   --listen :2222
+pomerium-cli tcp tcp+https://ssh.localhost:pomerium.io:8443/ssh.localhost.pomerium.io:2222 --listen :2222
 ```


### PR DESCRIPTION
Fixes https://github.com/pomerium/internal/issues/1203

You can now specify TCP routes with a separate path to indicate a specialized bastion host:

```
tcp+https://proxy.example.com:8443/ssh.example.com:22
```

This does the same thing the custom `pomerium-url` option did, but does so more explicitly so that it works properly with Pomerium TLS certificate selection.