### PR TITLE
Fix typo in Identity Provider Settings

### DIFF
--- a/content/docs/reference/identity-provider-settings/readme.mdx
+++ b/content/docs/reference/identity-provider-settings/readme.mdx
@@ -203,7 +203,7 @@ Downstream application headers will be overwritten by Pomerium's headers on conf
 
 | **Config file keys** | **Environment variables** | **Type** | **Usage** |
 | :-- | :-- | :-- | :-- |
-| `ipd_request_params` | `IPD_REQUEST_PARAMS` | `string` (map of key-value pairs) | **optional** |
+| `idp_request_params` | `IDP_REQUEST_PARAMS` | `string` (map of key-value pairs) | **optional** |
 
 </TabItem>
 <TabItem value="Enterprise" label="Enterprise">


### PR DESCRIPTION
I think the config file key and environment variable should be 'idp_request_params' instead of 'ipd_request_params'.