### PR TITLE
Docs: Hosted Authenticate Service capabilities page and sidebar

### DIFF
--- a/content/docs/capabilities/hosted-authenticate-service.md
+++ b/content/docs/capabilities/hosted-authenticate-service.md
@@ -3,34 +3,34 @@ id: hosted-authenticate-service
 title: Hosted Authenticate Service
 sidebar_label: Hosted Authenticate Service
 keywords: [hosted authenticate service url, hosted identity provider]
-description: Use Pomerium's Hosted Authenticate Service to set up and deploy Pomerium quickly. 
+description: Use Pomerium's Hosted Authenticate Service to set up and deploy Pomerium quickly.
 ---
 
 # Hosted Authenticate Service
 
 Pomerium's **Hosted Authenticate Service** provides a **Hosted Authenticate Service URL** and a **Hosted Identity Provider** you can use in your Pomerium configuration as an alternative to self-hosting these services.
 
-The Hosted Authenticate Service is available for both open-source Pomerium Core and Enterprise users. 
+The Hosted Authenticate Service is available for both open-source Pomerium Core and Enterprise users.
 
 ## Why use Hosted Authenticate Service
 
-The Hosted Authenticate Service offers a quicker way for users to deploy and test Pomerium. 
+The Hosted Authenticate Service offers a quicker way for users to deploy and test Pomerium.
 
 ### Zero configuration
 
-Including the hosted authenticate URL in your configuration file authenticates your users against our hosted identity provider (IdP) solution (we use Cognito). 
+Including the hosted authenticate URL in your configuration file authenticates your users against our hosted identity provider (IdP) solution (we use Cognito).
 
 This means you only need to include the hosted URL in your configuration file to use Pomerium's hosted services — no IdP settings required.
 
 ### Less time to deploy
 
-Pomerium's hosted services solution removes the tedium of configuring your own IdP and authenticate service URL so you can deploy your Pomerium instance in less time. 
+Pomerium's hosted services solution removes the tedium of configuring your own IdP and authenticate service URL so you can deploy your Pomerium instance in less time.
 
 ### Faster proof of concept
 
 If you're testing Pomerium for the first time, run [Pomerium with Docker](/docs/quickstart) using our hosted services – you can run Pomerium Core in **under 5 minutes** with minimal setup.
 
