### PR TITLE
updates core changelog headers for consistency

### DIFF
--- a/content/docs/releases/changelog.mdx
+++ b/content/docs/releases/changelog.mdx
@@ -12,11 +12,11 @@ Please refer to the [upgrade guide](https://www.pomerium.com/docs/releases/upgra
 
 [Full Changelog](https://github.com/pomerium/pomerium/compare/v0.21.3...v0.22.0)
 
-## Security patch
+### Security
 
 - Pomerium upgraded to [Go v1.20.3](https://groups.google.com/g/golang-announce/c/Xdv6JL9ENs8/m/OV40vnafAwAJ) and [Envoy v1.24.5](https://groups.google.com/g/envoy-announce/c/o_W9gYVU2js/m/kU77ha6tBAAJ) to address security issues exposed in these packages. See the release notes in the links for more information.
 
-## Changed
+### Changed
 
 - add google cloud creds to ignore [\#3906](https://github.com/pomerium/pomerium/pull/3906) (@wasaga)
 - apple: fix userinfo [\#3974](https://github.com/pomerium/pomerium/pull/3974) (@calebdoxsey)
@@ -35,7 +35,7 @@ Please refer to the [upgrade guide](https://www.pomerium.com/docs/releases/upgra
 - Update SECURITY.md [\#4145](https://github.com/pomerium/pomerium/pull/4145) (@backport-actions-token[bot])
 - webauthn: only return known device credentials that match the given type [\#3981](https://github.com/pomerium/pomerium/pull/3981) (@calebdoxsey)
 
-## New
+### New
 
 - authenticate: fix authenticate_internal_service_url for all in one [\#4003](https://github.com/pomerium/pomerium/pull/4003) (@wasaga)
 - authenticate: have an option to trim the contents of the callback [\#4090](https://github.com/pomerium/pomerium/pull/4090) (@wasaga)
@@ -46,7 +46,7 @@ Please refer to the [upgrade guide](https://www.pomerium.com/docs/releases/upgra
 - support loading route configuration via rds [\#4098](https://github.com/pomerium/pomerium/pull/4098) (@calebdoxsey)
 - urlutil: add version to query string [\#4028](https://github.com/pomerium/pomerium/pull/4028) (@calebdoxsey)
 
-## Fixed
+### Fixed
 
 - authenticate: always trust the passed in idp [\#3917](https://github.com/pomerium/pomerium/pull/3917) (@calebdoxsey)
 - authenticate: don't require a session for sign_out [\#4007](https://github.com/pomerium/pomerium/pull/4007) (@calebdoxsey)
@@ -64,7 +64,7 @@ Please refer to the [upgrade guide](https://www.pomerium.com/docs/releases/upgra
 - store authenticate state on creation [\#4064](https://github.com/pomerium/pomerium/pull/4064) (@wasaga)
 - tls: wildcard catch-all cert must be at the end of cert list [\#4119](https://github.com/pomerium/pomerium/pull/4119) (@wasaga)
 
-## Dependency
+### Dependency
 
 - chore\(deps\): bump actions/cache from 3.2.3 to 3.2.4 [\#3923](https://github.com/pomerium/pomerium/pull/3923) (@dependabot[bot])
 - chore\(deps\): bump actions/cache from 3.2.4 to 3.2.5 [\#3962](https://github.com/pomerium/pomerium/pull/3962) (@dependabot[bot])
@@ -179,7 +179,7 @@ Please refer to the [upgrade guide](https://www.pomerium.com/docs/releases/upgra
 
 [Full Changelog](https://github.com/pomerium/pomerium/compare/v0.21.2...v0.21.3)
 
-## Changed
+### Changed
 
 - ci: build version branch images [\#4062](https://github.com/pomerium/pomerium/pull/4062) (@backport-actions-token[bot])
 - authorize: move sign out and jwks urls to route, update issuer for JWT [\#4049](https://github.com/pomerium/pomerium/pull/4049) (@backport-actions-token[bot])
@@ -189,7 +189,7 @@ Please refer to the [upgrade guide](https://www.pomerium.com/docs/releases/upgra
 
 [Full Changelog](https://github.com/pomerium/pomerium/compare/v0.21.1...v0.21.2)
 
-## Changed
+### Changed
 
 - authenticate: fix identity provider id in encrypted query string [\#4011](https://github.com/pomerium/pomerium/pull/4011) (@backport-actions-token[bot])
 - authenticate: fix callback handler for split mode [\#4010](https://github.com/pomerium/pomerium/pull/4010) (@backport-actions-token[bot])
@@ -203,7 +203,7 @@ Please refer to the [upgrade guide](https://www.pomerium.com/docs/releases/upgra
 
 [Full Changelog](https://github.com/pomerium/pomerium/compare/v0.21.0...v0.21.1)
 
-## Changed
+### Changed
 
 - authenticate: save the session cookie with a different name by @calebdoxsey in https://github.com/pomerium/pomerium/pull/3984
 - lua: fix rewrite response headers to handle dashes in URLs by @calebdoxsey in https://github.com/pomerium/pomerium/pull/3986
@@ -212,7 +212,7 @@ Please refer to the [upgrade guide](https://www.pomerium.com/docs/releases/upgra
 
 [Full Changelog](https://github.com/pomerium/pomerium/compare/v0.21.0-rc2...v0.21.0)
 
-## Changed
+### Changed
 
 - docker: switch to debian [\#3939](https://github.com/pomerium/pomerium/pull/3939) (@backport-actions-token[bot])
 - identity: fix nil reference error when there is no authenticator [\#3933](https://github.com/pomerium/pomerium/pull/3933) (@backport-actions-token[bot])
@@ -224,12 +224,12 @@ Please refer to the [upgrade guide](https://www.pomerium.com/docs/releases/upgra
 - controlplane: remove gorilla handlers dependency [\#3813](https://github.com/pomerium/pomerium/pull/3813) (@calebdoxsey)
 - events: remove xds configuraton update [\#3792](https://github.com/pomerium/pomerium/pull/3792) (@wasaga)
 
-## Breaking
+### Breaking
 
 - proxy: add userinfo and webauthn endpoints [\#3755](https://github.com/pomerium/pomerium/pull/3755) (@calebdoxsey)
 - remove forward auth [\#3628](https://github.com/pomerium/pomerium/pull/3628) (@calebdoxsey)
 
-## New
+### New
 
 - authenticate: add additional error details for hmac errors [\#3878](https://github.com/pomerium/pomerium/pull/3878) (@calebdoxsey)
 - authenticate: implement hpke-based login flow [\#3779](https://github.com/pomerium/pomerium/pull/3779) (@calebdoxsey)
@@ -248,7 +248,7 @@ Please refer to the [upgrade guide](https://www.pomerium.com/docs/releases/upgra
 - scripts: update get-envoy script to download all binaries [\#3886](https://github.com/pomerium/pomerium/pull/3886) (@calebdoxsey)
 - urlutil: add time validation functions [\#3776](https://github.com/pomerium/pomerium/pull/3776) (@calebdoxsey)
 
-## Fixed
+### Fixed
 
 - autocert: use atomic pointer to allow nil [\#3816](https://github.com/pomerium/pomerium/pull/3816) (@calebdoxsey)
 - config: add missing options [\#3882](https://github.com/pomerium/pomerium/pull/3882) (@calebdoxsey)
@@ -263,7 +263,7 @@ Please refer to the [upgrade guide](https://www.pomerium.com/docs/releases/upgra
 - storage: ignore removed fields when deserializing the data [\#3768](https://github.com/pomerium/pomerium/pull/3768) (@wasaga)
 - webauthn: require session when accessing /.pomerium/webauthn [\#3814](https://github.com/pomerium/pomerium/pull/3814) (@calebdoxsey)
 
-## Dependency
+### Dependency
 
 - bump goreleaser to v4.1.1 [\#3919](https://github.com/pomerium/pomerium/pull/3919) (@backport-actions-token[bot])
 - chore\(deps\): bump actions/cache from 3.0.11 to 3.2.2 [\#3851](https://github.com/pomerium/pomerium/pull/3851) (@dependabot[bot])


### PR DESCRIPTION
Closes #613 

Updates the Core Changelog headers to H3s. 

Suggestion: What if we organized headers alphabetically? This would give a more uniform look to the Changelog.