### PR TITLE
Docs: cleans up redirects

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -93,6 +93,7 @@
     "proxying",
     "psql",
     "quickstart",
+    "quickstarts",
     "rego",
     "Remmina",
     "roundrobin",

--- a/static/_redirects
+++ b/static/_redirects
@@ -22,7 +22,7 @@
 /docs/security.html /docs/internals/security
 /docs/community/security.html /docs/internals/security
 
-# Guide and examples links (figure out guides redirects issue)
+# Guide and examples links
 /guide/ /docs/quick-start/
 /guide/kubernetes.html /docs/k8s
 /guide/kubernetes /docs/k8s
@@ -36,9 +36,10 @@
 /docs/guides/enroll-device /docs/capabilities/device-identity
 /docs/guides/enroll-device.html /docs/capabilities/device-identity
 /docs/guides/admin-enroll-device.html /docs/capabilities/device-identity
+/docs/guides/tcp /docs/guides/securing-tcp
+/docs/guides/tcp.html /docs/guides/securing-tcp
 
-# More docs guides redirects - mostly work as expected
-# Redirects to /docs/guides and /category/guides go to /
+# More docs guides redirects
 /recipes/ /docs/guides
 /docs/guides /category/guides
 /recipes/ad-guard.html /docs/guides/ad-guard
@@ -57,6 +58,7 @@
 
 # Reference, capabilities, topics, concepts links
 /docs/reference/readme.html /docs/
+/docs/concepts/namespacing /docs/capabilities/namespacing
 # Redirects incorrectly
 /docs/reference/certificates.html /docs/topics/certificates
 /docs/topics/certificates /docs/concepts/certificates
@@ -91,25 +93,23 @@
 
 
 
-
+# Blog posts
 /posts/2020/06/01/release-0-9/ /blog/posts-2020-06-01-release-0-9/
 /posts/2020/05/11/release-0-8/ /blog/announcing-pomerium-0-8/
 /posts/2020/04/16/release-0-7/ /blog/announcing-pomerium-0-7/
-
-# Redirects /blog/tag urls to /blog
 /blog/tag/releases /blog
 /blog/tag/tcp /blog
 /blog/tag/kubernetes /blog
 /blog/tag/istio /blog
 /blog/author/pomerium/feed /blog
-
+# Careers
 /jobs/ /careers/
 /jobs/Frontend-Engineer.html /careers/frontend-engineer/
 /jobs/Backend-Engineer.html /careers/backend-engineer/
 
 # Redirects enterprise links
 /enterprise/ /docs/enterprise
-/docs/enterprise /docs/releases/enterprise
+/docs/enterprise /docs/releases/enterprise/about
 /enterprise/service-accounts/ /docs/capabilities/service-accounts
 /enterprise/service-accounts.html /docs/capabilities/service-accounts
 /enterprise/prometheus.html /docs/capabilities/metrics
@@ -121,11 +121,17 @@
 /docs/enterprise/reference/config.html /docs/releases/enterprise/configure
 /enterprise/reference/configure.html /docs/releases/enterprise/configure
 /enterprise/reference/config.html /docs/releases/enterprise/configure
