### PR TITLE
Docs: adds v21 changelogs

### DIFF
--- a/content/docs/releases/changelog.mdx
+++ b/content/docs/releases/changelog.mdx
@@ -8,6 +8,39 @@ lang: en-US
 
 Please refer to the [upgrade guide](https://www.pomerium.com/docs/releases/upgrading#since-0190) before upgrading.
 
+## [v0.21.3](https://github.com/pomerium/pomerium/tree/v0.21.3) (2023-03-23)
+
+[Full Changelog](https://github.com/pomerium/pomerium/compare/v0.21.2...v0.21.3)
+
+## Changed
+
+- ci: build version branch images [\#4062](https://github.com/pomerium/pomerium/pull/4062) (@backport-actions-token[bot])
+- authorize: move sign out and jwks urls to route, update issuer for JWT [\#4049](https://github.com/pomerium/pomerium/pull/4049) (@backport-actions-token[bot])
+- hpke: move published public keys to a new endpoint [\#4048](https://github.com/pomerium/pomerium/pull/4048) (@backport-actions-token[bot])
+
+## [v0.21.2](https://github.com/pomerium/pomerium/tree/v0.21.2) (2023-02-23)
+
+[Full Changelog](https://github.com/pomerium/pomerium/compare/v0.21.1...v0.21.2)
+
+## Changed
+
+- authenticate: fix identity provider id in encrypted query string [\#4011](https://github.com/pomerium/pomerium/pull/4011) (@backport-actions-token[bot])
+- authenticate: fix callback handler for split mode [\#4010](https://github.com/pomerium/pomerium/pull/4010) (@backport-actions-token[bot])
+- authenticate: don't require a session for sign\_out [\#4009](https://github.com/pomerium/pomerium/pull/4009) (@backport-actions-token[bot])
+- authenticate: fix authenticate\_internal\_service\_url for all in one [\#4005](https://github.com/pomerium/pomerium/pull/4005) (@backport-actions-token[bot])
+- derivecert: fix ecdsa code to be deterministic [\#3991](https://github.com/pomerium/pomerium/pull/3991) (@backport-actions-token[bot])
+- fix webauthn url [\#3988](https://github.com/pomerium/pomerium/pull/3988) (@backport-actions-token[bot])
+- webauthn: only return known device credentials that match the given type [\#3987](https://github.com/pomerium/pomerium/pull/3987) (@backport-actions-token[bot])
+
+## [v0.21.1](https://github.com/pomerium/pomerium/releases/tag/v0.21.1) (2023-02-16)
+
+[Full Changelog](https://github.com/pomerium/pomerium/compare/v0.21.0...v0.21.1)
+
+## Changed
+
+* authenticate: save the session cookie with a different name by @calebdoxsey in https://github.com/pomerium/pomerium/pull/3984
+* lua: fix rewrite response headers to handle dashes in URLs by @calebdoxsey in https://github.com/pomerium/pomerium/pull/3986
+
 ## [v0.21.0](https://github.com/pomerium/pomerium/tree/v0.21.0) (2023-02-09)
 
 [Full Changelog](https://github.com/pomerium/pomerium/compare/v0.21.0-rc2...v0.21.0)

--- a/content/docs/releases/changelog.mdx
+++ b/content/docs/releases/changelog.mdx
@@ -26,8 +26,8 @@ Please refer to the [upgrade guide](https://www.pomerium.com/docs/releases/upgra
 
 - authenticate: fix identity provider id in encrypted query string [\#4011](https://github.com/pomerium/pomerium/pull/4011) (@backport-actions-token[bot])
 - authenticate: fix callback handler for split mode [\#4010](https://github.com/pomerium/pomerium/pull/4010) (@backport-actions-token[bot])
-- authenticate: don't require a session for sign\_out [\#4009](https://github.com/pomerium/pomerium/pull/4009) (@backport-actions-token[bot])
-- authenticate: fix authenticate\_internal\_service\_url for all in one [\#4005](https://github.com/pomerium/pomerium/pull/4005) (@backport-actions-token[bot])
+- authenticate: don't require a session for sign_out [\#4009](https://github.com/pomerium/pomerium/pull/4009) (@backport-actions-token[bot])
+- authenticate: fix authenticate_internal_service_url for all in one [\#4005](https://github.com/pomerium/pomerium/pull/4005) (@backport-actions-token[bot])
 - derivecert: fix ecdsa code to be deterministic [\#3991](https://github.com/pomerium/pomerium/pull/3991) (@backport-actions-token[bot])
 - fix webauthn url [\#3988](https://github.com/pomerium/pomerium/pull/3988) (@backport-actions-token[bot])
 - webauthn: only return known device credentials that match the given type [\#3987](https://github.com/pomerium/pomerium/pull/3987) (@backport-actions-token[bot])
@@ -38,8 +38,8 @@ Please refer to the [upgrade guide](https://www.pomerium.com/docs/releases/upgra
 
 ## Changed
 
-* authenticate: save the session cookie with a different name by @calebdoxsey in https://github.com/pomerium/pomerium/pull/3984
-* lua: fix rewrite response headers to handle dashes in URLs by @calebdoxsey in https://github.com/pomerium/pomerium/pull/3986
+- authenticate: save the session cookie with a different name by @calebdoxsey in https://github.com/pomerium/pomerium/pull/3984
+- lua: fix rewrite response headers to handle dashes in URLs by @calebdoxsey in https://github.com/pomerium/pomerium/pull/3986
 
 ## [v0.21.0](https://github.com/pomerium/pomerium/tree/v0.21.0) (2023-02-09)
 


### PR DESCRIPTION
Adds Core changelogs for the following releases:
- v0.21.1
- v0.21.2
- v0.21.3

The upgrade guide link in the changelog will need to be updated once the guides are ready. 