### PR TITLE
Docs: adds Okta sign-in quickstarts link to Okta IdP guide

### DIFF
--- a/content/docs/identity-providers/okta.mdx
+++ b/content/docs/identity-providers/okta.mdx
@@ -16,7 +16,7 @@ This page covers configuring Okta to communicate with Pomerium as an [IdP](/docs
 
 :::caution
 
-While we do our best to keep our documentation up to date, changes to third-party systems are outside our control. Refer to [Create an Okta app Integration](https://developer.okta.com/docs/guides/sign-into-web-app/aspnet/create-okta-application/) from Okta's developer docs as needed, or [let us know](https://github.com/pomerium/documentation/issues/new?assignees=&labels=&template=doc-error.md) if we need to re-visit this page.
+While we do our best to keep our documentation up to date, changes to third-party systems are outside our control. Refer to [Okta's developer docs](https://developer.okta.com/docs/guides/sign-into-web-app/aspnet/create-okta-application/) as needed, or [let us know](https://github.com/pomerium/documentation/issues/new?assignees=&labels=&template=doc-error.md) if we need to re-visit this page.
 
 :::
 

--- a/content/docs/identity-providers/okta.mdx
+++ b/content/docs/identity-providers/okta.mdx
@@ -16,7 +16,7 @@ This page covers configuring Okta to communicate with Pomerium as an [IdP](/docs
 
 :::caution
 
-While we do our best to keep our documentation up to date, changes to third-party systems are outside our control. Refer to [Okta's developer docs](https://developer.okta.com/docs/guides/sign-into-web-app/aspnet/create-okta-application/) as needed, or [let us know](https://github.com/pomerium/documentation/issues/new?assignees=&labels=&template=doc-error.md) if we need to re-visit this page.
+While we do our best to keep our documentation up to date, changes to third-party systems are outside our control. Refer to [Okta's developer docs](https://developer.okta.com/docs/guides/sign-in-overview/main/) as needed, or [let us know](https://github.com/pomerium/documentation/issues/new?assignees=&labels=&template=doc-error.md) if we need to re-visit this page.
 
 :::
 


### PR DESCRIPTION
The docs were completely reorganized, so it was difficult to the right substitute for the 404ing link. 