-Current Pomerium users who are interested in our [Enterprise Console](https://www.pomerium.com/enterprise-sales/) can test out the [Docker Enterprise Quickstart](/docs/releases/enterprise/install/quickstart) using hosted services as well. 
+Current Pomerium users who are interested in our [Enterprise Console](https://www.pomerium.com/enterprise-sales/) can test out the [Docker Enterprise Quickstart](/docs/releases/enterprise/install/quickstart) using hosted services as well.
 
 ## How to use the Hosted Authenticate Service
 
@@ -56,26 +56,21 @@ routes:
 
 This minimal configuration is all you need to connect to upstream services with Pomerium.
 
-:::tip 
+:::tip
 
-If you use the hosted URL and include your own IdP settings, Pomerium will override your IdP configuration and use the hosted IdP instead. 
+If you use the hosted URL and include your own IdP settings, Pomerium will override your IdP configuration and use the hosted IdP instead.
 
 :::
 
 ## Privacy considerations
 
-Users that take advantage of our Hosted Authenticate Service should review the [Terms of Service agreement](https://www.pomerium.com/pomerium-zero-user-agreement/). 
+Users that take advantage of our Hosted Authenticate Service should review the [Terms of Service agreement](https://www.pomerium.com/pomerium-zero-user-agreement/).
 
-Specifically, you should be aware that, by using our hosted services, you are aware and agree to Pomerium collecting the following data: 
+Specifically, you should be aware that, by using our hosted services, you are aware and agree to Pomerium collecting the following data:
+
 - IP address
 - OS version
 - Internal domain name
 - Session details (email, name, and domain)
 
-We collect this information to better understand how our users interact with and use Pomerium's services. 
-
-
-
-
-
-
+We collect this information to better understand how our users interact with and use Pomerium's services.

--- a/content/docs/capabilities/hosted-authenticate-service.md
+++ b/content/docs/capabilities/hosted-authenticate-service.md
@@ -1,0 +1,81 @@
+---
+id: hosted-authenticate-service
+title: Hosted Authenticate Service
+sidebar_label: Hosted Authenticate Service
+keywords: [hosted authenticate service url, hosted identity provider]
+description: Use Pomerium's Hosted Authenticate Service to set up and deploy Pomerium quickly. 
+---
+
+# Hosted Authenticate Service
+
+Pomerium's **Hosted Authenticate Service** provides a **Hosted Authenticate Service URL** and a **Hosted Identity Provider** you can use in your Pomerium configuration as an alternative to self-hosting these services.
+
+The Hosted Authenticate Service is available for both open-source Pomerium Core and Enterprise users. 
+
+## Why use Hosted Authenticate Service
+
+The Hosted Authenticate Service offers a quicker way for users to deploy and test Pomerium. 
+
+### Zero configuration
+
+Including the hosted authenticate URL in your configuration file authenticates your users against our hosted identity provider (IdP) solution (we use Cognito). 
+
+This means you only need to include the hosted URL in your configuration file to use Pomerium's hosted services — no IdP settings required.
+
+### Less time to deploy
+
+Pomerium's hosted services solution removes the tedium of configuring your own IdP and authenticate service URL so you can deploy your Pomerium instance in less time. 
+
+### Faster proof of concept
+
+If you're testing Pomerium for the first time, run [Pomerium with Docker](/docs/quickstart) using our hosted services – you can run Pomerium Core in **under 5 minutes** with minimal setup.
+
+Current Pomerium users who are interested in our [Enterprise Console](https://www.pomerium.com/enterprise-sales/) can test out the [Docker Enterprise Quickstart](/docs/releases/enterprise/install/quickstart) using hosted services as well. 
+
+## How to use the Hosted Authenticate Service
+
+The steps are simple:
+
+1. Include the Hosted Authenticate Service URL in your configuration file
+1. Remove your IdP settings
+1. Set up a route and policy
+
+```yaml title=pomerium-config.yaml
+authenticate_service_url: https://authenticate.pomerium.app
+
+routes:
+  - from: https://verify.localhost.pomerium.io
+    to: http://verify:8000
+    policy:
+      - allow:
+          or:
+            - email:
+                is: user@example.com
+    pass_identity_headers: true
+```
+
+This minimal configuration is all you need to connect to upstream services with Pomerium.
+
+:::tip 
+
+If you use the hosted URL and include your own IdP settings, Pomerium will override your IdP configuration and use the hosted IdP instead. 
+
+:::
+
+## Privacy considerations
+
+Users that take advantage of our Hosted Authenticate Service should review the [Terms of Service agreement](https://www.pomerium.com/pomerium-zero-user-agreement/). 
+
+Specifically, you should be aware that, by using our hosted services, you are aware and agree to Pomerium collecting the following data: 
+- IP address
+- OS version
+- Internal domain name
+- Session details (email, name, and domain)
+
+We collect this information to better understand how our users interact with and use Pomerium's services. 
+
+
+
+
+
+

--- a/content/docs/capabilities/hosted-authenticate-service.md
+++ b/content/docs/capabilities/hosted-authenticate-service.md
@@ -18,7 +18,7 @@ Pomerium's hosted service includes a **Hosted Authenticate Service URL** and a *
 
 Starting in **Pomerium v0.22.0**, both open-source Pomerium Core and Enterprise deployments will use our hosted services by default.
 
-The Hosted Authenticate Service is optional. If you prefer to self-host these services, you still can. See the Self-Hosted Authenticate service page for more information.
+The Hosted Authenticate Service is optional. If you prefer to self-host these services, you still can. See the [Self-Hosted Authenticate service](/docs/capabilities/self-hosted-authenticate-service) page for more information.
 
 ## Why use Hosted Authenticate Service
 

--- a/content/docs/capabilities/hosted-authenticate-service.md
+++ b/content/docs/capabilities/hosted-authenticate-service.md
@@ -8,7 +8,7 @@ description: Use Pomerium's Hosted Authenticate Service to set up and deploy Pom
 
 # Hosted Authenticate Service
 
-Pomerium's **Hosted Authenticate Service** provides a **Hosted Authenticate Service URL** and a **Hosted Identity Provider** you can use in your Pomerium configuration as an alternative to self-hosting these services.
+Pomerium v0.23.0 provides a **Hosted Authenticate Service**, which includes a **Hosted Authenticate Service URL** and a **Hosted Identity Provider** you can use in your Pomerium configuration as an alternative to self-hosting these services.
 
 The Hosted Authenticate Service is available for both open-source Pomerium Core and Enterprise users.
 

--- a/content/docs/capabilities/hosted-authenticate-service.md
+++ b/content/docs/capabilities/hosted-authenticate-service.md
@@ -104,6 +104,10 @@ Currently, you can only authenticate with Google single-sign on or with email an
 
 The hosted authenticate service is separate from your Pomerium installation. This means you can't refresh session tokens, so users must re-authenticate after roughly one hour.
 
+**Uptime commitment**
+
+We make no commitments to uptime for our free hosted authenticate service. 
+
 ## Privacy considerations
 
 Users that take advantage of our Hosted Authenticate Service should review the [Terms of Service agreement](https://www.pomerium.com/pomerium-zero-user-agreement/).

--- a/content/docs/capabilities/hosted-authenticate-service.md
+++ b/content/docs/capabilities/hosted-authenticate-service.md
@@ -8,9 +8,17 @@ description: Use Pomerium's Hosted Authenticate Service to set up and deploy Pom
 
 # Hosted Authenticate Service
 
-Pomerium v0.23.0 provides a **Hosted Authenticate Service**, which includes a **Hosted Authenticate Service URL** and a **Hosted Identity Provider** you can use in your Pomerium configuration as an alternative to self-hosting these services.
+Pomerium's **Hosted Authenticate Service** provides a hosted alternative to the Self-Hosted Authenticate Service. 
 
-The Hosted Authenticate Service is available for both open-source Pomerium Core and Enterprise users.
+The Hosted Authenticate Service is available in Pomerium v0.22.0 for both open-source Pomerium Core and Enterprise users.
+
+## How the Hosted Authenticate Service works
+
+Pomerium's hosted service includes a **Hosted Authenticate Service URL** and a **Hosted Identity Provider** that handle authentication and authorization using OAuth 2.0 and OIDC protocols. 
+
+Starting in **Pomerium v0.22.0**, both open-source Pomerium Core and Enterprise deployments will use our hosted services by default.
+
+The Hosted Authenticate Service is optional. If you prefer to self-host these services, you still can. See the Self-Hosted Authenticate service page for more information.
 
 ## Why use Hosted Authenticate Service
 
@@ -18,9 +26,7 @@ The Hosted Authenticate Service offers a quicker way for users to deploy and tes
 
 ### Zero configuration
 
-Including the hosted authenticate URL in your configuration file authenticates your users against our hosted identity provider solution (we use Cognito).
-
-This means you only need to include the hosted URL in your configuration file to use Pomerium's hosted services — no [identity provider configuration](/docs/identity-providers) required.
+The Hosted Authenticate Service requires no setup to use. That means you don't need to include the hosted authenticate service URL or IdP settings in your configuration for Pomerium to proxy your requests.
 
 ### Less time to deploy
 
@@ -32,11 +38,30 @@ If you're testing Pomerium for the first time, run [Pomerium with Docker](/docs/
 
 Current Pomerium users who are interested in our [Enterprise Console](https://www.pomerium.com/enterprise-sales/) can test out the [Docker Enterprise Quickstart](/docs/releases/enterprise/install/quickstart) using hosted services as well.
 
-## How to use the Hosted Authenticate Service
+## Configure the Hosted Authenticate Service
 
-1. Include the Hosted Authenticate Service URL in your configuration file
+The Hosted Authenticate Service requires zero configuraiton to use:
+
+1. Remove your Authenticate Service URL from the configuration file
 1. Remove your IdP settings
 1. Set up a route and policy
+
+```yaml title=pomerium-config.yaml
+
+routes:
+  - from: https://verify.localhost.pomerium.io
+    to: http://verify:8000
+    policy:
+      - allow:
+          or:
+            - email:
+                is: user@example.com
+    pass_identity_headers: true
+```
+
+This minimal configuration is all you need to connect to an upstream service with Pomerium's hosted services.
+
+If you want, you can still include the hosted URL in your configuration:
 
 ```yaml title=pomerium-config.yaml
 authenticate_service_url: https://authenticate.pomerium.app
@@ -52,13 +77,25 @@ routes:
     pass_identity_headers: true
 ```
 
-This minimal configuration is all you need to connect to an upstream service with Pomerium.
+If you use the hosted URL and include your own IdP settings, Pomerium will override your IdP configuration and use the hosted IdP instead:
 
-:::tip
+```yaml title=pomerium-config.yaml
+authenticate_service_url: https://authenticate.pomerium.app
 
-If you use the hosted URL and include your own IdP settings, Pomerium will override your IdP configuration and use the hosted IdP instead.
+idp_provider: google
+idp_client_id: my_client_id
+idp_client_secret: my_client_secret
 
-:::
+routes:
+  - from: https://verify.localhost.pomerium.io
+    to: http://verify:8000
+    policy:
+      - allow:
+          or:
+            - email:
+                is: user@example.com
+    pass_identity_headers: true
+```
 
 ## Privacy considerations
 

--- a/content/docs/capabilities/hosted-authenticate-service.md
+++ b/content/docs/capabilities/hosted-authenticate-service.md
@@ -26,11 +26,11 @@ The Hosted Authenticate Service offers a quicker way for users to deploy and tes
 
 ### Zero configuration
 
-The Hosted Authenticate Service requires no setup to use. That means you don't need to include the hosted authenticate service URL or IdP settings in your configuration for Pomerium to proxy your requests.
+The Hosted Authenticate Service requires no setup to use. That means you don't need to include the hosted authenticate service URL or IdP settings in your configuration.
 
 ### Less time to deploy
 
-Pomerium's hosted services solution removes the tedium of configuring your own identity provider (IdP) and authenticate service URL so you can deploy your Pomerium instance in less time.
+Pomerium's hosted services solution removes the tedium of configuring your own identity provider (IdP) and authenticate service URL so you can deploy Pomerium in less time.
 
 ### Faster proof of concept
 
@@ -40,62 +40,70 @@ Current Pomerium users who are interested in our [Enterprise Console](https://ww
 
 ## Configure the Hosted Authenticate Service
 
-The Hosted Authenticate Service requires zero configuraiton to use:
+The Hosted Authenticate Service requires zero configuration to use. 
 
-1. Remove your Authenticate Service URL from the configuration file
-1. Remove your IdP settings
-1. Set up a route and policy
+Add the following route and policy to your configuration file: 
 
-```yaml title=pomerium-config.yaml
+  ```yaml title=pomerium-config.yaml
 
-routes:
-  - from: https://verify.localhost.pomerium.io
-    to: http://verify:8000
-    policy:
-      - allow:
-          or:
-            - email:
-                is: user@example.com
-    pass_identity_headers: true
-```
+  routes:
+    - from: https://verify.localhost.pomerium.io
+      to: http://verify:8000
+      policy:
+        - allow:
+            or:
+              - email:
+                  is: user@example.com
+      pass_identity_headers: true
+  ```
 
 This minimal configuration is all you need to connect to an upstream service with Pomerium's hosted services.
 
 If you want, you can still include the hosted URL in your configuration:
 
-```yaml title=pomerium-config.yaml
-authenticate_service_url: https://authenticate.pomerium.app
+  ```yaml title=pomerium-config.yaml
+  authenticate_service_url: https://authenticate.pomerium.app
 
-routes:
-  - from: https://verify.localhost.pomerium.io
-    to: http://verify:8000
-    policy:
-      - allow:
-          or:
-            - email:
-                is: user@example.com
-    pass_identity_headers: true
-```
+  routes:
+    - from: https://verify.localhost.pomerium.io
+      to: http://verify:8000
+      policy:
+        - allow:
+            or:
+              - email:
+                  is: user@example.com
+      pass_identity_headers: true
+  ```
 
 If you use the hosted URL and include your own IdP settings, Pomerium will override your IdP configuration and use the hosted IdP instead:
 
-```yaml title=pomerium-config.yaml
-authenticate_service_url: https://authenticate.pomerium.app
+  ```yaml title=pomerium-config.yaml
+  authenticate_service_url: https://authenticate.pomerium.app
 
-idp_provider: google
-idp_client_id: my_client_id
-idp_client_secret: my_client_secret
+  idp_provider: google
+  idp_client_id: my_client_id
+  idp_client_secret: my_client_secret
 
-routes:
-  - from: https://verify.localhost.pomerium.io
-    to: http://verify:8000
-    policy:
-      - allow:
-          or:
-            - email:
-                is: user@example.com
-    pass_identity_headers: true
-```
+  routes:
+    - from: https://verify.localhost.pomerium.io
+      to: http://verify:8000
+      policy:
+        - allow:
+            or:
+              - email:
+                  is: user@example.com
+      pass_identity_headers: true
+  ```
+
+## Limitations
+
+**Limited sign-in options**
+
+Currently, you can only authenticate with Google single-sign on or with email and password credentials. 
+
+**Session management**
+
+The hosted authenticate service is separate from your Pomerium installation. This means you can't refresh session tokens, so users must re-authenticate after roughly one hour. 
 
 ## Privacy considerations
 

--- a/content/docs/capabilities/hosted-authenticate-service.md
+++ b/content/docs/capabilities/hosted-authenticate-service.md
@@ -18,13 +18,13 @@ The Hosted Authenticate Service offers a quicker way for users to deploy and tes
 
 ### Zero configuration
 
-Including the hosted authenticate URL in your configuration file authenticates your users against our hosted identity provider (IdP) solution (we use Cognito).
+Including the hosted authenticate URL in your configuration file authenticates your users against our hosted identity provider solution (we use Cognito).
 
-This means you only need to include the hosted URL in your configuration file to use Pomerium's hosted services — no IdP settings required.
+This means you only need to include the hosted URL in your configuration file to use Pomerium's hosted services — no [identity provider configuration](/docs/identity-providers) required.
 
 ### Less time to deploy
 
-Pomerium's hosted services solution removes the tedium of configuring your own IdP and authenticate service URL so you can deploy your Pomerium instance in less time.
+Pomerium's hosted services solution removes the tedium of configuring your own identity provider (IdP) and authenticate service URL so you can deploy your Pomerium instance in less time.
 
 ### Faster proof of concept
 
@@ -33,8 +33,6 @@ If you're testing Pomerium for the first time, run [Pomerium with Docker](/docs/
 Current Pomerium users who are interested in our [Enterprise Console](https://www.pomerium.com/enterprise-sales/) can test out the [Docker Enterprise Quickstart](/docs/releases/enterprise/install/quickstart) using hosted services as well.
 
 ## How to use the Hosted Authenticate Service
-
-The steps are simple:
 
 1. Include the Hosted Authenticate Service URL in your configuration file
 1. Remove your IdP settings
@@ -54,7 +52,7 @@ routes:
     pass_identity_headers: true
 ```
 
-This minimal configuration is all you need to connect to upstream services with Pomerium.
+This minimal configuration is all you need to connect to an upstream service with Pomerium.
 
 :::tip
 
@@ -66,7 +64,7 @@ If you use the hosted URL and include your own IdP settings, Pomerium will overr
 
 Users that take advantage of our Hosted Authenticate Service should review the [Terms of Service agreement](https://www.pomerium.com/pomerium-zero-user-agreement/).
 
-Specifically, you should be aware that, by using our hosted services, you are aware and agree to Pomerium collecting the following data:
+Specifically, you should be aware that by using our hosted services, you agree to Pomerium collecting the following data:
 
 - IP address
 - OS version

--- a/content/docs/capabilities/hosted-authenticate-service.md
+++ b/content/docs/capabilities/hosted-authenticate-service.md
@@ -8,13 +8,13 @@ description: Use Pomerium's Hosted Authenticate Service to set up and deploy Pom
 
 # Hosted Authenticate Service
 
-Pomerium's **Hosted Authenticate Service** provides a hosted alternative to the Self-Hosted Authenticate Service. 
+Pomerium's **Hosted Authenticate Service** provides a hosted alternative to the Self-Hosted Authenticate Service.
 
 The Hosted Authenticate Service is available in Pomerium v0.22.0 for both open-source Pomerium Core and Enterprise users.
 
 ## How the Hosted Authenticate Service works
 
-Pomerium's hosted service includes a **Hosted Authenticate Service URL** and a **Hosted Identity Provider** that handle authentication and authorization using OAuth 2.0 and OIDC protocols. 
+Pomerium's hosted service includes a **Hosted Authenticate Service URL** and a **Hosted Identity Provider** that handle authentication and authorization using OAuth 2.0 and OIDC protocols.
 
 Starting in **Pomerium v0.22.0**, both open-source Pomerium Core and Enterprise deployments will use our hosted services by default.
 
@@ -40,70 +40,69 @@ Current Pomerium users who are interested in our [Enterprise Console](https://ww
 
 ## Configure the Hosted Authenticate Service
 
-The Hosted Authenticate Service requires zero configuration to use. 
+The Hosted Authenticate Service requires zero configuration to use.
 
-Add the following route and policy to your configuration file: 
+Add the following route and policy to your configuration file:
 
-  ```yaml title=pomerium-config.yaml
-
-  routes:
-    - from: https://verify.localhost.pomerium.io
-      to: http://verify:8000
-      policy:
-        - allow:
-            or:
-              - email:
-                  is: user@example.com
-      pass_identity_headers: true
-  ```
+```yaml title=pomerium-config.yaml
+routes:
+  - from: https://verify.localhost.pomerium.io
+    to: http://verify:8000
+    policy:
+      - allow:
+          or:
+            - email:
+                is: user@example.com
+    pass_identity_headers: true
+```
 
 This minimal configuration is all you need to connect to an upstream service with Pomerium's hosted services.
 
 If you want, you can still include the hosted URL in your configuration:
 
-  ```yaml title=pomerium-config.yaml
-  authenticate_service_url: https://authenticate.pomerium.app
+```yaml title=pomerium-config.yaml
+authenticate_service_url: https://authenticate.pomerium.app
 
-  routes:
-    - from: https://verify.localhost.pomerium.io
-      to: http://verify:8000
-      policy:
-        - allow:
-            or:
-              - email:
-                  is: user@example.com
-      pass_identity_headers: true
-  ```
+routes:
+  - from: https://verify.localhost.pomerium.io
+    to: http://verify:8000
+    policy:
+      - allow:
+          or:
+            - email:
+                is: user@example.com
+    pass_identity_headers: true
+```
 
 If you use the hosted URL and include your own IdP settings, Pomerium will override your IdP configuration and use the hosted IdP instead:
 
-  ```yaml title=pomerium-config.yaml
-  authenticate_service_url: https://authenticate.pomerium.app
+```yaml title=pomerium-config.yaml
+authenticate_service_url: https://authenticate.pomerium.app
 
-  idp_provider: google
-  idp_client_id: my_client_id
-  idp_client_secret: my_client_secret
+idp_provider: google
+idp_client_id: my_client_id
+idp_client_secret: my_client_secret
 
-  routes:
-    - from: https://verify.localhost.pomerium.io
-      to: http://verify:8000
-      policy:
-        - allow:
-            or:
-              - email:
-                  is: user@example.com
-      pass_identity_headers: true
-  ```
+routes:
+  - from: https://verify.localhost.pomerium.io
+    to: http://verify:8000
+    policy:
+      - allow:
+          or:
+            - email:
+                is: user@example.com
+    pass_identity_headers: true
+```
 
 ## Limitations
 
 **Limited sign-in options**
 
-Currently, you can only authenticate with Google single-sign on or with email and password credentials. 
+Currently, you can only authenticate with Google single-sign on or with email and password credentials.
 
 **Session management**
 
-The hosted authenticate service is separate from your Pomerium installation. This means you can't refresh session tokens, so users must re-authenticate after roughly one hour. 
+The hosted authenticate service is separate from your Pomerium installation. This means you can't refresh session tokens, so users must re-authenticate after roughly one hour.
 
 ## Privacy considerations
 

--- a/content/docs/capabilities/hosted-authenticate-service.md
+++ b/content/docs/capabilities/hosted-authenticate-service.md
@@ -106,7 +106,7 @@ The hosted authenticate service is separate from your Pomerium installation. Thi
 
 **Uptime commitment**
 
-We make no commitments to uptime for our free hosted authenticate service. 
+We make no commitments to uptime for our free hosted authenticate service.
 
 ## Privacy considerations
 

--- a/content/docs/capabilities/self-hosted-authenticate-service.md
+++ b/content/docs/capabilities/self-hosted-authenticate-service.md
@@ -26,11 +26,11 @@ authenticate_service_url: https://authenticate.localhost.pomerium.io
 
 ### Identity provider
 
-Pomerium's Authenticate Service requires an IdP to authenticate and authorize users. Pomerium supports all major IdP solutions, but can support any IdP that uses OAuth 2.0 and OIDC protocols as well. 
+Pomerium's Authenticate Service requires an IdP to authenticate and authorize users. Pomerium supports all major IdP solutions and any IdP that uses OAuth 2.0 and OIDC protocols as well. 
 
 ## Configure the Self-Hosted Authenticate Service
 
-To configure your Pomerium instance to use self-hosted services:
+To configure Pomerium to use self-hosted services:
 
 1. Add your authenticate service URL
 
@@ -77,3 +77,5 @@ routes:
                 is: user@example.com
     pass_identity_headers: true
 ```
+
+See the [Pomerium Core Docker quickstart](/docs/quickstart) for more examples. 

--- a/content/docs/capabilities/self-hosted-authenticate-service.md
+++ b/content/docs/capabilities/self-hosted-authenticate-service.md
@@ -28,8 +28,6 @@ authenticate_service_url: https://authenticate.localhost.pomerium.io
 
 Pomerium's Authenticate Service requires an IdP to authenticate and authorize users. Pomerium supports all major IdP solutions, but can support any IdP that uses OAuth 2.0 and OIDC protocols as well. 
 
-See 
-
 ## Configure the Self-Hosted Authenticate Service
 
 To configure your Pomerium instance to use self-hosted services:

--- a/content/docs/capabilities/self-hosted-authenticate-service.md
+++ b/content/docs/capabilities/self-hosted-authenticate-service.md
@@ -1,0 +1,81 @@
+---
+id: self-hosted-authenticate-service
+title: Self-Hosted Authenticate Service
+sidebar_label: Self-Hosted Authenticate Service
+keywords: [self-hosted authenticate service url, self-hosted identity provider]
+description: Use Pomerium's Self-Hosted Authenticate Service to set up and deploy Pomerium with your own hosted settings.
+---
+
+# Self-Hosted Authenticate Service
+
+Pomerium's **Self-Hosted Authenticate Service** allows you to configure your own **Authenticate Service URL** and **Identity Provider**. 
+
+The Self-Hosted Authenticate Service is available for both open-source Pomerium Core and Enterprise users.
+
+## How the Self-Hosted Authenticate Service works
+
+Self-hosting your Pomerium instance requires you to configure an [Authenticate Service URL](/docs/reference/authenticate-service-url) and an OIDC-compliant [identity provider](/docs/identity-providers) (IdP). 
+
+### Authenticate service URL
+
+The authenticate service URL is an externally accessible URL used by Pomerium's Authenticate Service. You can include your own URL for testing or use Pomerium's localhost URL, which is hardcoded to point to `127.0.0.1`.  
+
+```yaml
+authenticate_service_url: https://authenticate.localhost.pomerium.io
+```
+
+### Identity provider
+
+Pomerium's Authenticate Service requires an IdP to authenticate and authorize users. Pomerium supports all major IdP solutions, but can support any IdP that uses OAuth 2.0 and OIDC protocols as well. 
+
+See 
+
+## Configure the Self-Hosted Authenticate Service
+
+To configure your Pomerium instance to use self-hosted services:
+
+1. Add your authenticate service URL
+
+  ```yaml pomerium-config.yaml
+  authenticate_service_url: https://authenticate.localhost.pomerium.io
+  ```
+1. Include your IdP settings
+
+  ```yaml pomerium-config.yaml
+  idp_provider: google
+  idp_client_id: my_client_id
+  idp_client_secret: my_client_secret
+  ```
+1. Build a route and policy
+
+  ```yaml pomerium-config.yaml
+  routes:
+    - from: https://verify.localhost.pomerium.io
+      to: http://verify:8000
+      policy:
+        - allow:
+            or:
+              - email:
+                  is: user@example.com
+      pass_identity_headers: true
+  ```
+
+Your self-hosted configuration file might look like this:
+
+```yaml pomerium-config.yaml
+authenticate_service_url: https://authenticate.localhost.pomerium.io
+
+idp_provider: google
+idp_client_id: my_client_id
+idp_client_secret: my_client_secret
+
+routes:
+  - from: https://verify.localhost.pomerium.io
+    to: http://verify:8000
+    policy:
+      - allow:
+          or:
+            - email:
+                is: user@example.com
+    pass_identity_headers: true
+```

--- a/content/docs/capabilities/self-hosted-authenticate-service.md
+++ b/content/docs/capabilities/self-hosted-authenticate-service.md
@@ -8,17 +8,17 @@ description: Use Pomerium's Self-Hosted Authenticate Service to set up and deplo
 
 # Self-Hosted Authenticate Service
 
-Pomerium's **Self-Hosted Authenticate Service** allows you to configure your own **Authenticate Service URL** and **Identity Provider**. 
+Pomerium's **Self-Hosted Authenticate Service** allows you to configure your own **Authenticate Service URL** and **Identity Provider**.
 
 The Self-Hosted Authenticate Service is available for both open-source Pomerium Core and Enterprise users.
 
 ## How the Self-Hosted Authenticate Service works
 
-Self-hosting your Pomerium instance requires you to configure an [Authenticate Service URL](/docs/reference/authenticate-service-url) and an OIDC-compliant [identity provider](/docs/identity-providers) (IdP). 
+Self-hosting your Pomerium instance requires you to configure an [Authenticate Service URL](/docs/reference/authenticate-service-url) and an OIDC-compliant [identity provider](/docs/identity-providers) (IdP).
 
 ### Authenticate service URL
 
-The authenticate service URL is an externally accessible URL used by Pomerium's Authenticate Service. You can include your own URL for testing or use Pomerium's localhost URL, which is hardcoded to point to `127.0.0.1`.  
+The authenticate service URL is an externally accessible URL used by Pomerium's Authenticate Service. You can include your own URL for testing or use Pomerium's localhost URL, which is hardcoded to point to `127.0.0.1`.
 
 ```yaml
 authenticate_service_url: https://authenticate.localhost.pomerium.io
@@ -26,7 +26,7 @@ authenticate_service_url: https://authenticate.localhost.pomerium.io
 
 ### Identity provider
 
-Pomerium's Authenticate Service requires an IdP to authenticate and authorize users. Pomerium supports all major IdP solutions and any IdP that uses OAuth 2.0 and OIDC protocols as well. 
+Pomerium's Authenticate Service requires an IdP to authenticate and authorize users. Pomerium supports all major IdP solutions and any IdP that uses OAuth 2.0 and OIDC protocols as well.
 
 ## Configure the Self-Hosted Authenticate Service
 
@@ -34,29 +34,31 @@ To configure Pomerium to use self-hosted services:
 
 1. Add your authenticate service URL
 
-  ```yaml pomerium-config.yaml
-  authenticate_service_url: https://authenticate.localhost.pomerium.io
-  ```
+```yaml pomerium-config.yaml
+authenticate_service_url: https://authenticate.localhost.pomerium.io
+```
+
 1. Include your IdP settings
 
-  ```yaml pomerium-config.yaml
-  idp_provider: google
-  idp_client_id: my_client_id
-  idp_client_secret: my_client_secret
-  ```
+```yaml pomerium-config.yaml
+idp_provider: google
+idp_client_id: my_client_id
+idp_client_secret: my_client_secret
+```
+
 1. Build a route and policy
 
-  ```yaml pomerium-config.yaml
-  routes:
-    - from: https://verify.localhost.pomerium.io
-      to: http://verify:8000
-      policy:
-        - allow:
-            or:
-              - email:
-                  is: user@example.com
-      pass_identity_headers: true
-  ```
+```yaml pomerium-config.yaml
+routes:
+  - from: https://verify.localhost.pomerium.io
+    to: http://verify:8000
+    policy:
+      - allow:
+          or:
+            - email:
+                is: user@example.com
+    pass_identity_headers: true
+```
 
 Your self-hosted configuration file might look like this:
 
@@ -78,4 +80,4 @@ routes:
     pass_identity_headers: true
 ```
 
-See the [Pomerium Core Docker quickstart](/docs/quickstart) for more examples. 
+See the [Pomerium Core Docker quickstart](/docs/quickstart) for more examples.

--- a/content/docs/identity-providers/index.md
+++ b/content/docs/identity-providers/index.md
@@ -3,56 +3,45 @@ title: Identity Provider Configuration
 sidebar_label: Identity Providers
 description: Connect Pomerium to third-party identity providers and single-sign-on services.
 keywords:
- [
-   authenticate service url,
-   identity provider,
-   hosted authenticate service,
-   oidc,
-   client id,
-   client secret,
-   redirect url,
- ]
+  [
+    authenticate service url,
+    identity provider,
+    hosted authenticate service,
+    oidc,
+    client id,
+    client secret,
+    redirect url,
+  ]
 pagination_prev: null
 pagination_next: null
 ---
 
 Pomerium provides authentication through your existing identity provider (**IdP**) and supports all major single sign-on (**SSO**) providers.
 
-
 Pomerium uses the OAuth 2.0 and OIDC protocols to integrate with your IdP so you can configure any IdP solution that supports these protocols.
 
-
 The steps to integrate your IdP with Pomerium vary depending on your provider, but all IdPs generally require the following settings:
-
 
 - **[Redirect URI](https://www.oauth.com/oauth2-servers/redirect-uris/)**
 - **[Client ID]**
 - **[Client Secret]**
 
-
 The **Redirect URI** should include your [Authenticate Service URL](/docs/reference/authenticate-service-url) with `/oauth2/callback` in the URL path.
-
 
 For example, `https://{authenticate_service_url}.com/oauth2/callback`.
 
-
 See the guides in this section for specific steps to integrate your IdP with Pomerium.
-
 
 ## Hosted identity provider
 
-
 Pomerium’s [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) provides a **Hosted Authenticate Service URL** and a **Hosted Identity Provider**.
-
 
 If you use the hosted services, you don’t need to include IdP settings or an authenticate service URL in your configuration.
 
 See [Configure hosted services](/docs/capabilities/hosted-authenticate-service#configure-the-hosted-authenticate-service) for more information.
-
 
 [client id]: /docs/reference/identity-provider-client-id
 [client secret]: /docs/reference/identity-provider-client-secret
 [environmental variables]: https://en.wikipedia.org/wiki/Environment_variable
 [oauth2]: https://oauth.net/2/
 [openid connect]: https://en.wikipedia.org/wiki/OpenID_Connect
-

--- a/content/docs/identity-providers/index.md
+++ b/content/docs/identity-providers/index.md
@@ -1,23 +1,58 @@
 ---
 title: Identity Provider Configuration
 sidebar_label: Identity Providers
-description: This article describes how to connect Pomerium to third-party identity providers / single-sign-on services.
+description: Connect Pomerium to third-party identity providers and single-sign-on services.
+keywords:
+ [
+   authenticate service url,
+   identity provider,
+   hosted authenticate service,
+   oidc,
+   client id,
+   client secret,
+   redirect url,
+ ]
 pagination_prev: null
 pagination_next: null
 ---
 
-Pomerium provides single-sign-on authentication and user identity details by integrating with your downstream Identity Provider (**IdP**) of choice. That authentication integration is achieved using OAuth2, and [OpenID Connect][openid connect] (**OIDC**).
+Pomerium provides authentication through your existing identity provider (**IdP**) and supports all major single sign-on (**SSO**) providers.
 
-The steps for integrating Pomerium with an IdP are specific to each provider, but they generally share the same base requirements:
 
-- A **[Redirect URL](https://www.oauth.com/oauth2-servers/redirect-uris/)** pointing back to Pomerium. For example, `https://${authenticate_service_url}/oauth2/callback`.
-  - The redirect URL will always be your [Authenticate Service URL](/docs/reference/authenticate-service-url), plus `/oauth2/callback`.
-- A **[Client ID]** and **[Client Secret]**.
+Pomerium uses the OAuth 2.0 and OIDC protocols to integrate with your IdP so you can configure any IdP solution that supports these protocols.
 
-The subsequent pages in this section provide specific instructions for the IdPs Pomerium supports.
+
+The steps to integrate your IdP with Pomerium vary depending on your provider, but all IdPs generally require the following settings:
+
+
+- **[Redirect URI](https://www.oauth.com/oauth2-servers/redirect-uris/)**
+- **[Client ID]**
+- **[Client Secret]**
+
+
+The **Redirect URI** should include your [Authenticate Service URL](/docs/reference/authenticate-service-url) with `/oauth2/callback` in the URL path.
+
+
+For example, `https://{authenticate_service_url}.com/oauth2/callback`.
+
+
+See the guides in this section for specific steps to integrate your IdP with Pomerium.
+
+
+## Hosted identity provider
+
+
+Pomerium’s [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) provides a **Hosted Authenticate Service URL** and a **Hosted Identity Provider**.
+
+
+If you use the hosted services, you don’t need to include IdP settings or an authenticate service URL in your configuration.
+
+See [Configure hosted services](/docs/capabilities/hosted-authenticate-service#configure-the-hosted-authenticate-service) for more information.
+
 
 [client id]: /docs/reference/identity-provider-client-id
 [client secret]: /docs/reference/identity-provider-client-secret
 [environmental variables]: https://en.wikipedia.org/wiki/Environment_variable
 [oauth2]: https://oauth.net/2/
 [openid connect]: https://en.wikipedia.org/wiki/OpenID_Connect
+

--- a/content/docs/reference/authenticate-callback-path.md
+++ b/content/docs/reference/authenticate-callback-path.md
@@ -30,3 +30,13 @@ See also:
 - [Google - Setting Redirect URI](https://developers.google.com/identity/protocols/OpenIDConnect#setredirecturi)
 
 [oidc rfc]: https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
+
+:::tip **Note:**
+
+Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default. 
+
+If you want to run Pomerium with a self-hosted authenticate service, you must include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration. 
+
+See [**Self-Hosted Authenticate Service**](/docs/capabilities/self-hosted-authenticate-service) for more information.
+
+:::

--- a/content/docs/reference/authenticate-callback-path.md
+++ b/content/docs/reference/authenticate-callback-path.md
@@ -33,9 +33,9 @@ See also:
 
 :::tip **Note:**
 
-Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default. 
+Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default.
 
-If you want to run Pomerium with a self-hosted authenticate service, you must include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration. 
+If you want to run Pomerium with a self-hosted authenticate service, you must include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration.
 
 See [**Self-Hosted Authenticate Service**](/docs/capabilities/self-hosted-authenticate-service) for more information.
 

--- a/content/docs/reference/authenticate-internal-service-url.md
+++ b/content/docs/reference/authenticate-internal-service-url.md
@@ -21,9 +21,9 @@ Authenticate Internal Service URL overrides `authenticate_service_url` when dete
 
 :::tip **Note:**
 
-Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default. 
+Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default.
 
-If you want to run Pomerium with a self-hosted authenticate service, you must include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration. 
+If you want to run Pomerium with a self-hosted authenticate service, you must include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration.
 
 See [**Self-Hosted Authenticate Service**](/docs/capabilities/self-hosted-authenticate-service) for more information.
 

--- a/content/docs/reference/authenticate-internal-service-url.md
+++ b/content/docs/reference/authenticate-internal-service-url.md
@@ -18,3 +18,13 @@ pagination_next: null
 - Example: `https://authenticate.internal`
 
 Authenticate Internal Service URL overrides `authenticate_service_url` when determining the TLS certificate and hostname for the authenticate service to listen with.
+
+:::tip **Note:**
+
+Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default. 
+
+If you want to run Pomerium with a self-hosted authenticate service, you must include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration. 
+
+See [**Self-Hosted Authenticate Service**](/docs/capabilities/self-hosted-authenticate-service) for more information.
+
+:::

--- a/content/docs/reference/authenticate-service-url.md
+++ b/content/docs/reference/authenticate-service-url.md
@@ -23,9 +23,9 @@ Authenticate Service URL is the externally accessible URL for the authenticate s
 
 :::tip **Note:**
 
-Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default. 
+Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default.
 
-If you want to run Pomerium with a self-hosted authenticate service, you must include an [**identity provider**](/docs/identity-providers) and **authenticate service URL** in your configuration. 
+If you want to run Pomerium with a self-hosted authenticate service, you must include an [**identity provider**](/docs/identity-providers) and **authenticate service URL** in your configuration.
 
 See [**Self-Hosted Authenticate Service**](/docs/capabilities/self-hosted-authenticate-service) for more information.
 

--- a/content/docs/reference/authenticate-service-url.md
+++ b/content/docs/reference/authenticate-service-url.md
@@ -20,3 +20,13 @@ pagination_next: null
 - Example: `https://authenticate.corp.example.com`
 
 Authenticate Service URL is the externally accessible URL for the authenticate service. In split service mode, this key is required by all services other than Databroker.
+
+:::tip **Note:**
+
+Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default. 
+
+If you want to run Pomerium with a self-hosted authenticate service, you must include an [**identity provider**](/docs/identity-providers) and **authenticate service URL** in your configuration. 
+
+See [**Self-Hosted Authenticate Service**](/docs/capabilities/self-hosted-authenticate-service) for more information.
+
+:::

--- a/content/docs/reference/identity-provider-client-id.md
+++ b/content/docs/reference/identity-provider-client-id.md
@@ -20,12 +20,11 @@ pagination_next: null
 
 Client ID is the OAuth 2.0 Client Identifier retrieved from your identity provider. See your identity provider's documentation, and our [identity provider](/docs/identity-providers/) docs for details.
 
-
 :::tip **Note:**
 
-Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default. 
+Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default.
 
-If you want to run Pomerium with a self-hosted authenticate service, include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration. 
+If you want to run Pomerium with a self-hosted authenticate service, include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration.
 
 See [**Self-Hosted Authenticate Service**](/docs/capabilities/self-hosted-authenticate-service) for more information.
 

--- a/content/docs/reference/identity-provider-client-id.md
+++ b/content/docs/reference/identity-provider-client-id.md
@@ -19,3 +19,14 @@ pagination_next: null
 - Required
 
 Client ID is the OAuth 2.0 Client Identifier retrieved from your identity provider. See your identity provider's documentation, and our [identity provider](/docs/identity-providers/) docs for details.
+
+
+:::tip **Note:**
+
+Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default. 
+
+If you want to run Pomerium with a self-hosted authenticate service, include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration. 
+
+See [**Self-Hosted Authenticate Service**](/docs/capabilities/self-hosted-authenticate-service) for more information.
+
+:::

--- a/content/docs/reference/identity-provider-client-secret-file.md
+++ b/content/docs/reference/identity-provider-client-secret-file.md
@@ -26,9 +26,9 @@ idp_client_secret_file: '/run/secrets/POMERIUM_CLIENT_SECRET'
 
 :::tip **Note:**
 
-Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default. 
+Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default.
 
-If you want to run Pomerium with a self-hosted authenticate service, include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration. 
+If you want to run Pomerium with a self-hosted authenticate service, include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration.
 
 See [**Self-Hosted Authenticate Service**](/docs/capabilities/self-hosted-authenticate-service) for more information.
 

--- a/content/docs/reference/identity-provider-client-secret-file.md
+++ b/content/docs/reference/identity-provider-client-secret-file.md
@@ -23,3 +23,13 @@ Client Secret is the OAuth 2.0 Secret Identifier retrieved from your identity pr
 ```yaml
 idp_client_secret_file: '/run/secrets/POMERIUM_CLIENT_SECRET'
 ```
+
+:::tip **Note:**
+
+Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default. 
+
+If you want to run Pomerium with a self-hosted authenticate service, include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration. 
+
+See [**Self-Hosted Authenticate Service**](/docs/capabilities/self-hosted-authenticate-service) for more information.
+
+:::

--- a/content/docs/reference/identity-provider-client-secret.md
+++ b/content/docs/reference/identity-provider-client-secret.md
@@ -20,9 +20,9 @@ Client Secret is the OAuth 2.0 Secret Identifier retrieved from your identity pr
 
 :::tip **Note:**
 
-Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default. 
+Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default.
 
-If you want to run Pomerium with a self-hosted authenticate service, include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration. 
+If you want to run Pomerium with a self-hosted authenticate service, include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration.
 
 See [**Self-Hosted Authenticate Service**](/docs/capabilities/self-hosted-authenticate-service) for more information.
 

--- a/content/docs/reference/identity-provider-client-secret.md
+++ b/content/docs/reference/identity-provider-client-secret.md
@@ -17,3 +17,13 @@ pagination_next: null
 - Required (unless using [identity_provider_client_secret_file](./identity-provider-client-secret-file))
 
 Client Secret is the OAuth 2.0 Secret Identifier retrieved from your identity provider. See your identity provider's documentation, and our [identity provider](/docs/identity-providers/) docs for details.
+
+:::tip **Note:**
+
+Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default. 
+
+If you want to run Pomerium with a self-hosted authenticate service, include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration. 
+
+See [**Self-Hosted Authenticate Service**](/docs/capabilities/self-hosted-authenticate-service) for more information.
+
+:::

--- a/content/docs/reference/identity-provider-name.md
+++ b/content/docs/reference/identity-provider-name.md
@@ -19,6 +19,16 @@ pagination_next: null
 - Required
 - Options: `auth0` `azure` `google` `okta` `onelogin` or `oidc`
 
-Provider is the short-hand name of a built-in OpenID Connect (oidc) identity provider to be used for authentication. To use a generic provider,set to `oidc`.
+Provider is the short-hand name of a built-in OpenID Connect (oidc) identity provider to be used for authentication. To use a generic provider, set to `oidc`.
 
 See [identity provider](/docs/identity-providers/) for details.
+
+:::tip **Note:**
+
+Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default. 
+
+If you want to run Pomerium with a self-hosted authenticate service, include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration. 
+
+See [**Self-Hosted Authenticate Service**](/docs/capabilities/self-hosted-authenticate-service) for more information.
+
+:::

--- a/content/docs/reference/identity-provider-name.md
+++ b/content/docs/reference/identity-provider-name.md
@@ -25,9 +25,9 @@ See [identity provider](/docs/identity-providers/) for details.
 
 :::tip **Note:**
 
-Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default. 
+Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default.
 
-If you want to run Pomerium with a self-hosted authenticate service, include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration. 
+If you want to run Pomerium with a self-hosted authenticate service, include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration.
 
 See [**Self-Hosted Authenticate Service**](/docs/capabilities/self-hosted-authenticate-service) for more information.
 

--- a/content/docs/reference/identity-provider-refresh-directory-settings.md
+++ b/content/docs/reference/identity-provider-refresh-directory-settings.md
@@ -29,3 +29,13 @@ Refresh directory interval is the time that pomerium will sync your IDP director
 Use it at your own risk, if you set a too low value, you may reach IDP API rate limit.
 
 :::
+
+:::tip **Note:**
+
+Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default. 
+
+If you want to run Pomerium with a self-hosted authenticate service, include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration. 
+
+See [**Self-Hosted Authenticate Service**](/docs/capabilities/self-hosted-authenticate-service) for more information.
+
+:::

--- a/content/docs/reference/identity-provider-refresh-directory-settings.md
+++ b/content/docs/reference/identity-provider-refresh-directory-settings.md
@@ -32,9 +32,9 @@ Use it at your own risk, if you set a too low value, you may reach IDP API rate 
 
 :::tip **Note:**
 
-Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default. 
+Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default.
 
-If you want to run Pomerium with a self-hosted authenticate service, include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration. 
+If you want to run Pomerium with a self-hosted authenticate service, include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration.
 
 See [**Self-Hosted Authenticate Service**](/docs/capabilities/self-hosted-authenticate-service) for more information.
 

--- a/content/docs/reference/identity-provider-request-params.md
+++ b/content/docs/reference/identity-provider-request-params.md
@@ -26,3 +26,13 @@ For more information see:
 - [IANA OAuth Parameters](https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml)
 - [Microsoft Azure Request params](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-authorization-code)
 - [Google Authentication URI parameters](https://developers.google.com/identity/protocols/oauth2/openid-connect)
+
+:::tip **Note:**
+
+Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default. 
+
+If you want to run Pomerium with a self-hosted authenticate service, include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration. 
+
+See [**Self-Hosted Authenticate Service**](/docs/capabilities/self-hosted-authenticate-service) for more information.
+
+:::

--- a/content/docs/reference/identity-provider-request-params.md
+++ b/content/docs/reference/identity-provider-request-params.md
@@ -29,9 +29,9 @@ For more information see:
 
 :::tip **Note:**
 
-Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default. 
+Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default.
 
-If you want to run Pomerium with a self-hosted authenticate service, include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration. 
+If you want to run Pomerium with a self-hosted authenticate service, include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration.
 
 See [**Self-Hosted Authenticate Service**](/docs/capabilities/self-hosted-authenticate-service) for more information.
 

--- a/content/docs/reference/identity-provider-scopes.md
+++ b/content/docs/reference/identity-provider-scopes.md
@@ -32,3 +32,13 @@ If you are using a built-in provider, you probably don't want to set customized 
 Some providers, like Amazon Cognito, _do not_ support the `offline_access` scope.
 
 :::
+
+:::tip **Note:**
+
+Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default. 
+
+If you want to run Pomerium with a self-hosted authenticate service, include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration. 
+
+See [**Self-Hosted Authenticate Service**](/docs/capabilities/self-hosted-authenticate-service) for more information.
+
+:::

--- a/content/docs/reference/identity-provider-scopes.md
+++ b/content/docs/reference/identity-provider-scopes.md
@@ -35,9 +35,9 @@ Some providers, like Amazon Cognito, _do not_ support the `offline_access` scope
 
 :::tip **Note:**
 
-Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default. 
+Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default.
 
-If you want to run Pomerium with a self-hosted authenticate service, include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration. 
+If you want to run Pomerium with a self-hosted authenticate service, include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration.
 
 See [**Self-Hosted Authenticate Service**](/docs/capabilities/self-hosted-authenticate-service) for more information.
 

--- a/content/docs/reference/identity-provider-url.md
+++ b/content/docs/reference/identity-provider-url.md
@@ -24,9 +24,9 @@ Provider URL is the base path to an identity provider's [OpenID connect discover
 
 :::tip **Note:**
 
-Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default. 
+Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default.
 
-If you want to run Pomerium with a self-hosted authenticate service, include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration. 
+If you want to run Pomerium with a self-hosted authenticate service, include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration.
 
 See [**Self-Hosted Authenticate Service**](/docs/capabilities/self-hosted-authenticate-service) for more information.
 

--- a/content/docs/reference/identity-provider-url.md
+++ b/content/docs/reference/identity-provider-url.md
@@ -21,3 +21,13 @@ pagination_next: null
 Provider URL is the base path to an identity provider's [OpenID connect discovery document](https://openid.net/specs/openid-connect-discovery-1_0.html). An example Azure URL would be `https://login.microsoftonline.com/common/v2.0` for [their discover document](https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration).
 
 "Base path" is defined as the section of the URL to the discovery document up to (but not including) `/.well-known/openid-configuration`.
+
+:::tip **Note:**
+
+Pomerium uses the [**Hosted Authenticate Service**](/docs/capabilities/hosted-authenticate-service) by default. 
+
+If you want to run Pomerium with a self-hosted authenticate service, include an [**identity provider**](/docs/identity-providers) and [**authenticate service URL**](/docs/reference/authenticate-service-url) in your configuration. 
+
+See [**Self-Hosted Authenticate Service**](/docs/capabilities/self-hosted-authenticate-service) for more information.
+
+:::

--- a/sidebars.js
+++ b/sidebars.js
@@ -30,6 +30,7 @@ const sidebars = {
         // secondary capabilities
         'docs/capabilities/audit-logs',
         'docs/capabilities/hosted-authenticate-service',
+        'docs/capabilities/self-hosted-authenticate-service',
         'docs/capabilities/jwt-verification',
         'docs/capabilities/mtls-clients',
         'docs/capabilities/mtls-services',

--- a/sidebars.js
+++ b/sidebars.js
@@ -29,6 +29,7 @@ const sidebars = {
         'docs/capabilities/routing',
         // secondary capabilities
         'docs/capabilities/audit-logs',
+        'docs/capabilities/hosted-authenticate-service',
         'docs/capabilities/jwt-verification',
         'docs/capabilities/mtls-clients',
         'docs/capabilities/mtls-services',


### PR DESCRIPTION
This PR adds a Hosted Authenticate Service capabilities page and sidebar slice. 

This is a first draft. It could probably be more informative in sections like Less time to deploy and Privacy considerations. 

Once a Hosted Authenticate URL reference page is live, it will also need to be linked here. 

