### PR TITLE
Docs: adds deprecation notices to forward auth ref, nginx and traefik guides

### DIFF
--- a/content/docs/guides/nginx.mdx
+++ b/content/docs/guides/nginx.mdx
@@ -13,9 +13,11 @@ import DockerCompose from '../../examples/nginx/docker-compose.yaml.md';
 
 :::danger
 
-Before You Proceed Since this guide was written, Pomerium has developed into a first-class proxy service, and provides an integrated [Ingress Controller](/docs/deploying/k8s/ingress) for Kubernetes.
+Starting v0.21.0, Pomerium will no longer support [**Forward Auth**](/docs/reference/forward-auth). Supporting Forward Auth requires Pomerium to route requests from third-party proxies to make access control decisions. This goes against zero-trust principles as specified in the BeyondCorp model, which states that all traffic should flow through a single proxy.
 
-This guide will remain available for those already using Nginx with Pomerium, but we strongly encourage new users to configure Pomerium as the single method of authentication and proxying.
+Since this guide was written, Pomerium has developed into a first-class proxy service, and provides an integrated [Ingress Controller](/docs/deploying/k8s/ingress) for Kubernetes.
+
+For previous versions of Pomerium up to v0.20.0, this guide will remain available for those already using Nginx with Pomerium, but we strongly encourage new users to configure Pomerium as the single method of authentication and proxying.
 
 :::
 

--- a/content/docs/guides/traefik-ingress.mdx
+++ b/content/docs/guides/traefik-ingress.mdx
@@ -27,9 +27,11 @@ import Install from '../../examples/traefik-ingress/install.sh.md';
 
 :::danger
 
-Before You Proceed Since this guide was written, Pomerium has developed into a first-class proxy service, and provides an integrated [Ingress Controller](/docs/deploying/k8s/ingress) for Kubernetes.
+Starting v0.21.0, Pomerium will no longer support [**Forward Auth**](/docs/reference/forward-auth). Supporting Forward Auth requires Pomerium to route requests from third-party proxies to make access control decisions. This goes against zero-trust principles as specified in the BeyondCorp model, which states that all traffic should flow through a single proxy.
 
-This guide will remain available for those already using Traefik with Pomerium, but we strongly encourage new users to configure Pomerium as the single method of authentication and proxying.
+Since this guide was written, Pomerium has developed into a first-class proxy service, and provides an integrated [Ingress Controller](/docs/deploying/k8s/ingress) for Kubernetes.
+
+For previous versions of Pomerium up to v0.20.0, this guide will remain available for those already using Nginx with Pomerium, but we strongly encourage new users to configure Pomerium as the single method of authentication and proxying.
 
 :::
 

--- a/content/docs/reference/forward-auth.md
+++ b/content/docs/reference/forward-auth.md
@@ -1,6 +1,6 @@
 ---
 id: forward-auth
-title: Forward Auth
+title: Forward Auth (Deprecated)
 description: |
   Forward authentication creates an endpoint that can be used with third-party proxies.
 keywords:
@@ -10,7 +10,13 @@ pagination_prev: null
 pagination_next: null
 ---
 
-# Forward Auth
+# Forward Auth (Deprecated)
+
+:::warning
+
+Starting v0.21.0, Pomerium will no longer support **Forward Auth**. Supporting Forward Auth requires Pomerium to route requests from third-party proxies to make access control decisions. This goes against zero-trust principles as specified in the BeyondCorp model, which states that all traffic should flow through a single proxy.
+
+:::
 
 - Environmental Variable: `FORWARD_AUTH_URL`
 - Config File Key: `forward_auth_url`


### PR DESCRIPTION
Adds Forward Auth deprecation notices in Forward Auth reference, NGINX and Traefik guides. 