### PR TITLE
Docs: adds notice to cloud run guide

### DIFF
--- a/content/docs/guides/cloud-run.mdx
+++ b/content/docs/guides/cloud-run.mdx
@@ -14,6 +14,14 @@ import PolicyTemplate from '../../examples/cloudrun/policy.template.yaml.md';
 import Zonefile from '../../examples/cloudrun/zonefile.txt.md';
 import DeployScript from '../../examples/cloudrun/deploy.sh.md';
 
+:::caution
+
+This guide is outdated and will not work with Pomerium's current environment settings. We are actively working on updating the guide so that it's compatible with the latest versions of Google Cloud and Pomerium Core.
+
+See [this GitHub issue](https://github.com/pomerium/pomerium/issues/4091) for more information, or refer to the [v0.17.0 Cloud Run guide](https://0-17-0.docs.pomerium.com/guides/cloud-run.html) for a working version.
+
+:::
+
 This recipe's sources can be found [on github](https://github.com/pomerium/pomerium/tree/main/examples/cloudrun)
 
 ## Background


### PR DESCRIPTION
Adds an oudated notice to the CloudRun guide: https://www.pomerium.com/docs/guides/cloud-run

I went ahead and linked to the last working version, but not sure if we should include that or not since it's v17. 