### PR TITLE
Document idp_request_params default values

### DIFF
--- a/content/docs/reference/identity-provider-settings.mdx
+++ b/content/docs/reference/identity-provider-settings.mdx
@@ -157,6 +157,20 @@ IDP_CLIENT_SECRET_FILE='/run/secrets/POMERIUM_CLIENT_SECRET'
 
 See [identity provider](/docs/identity-providers/) for details.
 
+The supported values for this setting are:
+
+- `apple`
+- `auth0`
+- `azure`
+- `cognito`
+- `github`
+- `gitlab`
+- `google`
+- `oidc`
+- `okta`
+- `onelogin`
+- `ping`
+
 ### How to configure
 
 <Tabs>
@@ -195,7 +209,17 @@ IDP_PROVIDER=github
 
 **Identity Provider Request Params** lists the parameters you want to include as part of a sign-in request using the OAuth 2.0 code flow.
 
-Downstream application headers will be overwritten by Pomerium's headers on conflict.
+### Defaults
+
+Pomerium includes some default parameters for specific identity providers. Setting this configuration option will replace these default parameters. To remove the default parameters entirely, set this option to an empty map\* (e.g. `idp_request_params: {}` in the config file).
+
+| **Provider** | **Default parameters** |
+| :-- | :-- |
+| `apple`\* | <pre>response_mode: form_post</pre> |
+| `azure` | <pre>prompt: select_account</pre> |
+| `google` | <pre>prompt: select_account consent<br />access_type: offline</pre> |
+
+\*_Note:_ the default parameters for `apple` behave differently; any values set using this configuration option will be merged with the default parameters.
 
 ### How to configure
 

--- a/content/docs/reference/identity-provider-settings.mdx
+++ b/content/docs/reference/identity-provider-settings.mdx
@@ -209,22 +209,6 @@ IDP_PROVIDER=github
 
 **Identity Provider Request Params** lists the parameters you want to include as part of a sign-in request using the OAuth 2.0 code flow.
 
-### Defaults
-
-Pomerium includes some default parameters for specific identity providers. Setting this configuration option will replace these default parameters. To remove the default parameters entirely, set this option to an empty map\* (e.g. `idp_request_params: {}` in the config file).
-
-| **Provider** | **Default parameters** |
-| :-- | :-- |
-| `apple`\* | <pre>response_mode: form_post</pre> |
-| `azure` | <pre>prompt: select_account</pre> |
-| `google` | <pre>prompt: select_account consent<br />access_type: offline</pre> |
-
-:::note 
-
-\*The default parameters for `apple` behave differently; any values set using this configuration option will be merged with the default parameters.
-
-:::
-
 ### How to configure
 
 <Tabs>
@@ -248,6 +232,22 @@ See Kubernetes [`identityProvider.requestParams` and `identityProvider.requestPa
 
 </TabItem>
 </Tabs>
+
+### Defaults
+
+Pomerium includes some default parameters for specific identity providers. Setting this configuration option will replace these default parameters. To remove the default parameters entirely, set this option to an empty map\* (e.g. `idp_request_params: {}` in the config file).
+
+| **Provider** | **Default parameters** |
+| :-- | :-- |
+| `apple`\* | <pre>response_mode: form_post</pre> |
+| `azure` | <pre>prompt: select_account</pre> |
+| `google` | <pre>prompt: select_account consent<br />access_type: offline</pre> |
+
+:::note
+
+\*The default parameters for `apple` behave differently; any values set using this configuration option will be merged with the default parameters.
+
+:::
 
 ### Examples
 

--- a/content/docs/reference/identity-provider-settings.mdx
+++ b/content/docs/reference/identity-provider-settings.mdx
@@ -219,7 +219,11 @@ Pomerium includes some default parameters for specific identity providers. Setti
 | `azure` | <pre>prompt: select_account</pre> |
 | `google` | <pre>prompt: select_account consent<br />access_type: offline</pre> |
 
-\*_Note:_ the default parameters for `apple` behave differently; any values set using this configuration option will be merged with the default parameters.
+:::note 
+
+\*The default parameters for `apple` behave differently; any values set using this configuration option will be merged with the default parameters.
+
+:::
 
 ### How to configure
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -215,3 +215,7 @@ select:focus {
 [data-theme='dark'] .enterprise a:before {
   color: #ffffff;
 }
+
+td > .theme-code-block:last-child {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
Add a 'Defaults' sub-section to the Identity Provider Request Params documentation, listing the default request parameters for Apple, Azure, and Google. Add a note about the newly implemented support for clearing the default parameters entirely (from pomerium/pomerium#4315).

Also list the supported identity provider types explicitly, under Identity Provider Name.

Add a custom CSS rule to avoid some unwanted extra space when placing a code block inside a table cell.