### PR TITLE
Fix broken "Certificates" link in quickstart

### DIFF
--- a/content/docs/quickstart.mdx
+++ b/content/docs/quickstart.mdx
@@ -85,7 +85,7 @@ If you want to try connecting Pomerium with other services, see some of our [Gui
 
 :::caution
 
-This is a test environment! If you followed all the steps in this doc your Pomerium environment is not using trusted certificates. Remember to use a valid certificate solution before moving this configuration to a production environment. See [Certificates][tls certificates] for more information.
+This is a test environment! If you followed all the steps in this doc your Pomerium environment is not using trusted certificates. Remember to use a valid certificate solution before moving this configuration to a production environment. See [Certificates](/docs/concepts/certificates) for more information.
 
 :::
 


### PR DESCRIPTION
I think the link target was unintentionally removed in commit d7aab795c31a869d890aa7ccc4c4cdd104a400a7.