### PR TITLE
Docs: fixes more redirects

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -194,6 +194,14 @@
 /docs/enterprise/external-data/* /docs/integrations/:splat
 
 # TCP links
+
+# /docs/topics/tcp-support.html uses multiple redirects
+/docs/topics/tcp-support.html /docs/tcp/
+/docs/tcp /docs/capabilities/tcp
+
+/docs/topics/tcp-support /docs/tcp/
+/docs/tcp /docs/capabilities/tcp
+
 # /docs/tcp/examples/* redirects links to tcp/examples
 /docs/tcp/examples/* /docs/capabilities/tcp/examples/:splat
 # /docs/tcp/* redirects links to /docs/capabilities/tcp/examples/
@@ -208,10 +216,6 @@
 /docs/tcp/client.html /docs/capabilities/tcp/client
 
 /docs/tcp/client /docs/capabilities/tcp/client
-
-# /docs/topics/tcp-support.html uses multiple redirects
-/docs/topics/tcp-support.html /docs/tcp/
-/docs/tcp /docs/capabilities/tcp
 
 # redirects /examples/ links
 # /examples/js-sdk/express-server 404s

--- a/static/_redirects
+++ b/static/_redirects
@@ -128,6 +128,8 @@
 /docs/releases/enterprise /docs/releases/enterprise/about
 /docs/enterprise/about.html /docs/releases/enterprise/about
 /enterprise/reference/reports.html /docs/capabilities/reports
+
+/enterprise/install/helm.html /docs/releases/enterprise/install/helm
 /enterprise/* /docs/enterprise/:splat
 
 #  Installation and deployment methods redirects
@@ -160,7 +162,6 @@
 /docs/k8s/helm.html /docs/guides/helm
 /docs/install/helm /docs/releases/enterprise/install/helm
 /docs/k8s/quickstart /docs/deploying/k8s/quickstart
-/enterprise/install/helm.html /docs/releases/enterprise/install/helm
 
 # From-source links
 /docs/quick-start/from-source.html /docs/install/from-source

--- a/static/_redirects
+++ b/static/_redirects
@@ -197,20 +197,6 @@
 /docs/tcp/examples/* /docs/capabilities/tcp/examples/:splat
 # /docs/tcp/* redirects links to /docs/capabilities/tcp/examples/
 /docs/tcp/* /docs/capabilities/tcp/examples/:splat
-/docs/tcp/git.html /docs/capabilities/tcp/examples/git
-/docs/tcp/git /docs/capabilities/tcp/examples/git
-/docs/tcp/rdp.html /docs/capabilities/tcp/examples/rdp
-/docs/tcp/rdp /docs/capabilities/tcp/examples/rdp
-/docs/tcp/ssh.html /docs/capabilities/tcp/examples/ssh
-/docs/tcp/redis.html /docs/capabilities/tcp/examples/redis
-/docs/tcp/redis /docs/capabilities/tcp/examples/redis
-/docs/tcp/ms-sql.html /docs/capabilities/tcp/examples/ms-sql
-/docs/tcp/ms-sql /docs/capabilities/tcp/examples/ms-sql
-/docs/tcp/examples/ms-sql /docs/capabilities/tcp/examples/ms-sql
-/docs/tcp/mysql.html /docs/capabilities/tcp/examples/mysql
-/docs/tcp/mysql /docs/capabilities/tcp/examples/mysql
-/docs/tcp/examples/mysql /docs/capabilities/tcp/examples/mysql
-/docs/tcp/examples/ssh /docs/capabilities/tcp/examples/ssh
 
 # Enterprise metrics links
 /docs/enterprise/metrics.html /docs/capabilities/metrics


### PR DESCRIPTION
This should fix the following links:
- [ ] https://github.com/pomerium/documentation/issues/337
- [ ] https://github.com/pomerium/documentation/issues/334
- [ ] https://github.com/pomerium/documentation/issues/334