### PR TITLE
cspell: add pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,7 @@ repos:
           - 'prettier@2.7.1'
         files: ^content\/.*$
         exclude: content/docs/deploying/k8s/reference.md
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v6.2.0
+    hooks:
+      - id: cspell


### PR DESCRIPTION
Fixes https://github.com/pomerium/documentation/issues/237

Add a pre-commit hook for running cspell