### PR TITLE
Docs: fix gsc redirects

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -36,6 +36,7 @@
 
 # 301 deprecated guides in v21 to v20 guides
 /docs/guides/nginx https://0-20-0.docs.pomerium.com/docs/guides/nginx 301!
+/docs/guides/nginx.html https://0-20-0.docs.pomerium.com/docs/guides/nginx 301!
 /docs/guides/traefik-ingress https://0-20-0.docs.pomerium.com/docs/guides/traefik-ingress 301!
 /docs/guides/traefik-ingress.html https://0-20-0.docs.pomerium.com/docs/guides/traefik-ingress 301!
 /guides/traefik-ingress.html https://0-20-0.docs.pomerium.com/docs/guides/traefik-ingress 301!
@@ -49,11 +50,15 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/reference/policy/policy https://0-14-0.docs.pomerium.com/reference
 
 
-# 301 Helm redirects
+# 301 Helm and Kubernetes redirects
 /docs/guides/helm https://0-19-0.docs.pomerium.com/docs/guides/helm 301!
 /docs/releases/enterprise/install/helm https://0-19-0.docs.pomerium.com/docs/enterprise/install/helm 301!
+/docs/enterprise/install/helm.html https://0-19-0.docs.pomerium.com/docs/enterprise/install/helm 301!
 /docs/guides/kubernetes https://0-19-0.docs.pomerium.com/docs/guides/kubernetes 301!
 /docs/guides/kubernetes-dashboard https://0-19-0.docs.pomerium.com/docs/guides/kubernetes-dashboard 301!
+/docs/guides/kubernetes-dashboard.html https://0-19-0.docs.pomerium.com/docs/guides/kubernetes-dashboard 301!
+/guides/kubernetes-dashboard.html https://0-19-0.docs.pomerium.com/docs/guides/kubernetes-dashboard 301!
+/recipes/kubernetes.html https://0-20-0.docs.pomerium.com/docs/guides/kubernetes 301!
 
 # /guides/ redirects to capabilities pages
 /docs/guides/enroll-device /docs/capabilities/device-identity
@@ -246,7 +251,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/tcp/client /docs/capabilities/tcp/client
 
 /docs/capabilities/tcp/reference/tcp-cli-reference /docs/capabilities/tcp/reference
-
+/docs/capabilities/tcp/examples/service-template.html /docs/capabilities/tcp
 # splats
 /docs/tcp/examples/* /docs/capabilities/tcp/examples/:splat
 /docs/tcp/* /docs/capabilities/tcp/examples/:splat
@@ -282,6 +287,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 
 # /docs/glossary.html uses multiple redirects
 /docs/glossary.html /docs/overview/glossary
+/docs/glossary /docs/internals/glossary
 /docs/overview/glossary /docs/internals/glossary
 
 
@@ -295,6 +301,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 
 /docs/architecture /docs/internals/architecture
 # /docs/background.html has multiple redirects
+/docs/background /docs/concepts/zero-trust
 /docs/background.html /docs/overview/background
 /docs/overview/background /docs/concepts/zero-trust
 
@@ -308,6 +315,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/overview/changelog /docs/releases/changelog
 # Redirects are case sensitive https://answers.netlify.com/t/case-sensitivity-with-redirects/956/2
 /docs/CHANGELOG /docs/releases/changelog
+/docs/CHANGELOG.html /docs/deploy/core/changelog
 
 # Consolidated Reference Page redirects
 # Autocert
@@ -340,6 +348,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/reference/cookie-secret /docs/reference/cookies
 /docs/reference/cookie-secure /docs/reference/cookies
 /docs/reference/javascript-security /docs/reference/cookies
+/docs/reference/cookie-expire /docs/reference/cookies
 
 # IdP Settings
 /docs/reference/identity-provider-client-id /docs/reference/identity-provider-settings

--- a/static/_redirects
+++ b/static/_redirects
@@ -167,6 +167,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/deploy/enterprise/about /docs/deploy/enterprise
 /docs/releases/enterprise /docs/deploy/enterprise
 /docs/deploy/enterprise/install/installation /docs/deploy/enterprise/install
+/docs/releases/enterprise/install/quickstart /docs/deploy/enterprise/quickstart
 /docs/releases/* /docs/deploy/:splat
 /docs/deploying/* /docs/deploy/:splat
 


### PR DESCRIPTION
Fixes the following 404s:
- [ ] https://github.com/pomerium/documentation/issues/730
- [ ] https://github.com/pomerium/documentation/issues/729
- [ ] https://github.com/pomerium/documentation/issues/728
- [ ] https://github.com/pomerium/documentation/issues/727
- [ ] https://github.com/pomerium/documentation/issues/726
- [ ] https://github.com/pomerium/documentation/issues/725
- [ ] https://github.com/pomerium/documentation/issues/724
- [ ] https://github.com/pomerium/documentation/issues/723
- [ ] https://github.com/pomerium/documentation/issues/722
- [ ] https://github.com/pomerium/documentation/issues/721
- [ ] https://github.com/pomerium/documentation/issues/720
- [ ] https://github.com/pomerium/documentation/issues/719