### PR TITLE
Docs: fixes redirects

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -30,7 +30,7 @@
 /guide/synology /docs/guides/synology
 /guide/synology.html /docs/guides/synology
 /docs/quick-start/synology.html /docs/guides/synology
-# Redirects to /docs/guides go to pomerium homepage (/)
+
 /docs/examples.html /docs/guides
 /docs/examples /docs/guides
 /docs/guides/enroll-device /docs/capabilities/device-identity
@@ -41,21 +41,14 @@
 /docs/guides/admin-enroll-device /docs/capabilities/device-identity
 
 # More docs guides redirects
-/recipes/ /docs/guides
-/docs/guides /category/guides
-/recipes/ad-guard.html /docs/guides/ad-guard
-/recipes/argo.html /docs/guides/argo
-/recipes/cloud-run.html /docs/guides/cloud-run
-/recipes/istio.html /docs/guides/istio
-/recipes/kubernetes.html /docs/guides/kubernetes
-/recipes/local-oidc.html /docs/guides/local-oidc
-/recipes/mtls.html /docs/guides/mtls
+/recipes/* /docs/guides/:splat
+/category/guides /docs/guides
 /docs/guides/mtls /docs/capabilities/mtls-clients
 /docs/guides/mtls.html /docs/capabilities/mtls-clients
-/recipes/vs-code-server.html /docs/guides/code-server
 /guides/vs-code-server.html /docs/guides/code-server
 /docs/guides/upstream-mtls /docs/capabilities/mtls-services
 /docs/guides/upstream-mtls.html /docs/capabilities/mtls-services
+/guides/local-oidc.html /docs/guides/local-oidc
 
 # Reference, capabilities, topics, concepts links
 /docs/reference/readme.html /docs/
@@ -68,6 +61,7 @@
 /docs/reference/data-storage.html /docs/topics/data-storage
 /docs/topics/data-storage /docs/concepts/data-storage
 /docs/concepts/data-storage /docs/internals/data-storage
+/docs/topics/data-storage.html /docs/internals/data-storage
 
 # This link requires multiple redirects
 /docs/reference/getting-users-identity.html /docs/topics/getting-users-identity
@@ -91,7 +85,6 @@
 /docs/concepts/programmatic-access /docs/capabilities/programmatic-access
 
 /docs/topics/programmatic-access.html /docs/capabilities/programmatic-access
-
 
 
 # Blog posts
@@ -293,6 +286,7 @@
 /docs/topics/impersonation.html /docs/concepts/impersonation
 /docs/concepts/impersonation /docs/capabilities/service-accounts
 
+/docs/topics/ /docs/concepts/access-control
 /docs/topics/* /docs/concepts/:splat 301!
 /docs/topics/device-identity /docs/concepts/device-identity
 /docs/topics/mutual-auth /docs/concepts/mutual-auth
@@ -334,3 +328,6 @@ https://0-10-0.docs.pomerium.io/ https://0-10-0.docs.pomerium.com/:splat 301!
 # 301 deprecated guides in v21 to v20 guides
 /docs/guides/nginx https://0-20-0.docs.pomerium.com/docs/guides/nginx 301!
 /docs/guides/traefik-ingress https://0-20-0.docs.pomerium.com/docs/guides/traefik-ingress 301!
+/docs/guides/traefik-ingress.html https://0-20-0.docs.pomerium.com/docs/guides/traefik-ingress 301!
+/guides/traefik-ingress.html https://0-20-0.docs.pomerium.com/docs/guides/traefik-ingress 301!
+/docs/reference/forward-auth https://0-20-0.docs.pomerium.com/docs/reference/forward-auth 301!


### PR DESCRIPTION
This PR:
- Cleans up 404s from GSC.
- Adds a `/recipe/` splat to reduce links in the file
- 301s deprecated Forward Auth to v20 docs

Should fix the following: 
- [ ] https://github.com/pomerium/documentation/issues/500
- [ ] https://github.com/pomerium/documentation/issues/499
- [ ] https://github.com/pomerium/documentation/issues/497
- [ ] https://github.com/pomerium/documentation/issues/496
- [ ] https://github.com/pomerium/documentation/issues/495
- [ ] https://github.com/pomerium/documentation/issues/494
- [ ] https://github.com/pomerium/documentation/issues/493
