### PR TITLE
Docs: add databroker storage certificate key file

### DIFF
--- a/content/docs/reference/databroker.mdx
+++ b/content/docs/reference/databroker.mdx
@@ -16,6 +16,7 @@ This reference covers all of Pomerium's **Databroker Settings**:
 - [Databroker Internal Service URL](#databroker-internal-service-url)
 - [Databroker Storage Certificate Authority](#databroker-storage-certificate-authority)
 - [Databroker Storage Certificate File](#databroker-storage-certificate-file)
+- [Databroker Storage Certificate Key File](#databroker-storage-certificate-key-file)
 - [Databroker Storage Connection String](#databroker-storage-connection-string)
 - [Databroker Storage TLS Skip Verify](#databroker-storage-tls-skip-verify)
 - [Databroker Storage Type](#databroker-storage-type)

--- a/content/docs/reference/databroker.mdx
+++ b/content/docs/reference/databroker.mdx
@@ -176,6 +176,39 @@ databroker_storage_cert_file: /relative/file/location
 DATABROKER_STORAGE_CERT_FILE=/relative/file/location
 ```
 
+## Databroker Storage Certificate Key File
+
+**Databroker Storage Certificate Key File** stores the certificate key used to connect to a storage backend.
+
+### How to configure
+
+<Tabs>
+<TabItem value="Core" label="Core">
+
+| **Config file keys**          | **Environment variables**     | **Type** | **Usage**    |
+| :---------------------------- | :---------------------------- | :------- | :----------- |
+| `databroker_storage_key_file` | `DATABROKER_STORAGE_KEY_FILE` | `string` | **optional** |
+
+</TabItem>
+<TabItem value="Enterprise" label="Enterprise">
+
+`databroker_storage_key_file` is a bootstrap configuration setting and is not configurable in the Console.
+
+</TabItem>
+<TabItem value="Kubernetes" label="Kubernetes">
+
+See Kubernetes [Storage reference](/docs/deploy/k8s/reference#storage) for more information.
+
+</TabItem>
+</Tabs>
+
+### Examples
+
+```yaml
+databroker_storage_key_file: /relative/file/location
+DATABROKER_STORAGE_KEY_FILE=/relative/file/location
+```
+
 ## Databroker Storage Connection String
 
 **Databroker Storage Connection String** sets the Postgres connection string that the Databroker service uses to connect to storage backend.

--- a/content/docs/reference/databroker.mdx
+++ b/content/docs/reference/databroker.mdx
@@ -185,8 +185,8 @@ DATABROKER_STORAGE_CERT_FILE=/relative/file/location
 <Tabs>
 <TabItem value="Core" label="Core">
 
-| **Config file keys**          | **Environment variables**     | **Type** | **Usage**    |
-| :---------------------------- | :---------------------------- | :------- | :----------- |
+| **Config file keys** | **Environment variables** | **Type** | **Usage** |
+| :-- | :-- | :-- | :-- |
 | `databroker_storage_key_file` | `DATABROKER_STORAGE_KEY_FILE` | `string` | **optional** |
 
 </TabItem>

--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -213,13 +213,13 @@
   },
   "data-broker-service": {
     "id": "data-broker-service",
-    "title": "Data Broker Service",
+    "title": "Databroker Service",
     "path": "/databroker",
     "services": ["databroker"]
   },
   "data-broker-service-url": {
     "id": "data-broker-service-url",
-    "title": "Data Broker Service URL",
+    "title": "Databroker Service URL",
     "path": "/databroker",
     "services": [],
     "type": "URL"

--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -570,7 +570,7 @@
     "type": "relative file location"
   },
   "data-broker-storage-certificate-key-file": {
-    "id": "databroker",
+    "id": "data-broker-storage-certificate-key-file",
     "title": "Databroker Storage Certificate Key File",
     "path": "/databroker",
     "services": [],


### PR DESCRIPTION
The `databroker-storage-certificate-key-file` was removed during the Databroker Settings consolidation. This PR restores the file.