+/enterprise/concepts.html /docs/concepts/access-control
+# /docs/enterprise/about uses multiple redirects
+/docs/enterprise/about /docs/releases/enterprise
+/docs/releases/enterprise /docs/releases/enterprise/about
+/docs/enterprise/about.html /docs/releases/enterprise/about
+/enterprise/* /docs/enterprise/:splat
 
 #  Installation and deployment methods redirects
-# /docs/installation.html uses multiple redirects
 /docs/installation.html /docs/install
 /docs/installation /docs/install
+# /docs/quick-start uses multiple redirects
 /docs/quick-start /docs/install
 /docs/install/ /docs/quickstart
 
@@ -139,13 +145,27 @@
 /docs/releases/core /docs/deploying/binary
 
 /docs/install/binary.html /docs/deploying/binary
+
+# Helm links
 /docs/quick-start/helm.html /docs/k8s/helm
 /docs/k8s/helm /docs/guides/helm
+/docs/enterprise/install/helm /docs/guides/helm
+
+# /docs/install/helm.html uses multiple redirects
+/docs/install/helm.html /docs/k8s/helm
+/docs/k8s/helm /docs/guides/helm
+
+/docs/k8s/helm.html /docs/guides/helm
+/docs/install/helm /docs/releases/enterprise/install/helm
+/docs/k8s/quickstart /docs/deploying/k8s/quickstart
+
+# From-source links
 /docs/quick-start/from-source.html /docs/install/from-source
 /docs/install/from-source /docs/deploying/from-source
 /docs/install/from-source.html /docs/deploying/from-source
+
+# Enterprise and Core quickstarts
 /docs/install/quickstart /docs/quickstart
-/docs/enterprise/install/helm /docs/guides/helm
 /docs/enterprise/install/quickstart /docs/releases/enterprise/install/quickstart
 /docs/enterprise/install/quickstart.html /docs/releases/enterprise/install/quickstart
 /docs/enterprise/install /docs/releases/enterprise/install/quickstart
@@ -163,29 +183,33 @@
 /docs/enterprise/api.html /docs/capabilities/enterprise-api
 /docs/enterprise/api /docs/capabilities/enterprise-api
 
-/docs/enterprise/external-data/ip-ranges /docs/integrations/ip-ranges
-/docs/enterprise/external-data/geoip /docs/integrations/geoip
-/docs/enterprise/identity-providers/ping /docs/identity-providers/ping
+# redirects all /docs/enterprise/identity-providers to /docs/identity-providers
 /docs/enterprise/identity-providers/* /docs/identity-providers/:splat
 
 #redirects /docs/enterprise/external-data/* to /docs/integrations/
 /docs/enterprise/external-data/* /docs/integrations/:splat
 
-# Integrations redirects -- found on pomerium.com/integrations/
-/docs/enterprise/external-data/zenefits /docs/integrations/zenefits
-/docs/enterprise/external-data/tor-exit-nodes /docs/integrations/tor-exit-nodes
-/docs/enterprise/external-data/bamboohr /docs/integrations/bamboohr
-
 # TCP links
+# /docs/tcp/* redirects links to tcp/examples *TEST* if splat works, will clean up links below
+/docs/tcp/* /docs/capabilities/tcp/examples/:splat
 /docs/tcp/git.html /docs/capabilities/tcp/examples/git
 /docs/tcp/git /docs/capabilities/tcp/examples/git
-/docs/enterprise/metrics.html /docs/capabilities/metrics
-/docs/enterprise/metrics /docs/capabilities/metrics
 /docs/tcp/rdp.html /docs/capabilities/tcp/examples/rdp
 /docs/tcp/rdp /docs/capabilities/tcp/examples/rdp
 /docs/tcp/ssh.html /docs/capabilities/tcp/examples/ssh
 /docs/tcp/redis.html /docs/capabilities/tcp/examples/redis
 /docs/tcp/redis /docs/capabilities/tcp/examples/redis
+/docs/tcp/ms-sql.html /docs/capabilities/tcp/examples/ms-sql
+/docs/tcp/ms-sql /docs/capabilities/tcp/examples/ms-sql
+/docs/tcp/examples/ms-sql /docs/capabilities/tcp/examples/ms-sql
+/docs/tcp/mysql.html /docs/capabilities/tcp/examples/mysql
+/docs/tcp/mysql /docs/capabilities/tcp/examples/mysql
+/docs/tcp/examples/mysql /docs/capabilities/tcp/examples/mysql
+/docs/tcp/examples/ssh /docs/capabilities/tcp/examples/ssh
+
+# Enterprise metrics links
+/docs/enterprise/metrics.html /docs/capabilities/metrics
+/docs/enterprise/metrics /docs/capabilities/metrics
 
 # /docs/client.html uses multiple redirects
 /docs/client.html /docs/tcp/client
@@ -197,103 +221,96 @@
 /docs/topics/tcp-support.html /docs/tcp/
 /docs/tcp /docs/capabilities/tcp
 
-/docs/tcp/ms-sql.html /docs/capabilities/tcp/examples/ms-sql
-/docs/tcp/ms-sql /docs/capabilities/tcp/examples/ms-sql
-/docs/tcp/examples/ms-sql /docs/capabilities/tcp/examples/ms-sql
-/docs/tcp/mysql.html /docs/capabilities/tcp/examples/mysql
-/docs/tcp/mysql /docs/capabilities/tcp/examples/mysql
-/docs/tcp/examples/mysql /docs/capabilities/tcp/examples/mysql
-/docs/tcp/examples/ssh /docs/capabilities/tcp/examples/ssh
-
-# redirects /docs/tcp/examples/* to /docs/tcp/capabilities/examples/
-/docs/tcp/examples/* /docs/capabilities/tcp/examples/:splat
-
 # redirects /examples/ links
 # /examples/js-sdk/express-server 404s
 /examples/js-sdk/express-server /docs/capabilities/jwt-verification
 
-/docs/install/helm.html /docs/k8s/helm
-/docs/k8s/helm /docs/guides/helm
-/docs/k8s/helm.html /docs/guides/helm
-/docs/install/helm /docs/guides/helm
+# Kubernetes links
+# /docs/topics/kubernetes-integration.html uses mulitple redirects
 /docs/topics/kubernetes-integration.html /docs/k8s/
 /docs/k8s /docs/deploying/k8s/quickstart
+/docs/k8s/reference /docs/deploying/k8s/reference
+/docs/k8s/ingress /docs/deploying/k8s/ingress
+/docs/k8s/ingress.html /docs/deploying/k8s/ingress
+/docs/k8s/install /docs/deploying/k8s/install
+
 /docs/k8s/configure /docs/deploying/k8s/configure
 /docs/topics/kubernetes-integration /docs/deploying/k8s/quickstart
 /docs/topics/ingress /docs/deploying/k8s/ingress
-/docs/guides/tcp /docs/guides/securing-tcp
-/docs/guides/tcp.html /docs/guides/securing-tcp
-
+# Still 404s...
 /kubernetes/ /docs/deploying/k8s/quickstart
 
+# Troubshooting and FAQs
 /docs/FAQ.html /docs/troubleshooting
 /docs/troubleshooting /docs/internals/troubleshooting
 /docs/troubleshooting.html /docs/internals/troubleshooting
 /docs/faq /docs/internals/troubleshooting
 
+# /docs/glossary.html uses multiple redirects
 /docs/glossary.html /docs/overview/glossary
 /docs/overview/glossary /docs/internals/glossary
+
+
+# Releases and upgrading guides
+# /docs/releases.html has multiple redirects
 /docs/releases.html /docs/overview/releases
 /docs/overview/releases /docs/releases
+# /docs/architecture.html has multiple redirects
 /docs/architecture.html /docs/overview/architecture
 /docs/overview/architecture /docs/internals/architecture
+
 /docs/architecture /docs/internals/architecture
+# /docs/background.html has multiple redirects
 /docs/background.html /docs/overview/background
 /docs/overview/background /docs/concepts/zero-trust
+
 /docs/upgrading.html /docs/overview/upgrading
 /docs/upgrading /docs/releases/upgrading
+# /docs/changelog.html has multiple redirects
 /docs/changelog.html /docs/overview/changelog
 /docs/overview/changelog /docs/releases/changelog
+# /docs/changelog has multiple redirects
 /docs/changelog /docs/overview/changelog
 /docs/overview/changelog /docs/releases/changelog
 
 /docs/reference/identity-provider-service-account /docs/releases/upgrading
 /reference/ /docs/reference/
 /reference/* /docs/reference/:splat
-/docs/reference/cookie-secure /docs/reference/https-only
-/docs/reference/cookie-http-only /docs/deploying/k8s/reference
 
-/guides/ /docs/guides
-/guides/* /docs/guides/:splat
-/enterprise/ /docs/enterprise/about
-/enterprise/concepts.html /docs/capabilities/authentication
-/docs/enterprise/about /docs/releases/enterprise
-/docs/releases/enterprise /docs/releases/enterprise/about
-/docs/enterprise/about.html /docs/releases/enterprise/about
-/enterprise/* /docs/enterprise/:splat
-
-/docs/k8s/helm /docs/k8s/quickstart
-/docs/k8s/quickstart /docs/deploying/k8s/quickstart
-
-#redirects from /topics to /capabilities
+# Topics links - now concepts
 /docs/topics/auth-logs /docs/capabilities/audit-logs
 /docs/topics/single-sign-out.html /docs/capabilities/single-sign-out
 /docs/topics/single-sign-out /docs/capabilities/single-sign-out
 
 #redirects topics
-/docs/topics/* /docs/concepts/:splat 301!
-/docs/topics/device-identity /docs/concepts/device-identity
-/docs/topics/mutual-auth /docs/concepts/mutual-auth
-/docs/topics/original-request-context /docs/concepts/original-request-context
-/docs/concepts/original-request-context /docs/capabilities/original-request-context
+# /docs/topics/orc.html uses multiple redirects - still 404s
 /docs/topics/original-request-context.html /docs/concepts/original-request-context
 /docs/concepts/original-request-context /docs/capabilities/original-request-context
-/docs/topics/ppl /docs/concepts/ppl
-/docs/concepts/ppl /docs/capabilities/ppl
-/docs/topics/ppl.html /docs/concepts/ppl.html
-/docs/concepts/ppl.html /docs/capabilities/ppl.html
-/docs/topics/load-balancing /docs/concepts/load-balancing
-/docs/concepts/load-balancing /docs/capabilities/routing
+
+# multiple redirects - still 404s
 /docs/topics/load-balancing.html /docs/capabilities/routing
 /docs/topics/certificates /docs/concepts/certificates
+
+# multiple redriects - still 404s
 /docs/topics/impersonation.html /docs/concepts/impersonation
 /docs/concepts/impersonation /docs/capabilities/service-accounts
 
-# redirects k8s links
-/docs/k8s/reference /docs/deploying/k8s/reference
-/docs/k8s/ingress /docs/deploying/k8s/ingress
-/docs/k8s/ingress.html /docs/deploying/k8s/ingress
-/docs/k8s/install /docs/deploying/k8s/install
+/docs/topics/* /docs/concepts/:splat 301!
+/docs/topics/device-identity /docs/concepts/device-identity
+/docs/topics/mutual-auth /docs/concepts/mutual-auth
+
+# multiple redirects
+/docs/topics/original-request-context /docs/concepts/original-request-context
+/docs/concepts/original-request-context /docs/capabilities/original-request-context
+# multiple redirects
+/docs/topics/ppl /docs/concepts/ppl
+/docs/concepts/ppl /docs/capabilities/ppl
+# multiple redirects
+/docs/topics/ppl.html /docs/concepts/ppl.html
+/docs/concepts/ppl.html /docs/capabilities/ppl.html
+# multiple redirects
+/docs/topics/load-balancing /docs/concepts/load-balancing
+/docs/concepts/load-balancing /docs/capabilities/routing
 
 # flattened the changelog, and upgrading guide
 /docs/overview/upgrading/archive  /docs/overview/upgrading
@@ -319,5 +336,3 @@ https://0-10-0.docs.pomerium.io/ https://0-10-0.docs.pomerium.com/:splat 301!
 # 301 deprecated guides in v21 to v20 guides
 /docs/guides/nginx https://0-20-0.docs.pomerium.com/docs/guides/nginx 301!
 /docs/guides/traefik-ingress https://0-20-0.docs.pomerium.com/docs/guides/traefik-ingress 301!
-
-/docs/concepts/namespacing /docs/capabilities/namespacing

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,11 +1,14 @@
 # redirects will process the first matching rule it finds, reading from top to bottom.
 # https://docs.netlify.com/routing/redirects/
+
+# Configuration & Settings Reference (reference links redirect correctly)
 /docs/reference/reference /docs/reference
 /docs/reference/reference.html /docs/reference
 /docs/configuration/ /docs/reference
 /docs/config-reference.html /docs/reference
 /configuration/ /docs/reference
 
+# Community links (community links redirect correctly)
 /community/ /docs/community/
 /community/index.html /docs/community/
 /community/contributing /docs/community/contributing
@@ -19,18 +22,23 @@
 /docs/security.html /docs/internals/security
 /docs/community/security.html /docs/internals/security
 
+# Guide and examples links (figure out guides redirects issue)
 /guide/ /docs/quick-start/
 /guide/kubernetes.html /docs/k8s
 /guide/kubernetes /docs/k8s
 /docs/k8s /docs/deploying/k8s/quickstart
 /guide/synology /docs/guides/synology
 /guide/synology.html /docs/guides/synology
+/docs/quick-start/synology.html /docs/guides/synology
+# Redirects to /docs/guides go to pomerium homepage (/)
 /docs/examples.html /docs/guides
 /docs/examples /docs/guides
 /docs/guides/enroll-device /docs/capabilities/device-identity
 /docs/guides/enroll-device.html /docs/capabilities/device-identity
 /docs/guides/admin-enroll-device.html /docs/capabilities/device-identity
 
+# More docs guides redirects - mostly work as expected
+# Redirects to /docs/guides and /category/guides go to /
 /recipes/ /docs/guides
 /docs/guides /category/guides
 /recipes/ad-guard.html /docs/guides/ad-guard
@@ -47,26 +55,38 @@
 /docs/guides/upstream-mtls /docs/capabilities/mtls-services
 /docs/guides/upstream-mtls.html /docs/capabilities/mtls-services
 
+# Reference, capabilities, topics, concepts links
 /docs/reference/readme.html /docs/
+# Redirects incorrectly
 /docs/reference/certificates.html /docs/topics/certificates
 /docs/topics/certificates /docs/concepts/certificates
+
+# This link requires multiple redirects
 /docs/reference/data-storage.html /docs/topics/data-storage
 /docs/topics/data-storage /docs/concepts/data-storage
-/docs/topics/data-storage#backends /docs/concepts/data-storage#backends
+/docs/concepts/data-storage /docs/internals/data-storage
+
+# This link requires multiple redirects
 /docs/reference/getting-users-identity.html /docs/topics/getting-users-identity
 /docs/topics/getting-users-identity /docs/concepts/getting-users-identity
 /docs/concepts/getting-users-identity /docs/capabilities/getting-users-identity
+
 /docs/topics/getting-users-identity.html /docs/capabilities/getting-users-identity
+# This link requires multiple redirects
 /docs/reference/production-deployment.html /docs/topics/production-deployment
 /docs/topics/production-deployment /docs/deploying/production-deployment
+
 /docs/topics/production-deployment.html /docs/deploying/production-deployment
 /docs/production-deployment /docs/deploying/production-deployment
 /docs/production-deployment.html /docs/deploying/production-deployment
 /docs/production/security /docs/deploying/production-deployment
 /docs/production/production-deployment /docs/deploying/production-deployment
+
+# This links requires multiple redirects
 /docs/reference/programmatic-access.html /docs/topics/programmatic-access
 /docs/topics/programmatic-access /docs/concepts/programmatic-access
 /docs/concepts/programmatic-access /docs/capabilities/programmatic-access
+
 /docs/topics/programmatic-access.html /docs/capabilities/programmatic-access
 
 
@@ -94,45 +114,57 @@
 /enterprise/service-accounts.html /docs/capabilities/service-accounts
 /enterprise/prometheus.html /docs/capabilities/metrics
 /enterprise/prometheus /docs/capabilities/metrics
-/docs/enterprise/reference/ /docs/concepts/
+/docs/enterprise/reference/ /docs/releases/enterprise/configure
 /docs/enterprise/reference/configure /docs/releases/enterprise/configure
 /docs/enterprise/reference/configure.html /docs/releases/enterprise/configure
 /docs/enterprise/reference/config /docs/releases/enterprise/configure
 /docs/enterprise/reference/config.html /docs/releases/enterprise/configure
 /enterprise/reference/configure.html /docs/releases/enterprise/configure
 /enterprise/reference/config.html /docs/releases/enterprise/configure
+
+#  Installation and deployment methods redirects
+# /docs/installation.html uses multiple redirects
 /docs/installation.html /docs/install
 /docs/installation /docs/install
 /docs/quick-start /docs/install
+/docs/install/ /docs/quickstart
+
+# /docs/quick-start/binary.html uses multiple redirects
 /docs/quick-start/binary.html /docs/install/binary
 /docs/install/binary /docs/releases/core
+
+# /docs/quick-start/binary uses mulitple redirects
 /docs/quick-start/binary /docs/install/binary
 /docs/install/binary /docs/releases/core
+/docs/releases/core /docs/deploying/binary
+
+/docs/install/binary.html /docs/deploying/binary
 /docs/quick-start/helm.html /docs/k8s/helm
 /docs/k8s/helm /docs/guides/helm
 /docs/quick-start/from-source.html /docs/install/from-source
 /docs/install/from-source /docs/deploying/from-source
 /docs/install/from-source.html /docs/deploying/from-source
 /docs/install/quickstart /docs/quickstart
-/docs/quick-start/synology.html /docs/guides/synology
+/docs/enterprise/install/helm /docs/guides/helm
+/docs/enterprise/install/quickstart /docs/releases/enterprise/install/quickstart
+/docs/enterprise/install/quickstart.html /docs/releases/enterprise/install/quickstart
+/docs/enterprise/install /docs/releases/enterprise/install/quickstart
+/enterprise/install/ /docs/releases/enterprise/install/quickstart
+
 /docs/enterprise/concepts /docs/capabilities/authentication
 /docs/enterprise/concepts.html /docs/capabilities/authentication
 /docs/enterprise/reference/manage /docs/capabilities/authentication
 /docs/enterprise/reference/manage.html /docs/capabilities/authentication
 /docs/enterprise/reference/reports /docs/capabilities/reports
 /docs/enterprise/external-data /docs/integrations/
-/docs/enterprise/install/helm /docs/guides/helm
-/docs/enterprise/install/quickstart /docs/releases/enterprise/install/quickstart
-/docs/enterprise/install/quickstart.html /docs/releases/enterprise/install/quickstart
 /docs/enterprise/branding /docs/capabilities/branding
 /docs/enterprise/branding/logo /docs/capabilities/branding
 /docs/enterprise/branding/colors /docs/capabilities/branding
 /docs/enterprise/api.html /docs/capabilities/enterprise-api
 /docs/enterprise/api /docs/capabilities/enterprise-api
-/docs/enterprise/install /docs/releases/enterprise/install/quickstart
+
 /docs/enterprise/external-data/ip-ranges /docs/integrations/ip-ranges
 /docs/enterprise/external-data/geoip /docs/integrations/geoip
-/enterprise/install/ /docs/releases/enterprise/install/quickstart
 /docs/enterprise/identity-providers/ping /docs/identity-providers/ping
 /docs/enterprise/identity-providers/* /docs/identity-providers/:splat
 
@@ -143,27 +175,27 @@
 /docs/enterprise/external-data/zenefits /docs/integrations/zenefits
 /docs/enterprise/external-data/tor-exit-nodes /docs/integrations/tor-exit-nodes
 /docs/enterprise/external-data/bamboohr /docs/integrations/bamboohr
+
+# TCP links
 /docs/tcp/git.html /docs/capabilities/tcp/examples/git
+/docs/tcp/git /docs/capabilities/tcp/examples/git
 /docs/enterprise/metrics.html /docs/capabilities/metrics
 /docs/enterprise/metrics /docs/capabilities/metrics
 /docs/tcp/rdp.html /docs/capabilities/tcp/examples/rdp
-/docs/tcp/ssh.html /docs/capabilities/tcp/examples/ssh
-/docs/tcp/mysql.html /docs/capabilities/tcp/examples/mysql
-/docs/tcp/redis.html /docs/capabilities/tcp/examples/redis
-/docs/install/binary.html /docs/releases/enterprise/install/quickstart
-/docs/install/ /docs/quickstart
-
-/docs/client.html /docs/tcp/client
-/docs/tcp/client.html /docs/capabilities/tcp/client
-/docs/tcp/client /docs/capabilities/tcp/client
-/docs/topics/tcp-support.html /docs/tcp/
-/docs/tcp /docs/capabilities/tcp
-/docs/tcp/rdp.html /docs/capabilities/tcp/examples/rdp
 /docs/tcp/rdp /docs/capabilities/tcp/examples/rdp
+/docs/tcp/ssh.html /docs/capabilities/tcp/examples/ssh
 /docs/tcp/redis.html /docs/capabilities/tcp/examples/redis
 /docs/tcp/redis /docs/capabilities/tcp/examples/redis
-/docs/tcp/git.html /docs/capabilities/tcp/examples/git
-/docs/tcp/git /docs/capabilities/tcp/examples/git
+
+# /docs/client.html uses multiple redirects
+/docs/client.html /docs/tcp/client
+/docs/tcp/client.html /docs/capabilities/tcp/client
+
+/docs/tcp/client /docs/capabilities/tcp/client
+
+# /docs/topics/tcp-support.html uses multiple redirects
+/docs/topics/tcp-support.html /docs/tcp/
+/docs/tcp /docs/capabilities/tcp
 
 /docs/tcp/ms-sql.html /docs/capabilities/tcp/examples/ms-sql
 /docs/tcp/ms-sql /docs/capabilities/tcp/examples/ms-sql
@@ -177,6 +209,7 @@
 /docs/tcp/examples/* /docs/capabilities/tcp/examples/:splat
 
 # redirects /examples/ links
+# /examples/js-sdk/express-server 404s
 /examples/js-sdk/express-server /docs/capabilities/jwt-verification
 
 /docs/install/helm.html /docs/k8s/helm

--- a/static/_redirects
+++ b/static/_redirects
@@ -139,7 +139,7 @@
 /docs/quick-start/binary.html /docs/install/binary
 /docs/install/binary /docs/releases/core
 
-# /docs/quick-start/binary uses mulitple redirects
+# /docs/quick-start/binary uses multiple redirects
 /docs/quick-start/binary /docs/install/binary
 /docs/install/binary /docs/releases/core
 /docs/releases/core /docs/deploying/binary
@@ -226,7 +226,7 @@
 /examples/js-sdk/express-server /docs/capabilities/jwt-verification
 
 # Kubernetes links
-# /docs/topics/kubernetes-integration.html uses mulitple redirects
+# /docs/topics/kubernetes-integration.html uses multiple redirects
 /docs/topics/kubernetes-integration.html /docs/k8s/
 /docs/k8s /docs/deploying/k8s/quickstart
 /docs/k8s/reference /docs/deploying/k8s/reference
@@ -240,7 +240,7 @@
 # Still 404s...
 /kubernetes/ /docs/deploying/k8s/quickstart
 
-# Troubshooting and FAQs
+# Troubleshooting and FAQs
 /docs/FAQ.html /docs/troubleshooting
 /docs/troubleshooting /docs/internals/troubleshooting
 /docs/troubleshooting.html /docs/internals/troubleshooting
@@ -291,7 +291,7 @@
 /docs/topics/load-balancing.html /docs/capabilities/routing
 /docs/topics/certificates /docs/concepts/certificates
 
-# multiple redriects - still 404s
+# multiple redirects - still 404s
 /docs/topics/impersonation.html /docs/concepts/impersonation
 /docs/concepts/impersonation /docs/capabilities/service-accounts
 


### PR DESCRIPTION
This is just a housekeeping PR to clean up the redirects file:
- Deletes duplicate links 
- Rearranges links (somewhat) into categories.
- Labels links that use 2 or more lines (multiple redirects per link)
- Labels links that still 404 or redirect incorrectly (small handful)
I also found opportunities to consolidate links with a `:splat` but I'd like to do those in separate PRs one at a time so I can  test these out and make issues for them.