### PR TITLE
Docs: fixes impersonation 404 links and cookie links

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -181,9 +181,10 @@
 /docs/changelog.html /docs/overview/changelog
 
 /docs/reference/identity-provider-service-account /docs/releases/upgrading
-/docs/reference/cookie-secure /docs/reference/cookie-secret-file
 /reference/ /docs/reference/
 /reference/* /docs/reference/:splat
+/docs/reference/cookie-secure /docs/reference/https-only
+/docs/reference/cookie-http-only /docs/reference/expiration
 
 /guides/ /docs/guides
 /guides/* /docs/guides/:splat

--- a/static/_redirects
+++ b/static/_redirects
@@ -199,9 +199,6 @@
 /docs/topics/single-sign-out.html /docs/capabilities/single-sign-out
 /docs/topics/single-sign-out /docs/capabilities/single-sign-out
 
-/docs/topics/impersonation.html /docs/releases/upgrading
-/docs/topics/impersonation /docs/releases/upgrading
-
 #redirects topics
 /docs/topics/* /docs/concepts/:splat 301!
 /docs/topics/device-identity /docs/concepts/device-identity
@@ -214,6 +211,8 @@
 /docs/concepts/ppl /docs/capabilities/ppl
 /docs/topics/load-balancing /docs/concepts/load-balancing
 /docs/topics/certificates /docs/concepts/certificates
+/docs/topics/impersonation.html /docs/concepts/impersonation
+/docs/concepts/impersonation /docs/releases/upgrading
 
 # redirects k8s links
 /docs/k8s/reference /docs/deploying/k8s/reference


### PR DESCRIPTION
(Should) fix the following: 
- https://github.com/pomerium/internal/issues/1132
- https://github.com/pomerium/internal/issues/1188
- https://github.com/pomerium/internal/issues/1170