### PR TITLE
Docs: fixes redirects 

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -253,6 +253,8 @@
 /docs/concepts/ppl.html /docs/capabilities/ppl.html
 /docs/topics/load-balancing /docs/concepts/load-balancing
 /docs/concepts/load-balancing /docs/capabilities/routing
+/docs/topics/load-balancing.html /docs/concepts/load-balancing
+/docs/concepts/load-balancing /docs/capabilities/routing
 /docs/topics/certificates /docs/concepts/certificates
 
 # redirects k8s links

--- a/static/_redirects
+++ b/static/_redirects
@@ -106,6 +106,8 @@
 /docs/quick-start /docs/install
 /docs/quick-start/binary.html /docs/install/binary
 /docs/install/binary /docs/releases/core
+/docs/quick-start/binary /docs/install/binary
+/docs/install/binary /docs/releases/core
 /docs/quick-start/helm.html /docs/k8s/helm
 /docs/k8s/helm /docs/guides/helm
 /docs/quick-start/from-source.html /docs/install/from-source

--- a/static/_redirects
+++ b/static/_redirects
@@ -253,8 +253,7 @@
 /docs/concepts/ppl.html /docs/capabilities/ppl.html
 /docs/topics/load-balancing /docs/concepts/load-balancing
 /docs/concepts/load-balancing /docs/capabilities/routing
-/docs/topics/load-balancing.html /docs/concepts/load-balancing
-/docs/concepts/load-balancing /docs/capabilities/routing
+/docs/topics/load-balancing.html /docs/capabilities/routing
 /docs/topics/certificates /docs/concepts/certificates
 
 # redirects k8s links

--- a/static/_redirects
+++ b/static/_redirects
@@ -173,6 +173,8 @@
 # redirects /docs/tcp/examples/* to /docs/tcp/capabilities/examples/
 /docs/tcp/examples/* /docs/capabilities/tcp/examples/:splat
 
+# redirects /examples/ links
+/examples/js-sdk/express-server /docs/capabilities/jwt-verification
 
 /docs/install/helm.html /docs/k8s/helm
 /docs/k8s/helm /docs/guides/helm

--- a/static/_redirects
+++ b/static/_redirects
@@ -116,6 +116,7 @@
 /docs/install/quickstart /docs/quickstart
 /docs/quick-start/synology.html /docs/guides/synology
 /docs/enterprise/concepts /docs/capabilities/authentication
+/docs/enterprise/concepts.html /docs/capabilities/authentication
 /docs/enterprise/reference/manage /docs/capabilities/authentication
 /docs/enterprise/reference/manage.html /docs/capabilities/authentication
 /docs/enterprise/reference/reports /docs/capabilities/reports

--- a/static/_redirects
+++ b/static/_redirects
@@ -187,6 +187,7 @@
 /docs/k8s /docs/deploying/k8s/quickstart
 /docs/k8s/configure /docs/deploying/k8s/configure
 /docs/topics/kubernetes-integration /docs/deploying/k8s/quickstart
+/docs/topics/ingress /docs/deploying/k8s/ingress
 /docs/guides/tcp /docs/guides/securing-tcp
 /docs/guides/tcp.html /docs/guides/securing-tcp
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -185,6 +185,7 @@
 /docs/install/helm /docs/guides/helm
 /docs/topics/kubernetes-integration.html /docs/k8s/
 /docs/k8s /docs/deploying/k8s/quickstart
+/docs/k8s/configure /docs/deploying/k8s/configure
 /docs/topics/kubernetes-integration /docs/deploying/k8s/quickstart
 /docs/guides/tcp /docs/guides/securing-tcp
 /docs/guides/tcp.html /docs/guides/securing-tcp

--- a/static/_redirects
+++ b/static/_redirects
@@ -201,6 +201,8 @@
 /docs/upgrading /docs/releases/upgrading
 /docs/changelog.html /docs/overview/changelog
 /docs/overview/changelog /docs/releases/changelog
+/docs/changelog /docs/overview/changelog
+/docs/overview/changelog /docs/releases/changelog
 
 /docs/reference/identity-provider-service-account /docs/releases/upgrading
 /docs/reference/cookie-secure /docs/reference/cookie-secret-file

--- a/static/_redirects
+++ b/static/_redirects
@@ -120,6 +120,7 @@
 /docs/enterprise/external-data /docs/integrations/
 /docs/enterprise/install/helm /docs/guides/helm
 /docs/enterprise/install/quickstart /docs/releases/enterprise/install/quickstart
+/docs/enterprise/install/quickstart.html /docs/releases/enterprise/install/quickstart
 /docs/enterprise/branding /docs/capabilities/branding
 /docs/enterprise/branding/logo /docs/capabilities/branding
 /docs/enterprise/branding/colors /docs/capabilities/branding

--- a/static/_redirects
+++ b/static/_redirects
@@ -188,6 +188,8 @@
 /docs/guides/tcp /docs/guides/securing-tcp
 /docs/guides/tcp.html /docs/guides/securing-tcp
 
+/kubernetes/ /docs/deploying/k8s/quickstart
+
 /docs/FAQ.html /docs/troubleshooting
 /docs/troubleshooting /docs/internals/troubleshooting
 /docs/troubleshooting.html /docs/internals/troubleshooting

--- a/static/_redirects
+++ b/static/_redirects
@@ -267,7 +267,6 @@
 /docs/overview/upgrading/archive  /docs/overview/upgrading
 /docs/overview/changelog/archive  /docs/overview/upgrading
 /docs/overview/upgrading /docs/releases/upgrading
-/docs/changelog /docs/releases/changelog
 /enterprise/changelog /docs/releases/enterprise/changelog
 /docs/enterprise/changelog /docs/releases/enterprise/changelog
 /docs/enterprise/changelog.html /docs/releases/enterprise/changelog


### PR DESCRIPTION
SHOULD fix the following links:
- [ ] https://github.com/pomerium/documentation/issues/365
- [ ] https://github.com/pomerium/documentation/issues/364
- [ ] https://github.com/pomerium/documentation/issues/363
- [ ] https://github.com/pomerium/documentation/issues/362
- [ ] https://github.com/pomerium/documentation/issues/361
- [ ] https://github.com/pomerium/documentation/issues/360
- [ ] https://github.com/pomerium/documentation/issues/358
- [ ] https://github.com/pomerium/documentation/issues/357
- [ ] https://github.com/pomerium/documentation/issues/356