### PR TITLE
Docs: reference json update

### DIFF
--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -729,28 +729,6 @@
     "services": [],
     "type": "bool"
   },
-  "allowed-domains": {
-    "id": "allowed-domains",
-    "title": "Allowed Domains",
-    "path": "/policy/allowed-domains",
-    "services": [],
-    "type": "comma separated strings"
-  },
-  "allowed-idp-claims": {
-    "id": "allowed-idp-claims",
-    "title": "Allowed IdP Claims",
-    "path": "/policy/allowed-idp-claims",
-    "description": "Authorize users by matching claims attached to a user's identity token by their identity provider",
-    "services": [],
-    "type": "map of strings lists"
-  },
-  "allowed-users": {
-    "id": "allowed-users",
-    "title": "Allowed Users",
-    "path": "/policy/allowed-users",
-    "services": [],
-    "type": "comma separated strings"
-  },
   "allow-any-authenticated-user": {
     "id": "allow-any-authenticated-user",
     "title": "Allow Any Authenticated User",
@@ -892,14 +870,6 @@
     "path": "/routes/path",
     "services": ["proxy"],
     "short_description": "Only match requests with an exact match for this path",
-    "type": "string"
-  },
-  "policy-explanation": {
-    "id": "policy-explanation",
-    "title": "Explanation",
-    "description": "Adds an explanation to the user when they hit a 403 Unauthorized Endpoint that has this policy.",
-    "path": "/policy/policy-explanation",
-    "services": [],
     "type": "string"
   },
   "prefix": {

--- a/static/_redirects
+++ b/static/_redirects
@@ -41,7 +41,13 @@
 /guides/traefik-ingress.html https://0-20-0.docs.pomerium.com/docs/guides/traefik-ingress 301!
 /docs/reference/forward-auth https://0-20-0.docs.pomerium.com/docs/reference/forward-auth 301!
 https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.com/docs/guides
-/docs/reference/policy/* https://0-14-0.docs.pomerium.com/reference/:splat 301!
+/docs/reference/policy/allowed-domains https://0-14-0.docs.pomerium.com/reference
+/docs/reference/policy/allowed-idp-claims https://0-14-0.docs.pomerium.com/reference
+/docs/reference/policy/allowed-users https://0-14-0.docs.pomerium.com/reference
+/docs/reference/policy/policy-explanation https://0-14-0.docs.pomerium.com/reference
+/docs/reference/policy/policy-remediation https://0-14-0.docs.pomerium.com/reference
+/docs/reference/policy/policy https://0-14-0.docs.pomerium.com/reference
+
 
 # 301 Helm redirects
 /docs/guides/helm https://0-19-0.docs.pomerium.com/docs/guides/helm 301!


### PR DESCRIPTION
Removes deprecated `/policy/*` references from `/docs/reference/reference.json` and manually redirects links to v14 docs. 

The previous redirects 301 redirected to v14, but were still 404ing. I manually directed each deprecated link to `0-14-0.docs.pomerium/reference` to hopefully prevent 404ing. 
 