### PR TITLE
Docs: runs prettier on ppl, k8s reference, and installation

### DIFF
--- a/content/docs/capabilities/ppl.mdx
+++ b/content/docs/capabilities/ppl.mdx
@@ -81,7 +81,7 @@ allow:
 deny:
   not:
     - http_method:
-        is: GET 
+        is: GET
 ```
 
 PPL supports many different criteria:

--- a/content/docs/deploying/k8s/reference.md
+++ b/content/docs/deploying/k8s/reference.md
@@ -4,10 +4,10 @@ sidebar_label: Reference
 description: Reference for Pomerium settings in Kubernetes deployments.
 ---
 
-Pomerium-specific parameters should be configured via the `ingress.pomerium.io/Pomerium` CRD.
-The default Pomerium deployment is listening to the CRD `global`, that may be customized via command line parameters.
+Pomerium-specific parameters should be configured via the `ingress.pomerium.io/Pomerium` CRD. The default Pomerium deployment is listening to the CRD `global`, that may be customized via command line parameters.
 
 Pomerium posts updates to the CRD <a href="#status">`/status`</a>:
+
 ```shell
 kubectl describe pomerium
 ```
@@ -197,8 +197,6 @@ PomeriumSpec defines Pomerium-specific configuration parameters.
     </tbody>
 </table>
 
-
-
 ### `authenticate`
 
 Authenticate sets authenticate service parameters. If not specified, a Pomerium-hosted authenticate service would be used.
@@ -247,8 +245,6 @@ Authenticate sets authenticate service parameters. If not specified, a Pomerium-
     
     </tbody>
 </table>
-
-
 
 ### `cookie`
 
@@ -344,8 +340,6 @@ Cookie defines Pomerium session cookie options.
     
     </tbody>
 </table>
-
-
 
 ### `identityProvider`
 
@@ -497,8 +491,6 @@ IdentityProvider configure single-sign-on authentication and user identity detai
     </tbody>
 </table>
 
-
-
 ### `postgres`
 
 Postgres specifies PostgreSQL database connection parameters
@@ -567,8 +559,6 @@ Postgres specifies PostgreSQL database connection parameters
     
     </tbody>
 </table>
-
-
 
 ### `redis`
 
@@ -655,8 +645,6 @@ Redis defines REDIS connection parameters
     </tbody>
 </table>
 
-
-
 ### `refreshDirectory`
 
 RefreshDirectory is no longer supported, please see <a href="https://docs.pomerium.com/docs/overview/upgrading#idp-directory-sync">Upgrade Guide</a>.
@@ -707,8 +695,6 @@ RefreshDirectory is no longer supported, please see <a href="https://docs.pomeri
     </tbody>
 </table>
 
-
-
 ### `storage`
 
 Storage defines persistent storage for sessions and other data. See <a href="https://www.pomerium.com/docs/topics/data-storage">Storage</a> for details. If no storage is specified, Pomerium would use a transient in-memory storage (not recommended for production).
@@ -755,8 +741,6 @@ Storage defines persistent storage for sessions and other data. See <a href="htt
     </tbody>
 </table>
 
-
-
 ## Status
 
 PomeriumStatus represents configuration and Ingress status.
@@ -802,8 +786,6 @@ PomeriumStatus represents configuration and Ingress status.
     
     </tbody>
 </table>
-
-
 
 ### `ingress`
 
@@ -900,8 +882,6 @@ ResourceStatus represents the outcome of the latest attempt to reconcile relevan
     </tbody>
 </table>
 
-
-
 ### `settingsStatus`
 
 SettingsStatus represent most recent main configuration reconciliation status.
@@ -996,6 +976,3 @@ SettingsStatus represent most recent main configuration reconciliation status.
     
     </tbody>
 </table>
-
-
-

--- a/content/docs/releases/enterprise/install/installation.mdx
+++ b/content/docs/releases/enterprise/install/installation.mdx
@@ -116,6 +116,7 @@ Pull a specific tagged release:
 ```bash
 docker pull docker.cloudsmith.io/pomerium/enterprise/pomerium-console:${vX.X.X}
 ```
+
 </TabItem>
 <TabItem label="Main" value="Main">
 Pull an image in sync with git's main branch:
@@ -123,6 +124,7 @@ Pull an image in sync with git's main branch:
 ```bash
 docker pull docker.cloudsmith.io/pomerium/enterprise/pomerium-console:main
 ```
+
 </TabItem>
 </Tabs>
 


### PR DESCRIPTION
Just a cleanup PR to run prettier on the following pages:
- /docs/deploying/k8s/reference
- /docs/capabilities/ppl
- /docs/releases/enterprise/install/installation
