### PR TITLE
Docs: add golangci-lint as a build prerequisite

### DIFF
--- a/content/docs/deploying/from-source.mdx
+++ b/content/docs/deploying/from-source.mdx
@@ -27,6 +27,7 @@ This document covers how to retrieve and build Pomerium from its source-code as 
 - [git](https://git-scm.com/)
 - [go](https://golang.org/doc/install) programming language
 - A configured [identity provider]
+- [golangci-lint](https://golangci-lint.run/usage/install/#local-installation)
 
 ## Download
 

--- a/cspell.json
+++ b/cspell.json
@@ -46,6 +46,7 @@
     "getenv",
     "genkey",
     "godoc",
+    "golangci",
     "googleusercontent",
     "gsuite",
     "hsts",


### PR DESCRIPTION
On the Deploying / From Source page, add 'golangci-lint' to the Prerequisites list (linking to the local installation instructions). This is required by the `all` make target.