### PR TITLE
Docs:  split mode updates

### DIFF
--- a/content/docs/internals/data-storage.md
+++ b/content/docs/internals/data-storage.md
@@ -117,3 +117,9 @@ the second `s` in `rediss` is intentional and turns on TLS support
 ## Troubleshooting
 
 Most issues with the Databroker service are caused by a [`shared_secret`](/docs/reference/shared-secret) mismatch between services. See [Troubleshooting - Shared Secret Mismatch](/docs/reference/shared-secret) for details.
+
+:::tip **Note**
+
+You only need to include a [`shared_secret`](/docs/reference/shared-secret) and databroker parameters when running Pomerium in [all-in-one mode](/docs/internals/configuration). Running Pomerium in a distributed environment that handles each component separately does not require a shared secret or databroker parameters. 
+
+:::

--- a/content/docs/internals/data-storage.md
+++ b/content/docs/internals/data-storage.md
@@ -120,6 +120,6 @@ Most issues with the Databroker service are caused by a [`shared_secret`](/docs/
 
 :::tip **Note**
 
-You only need to include a [`shared_secret`](/docs/reference/shared-secret) and databroker parameters when running Pomerium in [all-in-one mode](/docs/internals/configuration). Running Pomerium in a distributed environment that handles each component separately does not require a shared secret or databroker parameters. 
+You only need to include a [`shared_secret`](/docs/reference/shared-secret) and databroker parameters when running Pomerium in [all-in-one mode](/docs/internals/configuration). Running Pomerium in a distributed environment that handles each component separately does not require a shared secret or databroker parameters.
 
 :::

--- a/content/docs/internals/troubleshooting.mdx
+++ b/content/docs/internals/troubleshooting.mdx
@@ -138,6 +138,12 @@ And Pomerium Enterprise will log the error with:
 
 Update the [shared secret](/docs/reference/shared-secret) across all Pomerium services to match the one set for the Databroker.
 
+:::tip **Note**
+
+You only need to include a [`shared_secret`](/docs/reference/shared-secret) and databroker parameters when running Pomerium in [all-in-one mode](/docs/internals/configuration). Running Pomerium in a distributed environment that handles each component separately does not require a shared secret or databroker parameters.
+
+:::
+
 #### Redis Secret Mismatch
 
 :::caution

--- a/content/docs/releases/enterprise/install/quickstart.mdx
+++ b/content/docs/releases/enterprise/install/quickstart.mdx
@@ -157,6 +157,12 @@ database_encryption_key: YYYYYYYYYYYYYYYYYYYYYY
 
 For database uri options (especially TLS settings) see the [PostgreSQL SSL Support](https://www.postgresql.org/docs/9.1/libpq-ssl.html) documentation.
 
+:::tip **Note**
+
+You only need to include a [`shared_secret`](/docs/reference/shared-secret) and databroker parameters when running Pomerium in [all-in-one mode](/docs/internals/configuration). Running Pomerium in a distributed environment that handles each component separately does not require a shared secret or databroker parameters.
+
+:::
+
 ### Administrators
 
 As a first-time setup step, you must also configure at least one administrator for console access. This user (or users) can then configure additional administrators in the console UI.


### PR DESCRIPTION
From what I could tell, there weren't any instances that suggest a shared key or databroker params as a requirement for split service mode. I added a tip to the Enterprise Quickstart and a few other pages. 