### PR TITLE
Docs: restores idp links in reference.json

### DIFF
--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -392,6 +392,62 @@
     "services": [],
     "type": "URL"
   },
+  "identity-provider-client-id": {
+    "id": "identity-provider-client-id",
+    "title": "Identity Provider Client ID",
+    "path": "/identity-provider-settings",
+    "description": "Client ID is the OAuth 2.0 Client Identifier retrieved from your identity provider.",
+    "services": [],
+    "type": "string"
+  },
+  "identity-provider-client-secret-file": {
+    "id": "identity-provider-client-secret-file",
+    "title": "Identity Provider Client Secret File",
+    "path": "/identity-provider-settings",
+    "description": "File path containing the client secret, the OAuth 2.0 Secret Identifier retrieved from your identity provider.",
+    "services": [],
+    "type": "string"
+  },
+  "identity-provider-client-secret": {
+    "id": "identity-provider-client-secret",
+    "title": "Identity Provider Client Secret",
+    "path": "/identity-provider-settings",
+    "description": "Client Secret is the OAuth 2.0 Secret Identifier retrieved from your identity provider.",
+    "services": [],
+    "type": "string"
+  },
+  "identity-provider-name": {
+    "id": "identity-provider-name",
+    "title": "Identity Provider Name",
+    "path": "/identity-provider-settings",
+    "description": "Provider is the short-hand name of a built-in OpenID Connect (oidc) identity provider to be used for authentication.",
+    "services": [],
+    "type": "string"
+  },
+  "identity-provider-scopes": {
+    "id": "identity-provider-scopes",
+    "title": "Identity Provider Scopes",
+    "path": "/identity-provider-settings",
+    "description": "Identity provider scopes correspond to access privilege scopes as defined in Section 33 of OAuth 20 RFC6749.",
+    "services": [],
+    "type": "comma separated strings"
+  },
+  "identity-provider-url": {
+    "id": "identity-provider-url",
+    "title": "Identity Provider URL",
+    "path": "/identity-provider-settings",
+    "description": "Provider URL is the base path to an identity provider's OpenID connect discovery document.",
+    "services": [],
+    "type": "string"
+  },
+  "identity-provider-request-params": {
+    "id": "identity-provider-request-params",
+    "title": "Identity Provider Request Params",
+    "path": "/identity-provider-settings",
+    "description": "Headers specifies a mapping of HTTP Header to be added to proxied  requests. Nota bene Downstream application headers will be overwritten by Pomerium's headers on conflict.",
+    "services": [],
+    "type": "map of strings key value pairs"
+  },
   "authorize-service-url": {
     "id": "authorize-service-url",
     "title": "Authorize Service URL",


### PR DESCRIPTION
The IDP links in `reference.json` were removed as part of the restructure. This PR restores those links so they all link to `identity-provider-settings`. 