### PR TITLE
Docs: restores branding refs to reference.json

### DIFF
--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -562,6 +562,23 @@
     "services": ["proxy"],
     "type": "bool"
   },
+  "error-message-header": {
+    "id": "error-message-first-paragraph",
+    "title": "Error Message Header",
+    "path": "/branding",
+    "description": "A paragraph that will appear on all Route Error Pages in the top section.",
+    "short_description": "Can contain plain text or Markdown.",
+    "services": [],
+    "type": "string"
+  },
+  "favicon-url": {
+    "id": "favicon-url",
+    "title": "Favicon Url",
+    "path": "/branding",
+    "description": "A Url pointing to your favicon. Defaults to Pomerium's Favicon.",
+    "services": [],
+    "type": "URL"
+  },
   "from": {
     "id": "from",
     "title": "From",
@@ -628,6 +645,14 @@
     "services": ["proxy"],
     "type": "object"
   },
+  "logo-url": {
+    "id": "logo-url",
+    "title": "Logo Url",
+    "path": "/branding",
+    "description": "A Url pointing to your logo. Defaults to Pomerium's Logo.",
+    "services": [],
+    "type": "URL"
+  },
   "outlier-detection": {
     "id": "outlier-detection",
     "title": "Outlier Detection",
@@ -665,6 +690,24 @@
     "path": "/routes/prefix-rewrite",
     "services": ["proxy"],
     "short_description": "Swaps the matched prefix (previous section) with this value",
+    "type": "string"
+  },
+  "primary-color": {
+    "id": "primary-color",
+    "title": "Primary Color",
+    "path": "/branding",
+    "description": "A hex code that determines the primary color for the Enterprise Console and Route Error Details pages.",
+    "short_description": "Defaults to #6F43E7",
+    "services": [],
+    "type": "string"
+  },
+  "primary-color-dark-mode": {
+    "id": "darkmode-primary-color",
+    "title": "Primary Color (Dark Mode)",
+    "path": "/branding",
+    "description": "A hex code that determines the primary color for the Enterprise Console and Route Error Details pages when in Dark Mode.",
+    "short_description": "Defaults to #6F43E7",
+    "services": [],
     "type": "string"
   },
   "public-access": {
@@ -731,6 +774,24 @@
     "path": "/routes/route-timeout",
     "services": ["proxy"],
     "type": "duration"
+  },
+  "secondary-color": {
+    "id": "secondary-color",
+    "title": "Secondary Color",
+    "description": "A hex code that determines the secondary color for the Enterprise Console and Route Error Details pages.",
+    "path": "/branding",
+    "short_description": "Defaults to #49AAA1",
+    "services": [],
+    "type": "string"
+  },
+  "secondary-color-dark-mode": {
+    "id": "darkmode-secondary-color",
+    "title": "Secondary Color (Dark Mode)",
+    "description": "A hex code that determines the secondary color for the Enterprise Console and Route Error Details pages when in Dark Mode.",
+    "short_description": "Defaults to #49AAA1",
+    "path": "/branding",
+    "services": [],
+    "type": "string"
   },
   "set-authorization-header": {
     "id": "set-authorization-header",


### PR DESCRIPTION
The Branding links in reference.json were removed as part of the restructure. This PR restores those links so they all link to `/branding`.