### PR TITLE
Docs: removes namespaces blurb from configuration page

### DIFF
--- a/content/docs/capabilities/namespacing.mdx
+++ b/content/docs/capabilities/namespacing.mdx
@@ -52,6 +52,12 @@ Hierarchical policy lets administrators enforce inheritable authorization policy
 
 Identities and their group memberships are defined by your Identity Provider (**IdP**). Pomerium looks to your IdP for identity information, so policies defined using groups are always up-to-date with the access management defined upstream.
 
+:::tip
+
+When using an IdP without directory sync or when working with non-domain users, they will not show up in the look-ahead search. See [Non-Domain Users](/docs/concepts/access-control#non-domain-users) for more information.
+
+:::
+
 Consider this scenario: you want to enable your security team to manage high level corporate policy while enabling application owners to set finer grained user access to their specific applications. Pomerium can help you do that!
 
 Your security team can enact top level security policies to ensure, everyone:

--- a/content/docs/deploy/enterprise/configure.mdx
+++ b/content/docs/deploy/enterprise/configure.mdx
@@ -111,20 +111,6 @@ The keys listed below can be applied in Pomerium Console's `config.yaml` file or
 </TabItem>
 </Tabs>
 
-## Namespaces
-
-A [Namespace][namespace] is a collection of users, groups, routes, and policies that allows system administrators to organize, manage, and delegate permissions across their infrastructure.
-
-- Policies can be optional or enforced on a Namespace.
-  - Enforced policies are also enforced on child Namespaces, and optional policies are available to them as well.
-- Users or groups can be granted permission to edit access to routes within a Namespace, allowing them self-serve access to the routes critical to their work.
-
-:::tip
-
-When using an IdP without directory sync or when working with non-domain users, they will not show up in the look-ahead search. See [Non-Domain Users](/docs/concepts/access-control#non-domain-users) for more information.
-
-:::
-
 ## External Data
 
 This section lets [administrators](/docs/capabilities/namespacing#admin) add and manage external data sources. Information from external data sources can be used to extend [policies](/docs/concepts/policies).


### PR DESCRIPTION
Removes namespaces blurb and adds idp tip to /capabilities/namespaces