### PR TITLE
Docs: updates programmatic whitelist ref

### DIFF
--- a/content/docs/capabilities/programmatic-access.mdx
+++ b/content/docs/capabilities/programmatic-access.mdx
@@ -46,7 +46,7 @@ curl -H 'Authorization: Pomerium a.real.jwt' https://verify.example.com
 - `localhost:8000` is our service we're developing locally, it'll need to accept the programmatic token directly as a query param `?pomerium_jwt=programmatic.pomerium.jwt` _see [callback handler](#callback-handler)_
 - `authenticate.example.com` is the pomerium-authenticate service, we'll open that in the browser to authenticate, it will be set as `iss` on the jwt
 
-**Note**: By default only `localhost` URLs are allowed as the `pomerium_redirect_uri`. This can be customized with the `programmatic_redirect_domain_whitelist` option.
+**Note**: By default only `localhost` URLs are allowed as the `pomerium_redirect_uri`. This can be customized with the [`programmatic_redirect_domain_whitelist`](/docs/reference/programmatic-redirect-domain-whitelist) option.
 
 ### Alternative to Login API for `localhost` development
 

--- a/content/docs/reference/programmatic-redirect-domain-whitelist.mdx
+++ b/content/docs/reference/programmatic-redirect-domain-whitelist.mdx
@@ -15,6 +15,16 @@ import TabItem from '@theme/TabItem';
 
 The **Programmatic Redirect Domain Whitelist** is used to restrict the allowed redirect URLs when using programmatic login.
 
+:::tip **Note**
+
+Whitelisted domains must match the redirect URL exactly; otherwise, the domain will be rejected.
+
+For example, whitelisting `example.com` will only accept a redirect URL that matches `example.com`.
+
+`dev.example.com` will be rejected, as the hostname does not exactly match `example.com`.
+
+:::
+
 ## How to configure
 
 | **Type**         | **Usage**    | **Default** |


### PR DESCRIPTION
Adds a note to the [programmatic whitelist reference](https://main.docs.pomerium.com/docs/reference/programmatic-redirect-domain-whitelist). 

Fixes https://github.com/pomerium/pomerium/issues/4198