### PR TITLE
Docs: fixes redirects from v22 sidebar restructure

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -157,8 +157,16 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/releases/upgrading /docs/deploy/core/upgrading
 /docs/deploying/binary /docs/deploy/core/binary
 /docs/deploying/from-source /docs/deploy/core/from-source
+/enterprise/about /docs/deploy/enterprise
+/docs/deploy/enterprise/about /docs/deploy/enterprise
+/docs/releases/enterprise /docs/deploy/enterprise
+/docs/deploy/enterprise/install/installation /docs/deploy/enterprise/install
 /docs/releases/* /docs/deploy/:splat
-/docs/deploying/* /docs/deploy:splat
+/docs/deploying/* /docs/deploy/:splat
+
+# v22 sidebar client redirects
+/docs/deploy/pomerium-cli /docs/deploy/clients/pomerium-cli
+/docs/deploy/pomerium-desktop /docs/deploy/clients/pomerium-desktop
 
 #  Installation and deployment methods redirects
 /docs/installation.html /docs/install


### PR DESCRIPTION
Should fix the following 404ing links:
- [ ] #693 
- [ ] #692 
- [ ] #691 
- [ ] #690 
- [ ] #689 
- [ ] #688 
- [ ] #687 
- [ ] #686 