### PR TITLE
[blocked] v0.21.x: bump core version in enterprise guide

### DIFF
--- a/content/docs/releases/enterprise/install/kustomize.mdx
+++ b/content/docs/releases/enterprise/install/kustomize.mdx
@@ -14,13 +14,13 @@ The assumption is that Pomerium is installed into the `pomerium` namespace, and 
 The below command will expose the Pomerium Core Databroker gRPC interface.
 
 ```console
-kubectl apply -k github.com/pomerium/documentation/k8s/core\?ref=0-20-0
+kubectl apply -k github.com/pomerium/documentation/k8s/core\?ref=0-21-0
 ```
 
 ## Deploy Enterprise Console
 
 ```console
-kubectl apply -k github.com/pomerium/documentation/k8s/console\?ref=0-20-0
+kubectl apply -k github.com/pomerium/documentation/k8s/console\?ref=0-21-0
 ```
 
 The Enterprise Console need be configured before it becomes fully operational.

--- a/k8s/config-template/ingress-console.yaml
+++ b/k8s/config-template/ingress-console.yaml
@@ -11,7 +11,6 @@ metadata:
     ingress.pomerium.io/allow_any_authenticated_user: 'true'
     # since v0.21.0, console is using TLS by default
     ingress.pomerium.io/secure_upstream: 'true'
-    ingress.pomerium.io/tls_skip_verify: 'true'
 spec:
   ingressClassName: pomerium
   tls:

--- a/k8s/config-template/ingress-console.yaml
+++ b/k8s/config-template/ingress-console.yaml
@@ -11,6 +11,7 @@ metadata:
     ingress.pomerium.io/allow_any_authenticated_user: 'true'
     # since v0.21.0, console is using TLS by default
     ingress.pomerium.io/secure_upstream: 'true'
+    ingress.pomerium.io/tls_skip_verify: 'true'
 spec:
   ingressClassName: pomerium
   tls:

--- a/k8s/config-template/ingress-console.yaml
+++ b/k8s/config-template/ingress-console.yaml
@@ -4,10 +4,12 @@ metadata:
   name: pomerium-console
   annotations:
     cert-manager.io/cluster-issuer: your-cluster-issuer
-    external-dns.alpha.kubernetes.io/hostname: "console.domain.com"
-    # the below two annotations are required
+    external-dns.alpha.kubernetes.io/hostname: 'console.domain.com'
+    # console requires user identity headers
     ingress.pomerium.io/pass_identity_headers: 'true'
+    # console has internal access control. alternatively, use PPL
     ingress.pomerium.io/allow_any_authenticated_user: 'true'
+    # since v0.21.0, console is using TLS by default
     ingress.pomerium.io/secure_upstream: 'true'
 spec:
   ingressClassName: pomerium
@@ -16,7 +18,7 @@ spec:
       hosts:
         - console.domain.com
   rules:
-    - host: "console.domain.com"
+    - host: 'console.domain.com'
       http:
         paths:
           - path: /

--- a/k8s/console/deployment/args.yaml
+++ b/k8s/console/deployment/args.yaml
@@ -7,7 +7,6 @@ spec:
     spec:
       containers:
         - name: pomerium-console
-          args: ['serve']
           args:
             - --tls-derive=pomerium-console.$(POMERIUM_ENTERPRISE_NAMESPACE).svc.cluster.local
             - serve

--- a/k8s/console/deployment/image.yaml
+++ b/k8s/console/deployment/image.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: pomerium-console
-          image: docker.cloudsmith.io/pomerium/enterprise/pomerium-console:v0.21.0
+          image: docker.cloudsmith.io/pomerium/enterprise/pomerium-console:v0.21.1
           imagePullPolicy: IfNotPresent
       imagePullSecrets:
         - name: pomerium-enterprise-docker

--- a/k8s/core/kustomization.yaml
+++ b/k8s/core/kustomization.yaml
@@ -1,6 +1,6 @@
 namespace: pomerium
 resources:
-  - github.com/pomerium/ingress-controller/config/default?ref=v0.20.0
+  - github.com/pomerium/ingress-controller/config/default?ref=v0.21.2
   - service.yaml
 patchesStrategicMerge:
   - ./deployment.yaml


### PR DESCRIPTION
Blocked by https://github.com/pomerium/internal/issues/1291