### PR TITLE
Docs: add stable sub headers to reference settings

### DIFF
--- a/content/docs/reference/autocert.mdx
+++ b/content/docs/reference/autocert.mdx
@@ -27,7 +27,7 @@ This reference covers all of Pomerium's **Autocert Settings**:
 - [Autocert Trusted Certificate Authority](#autocert-trusted-certificate-authority)
 - [Autocert Use Staging](#autocert-use-staging)
 
-## Autocert
+## Autocert {#autocert}
 
 Turning on Autocert allows Pomerium to automatically retrieve, manage, and renew public facing TLS Certificates from [Let's Encrypt][letsencrypt], which includes managed routes and the Authenticate Service.
 
@@ -51,7 +51,7 @@ Autocert requires that port `443` be accessible from the internet in order to co
 
 [letsencrypt]: https://letsencrypt.org/
 
-### How to configure
+### How to configure {#autocert-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -73,7 +73,7 @@ Kubernetes users should not use Autocert. See the [cert-manager's guide](https:/
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#autocert-examples}
 
 ```yaml
 # config file key
@@ -83,7 +83,7 @@ autocert: true
 AUTOCERT=TRUE
 ```
 
-## Autocert CA
+## Autocert CA {#autocert-ca}
 
 **Autocert CA** is the directory URL of the ACME CA to use when requesting certificates.
 
@@ -93,7 +93,7 @@ If set, Autocert CA will override the [**Autocert Use Staging**](/docs/reference
 
 :::
 
-### How to configure
+### How to configure {#autocert-ca-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -115,7 +115,7 @@ Kubernetes users should not use Autocert. See the [cert-manager's guide](https:/
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#autocert-ca-examples}
 
 ```yaml
 # config file key
@@ -125,11 +125,11 @@ autocert_ca: https://acme.zerossl.com/v2/DV90
 AUTOCERT_CA=https://acme.zerossl.com/v2/DV90
 ```
 
-## Autocert Directory
+## Autocert Directory {#autocert-directory}
 
 **Autocert Directory** is the path where [Autocert](/docs/reference/autocert) stores X.509 Certificate data.
 
-### How to configure
+### How to configure {#autocert-directory-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -153,7 +153,7 @@ Kubernetes users should not use Autocert. See the [cert-manager's guide](https:/
 </TabItem>
 </Tabs>
 
-### Defaults
+### Defaults {#autocert-directory-defaults}
 
 | **Default paths** | **Value** |
 | :-- | :-- |
@@ -162,9 +162,9 @@ Kubernetes users should not use Autocert. See the [cert-manager's guide](https:/
 | XDG base directories | [$XDG_DATA_HOME](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) |
 | Home directories | `$HOME/.local/share/pomerium` |
 
-### Examples
+### Examples {#autocert-directory-examples}
 
-#### S3 Bucket
+#### S3 Bucket {#s3-bucket}
 
 An S3 bucket can be used as storage by using a URL like:
 
@@ -174,7 +174,7 @@ autocert_dir: s3://your-bucket.s3.us-east-1.amazonaws.com/some/prefix
 
 Credentials are sourced from [the environment](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/config#EnvConfig).
 
-#### GCS Bucket
+#### GCS Bucket {#gcs-bucket}
 
 A Google Cloud Storage bucket can be used as storage by using a URL like:
 
@@ -184,11 +184,11 @@ autocert_dir: gs://your-bucket/some/prefix
 
 Credentials are sourced from [Google Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials).
 
-## Autocert EAB Key ID
+## Autocert EAB Key ID {#autocert-eab-key-id}
 
 **Autocert EAB Key ID** is the key identifier when requesting a certificate from a CA with External Account Binding (EAB) enabled.
 
-### How to configure
+### How to configure {#autocert-eab-key-id-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -212,7 +212,7 @@ Kubernetes users should not use Autocert. See the [cert-manager's guide](https:/
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#autocert-eab-key-id-examples}
 
 ```yaml
 # config file key
@@ -222,13 +222,13 @@ autocert_eab_key_id: EAB_KID
 AUTOCERT_EAB_KEY_ID=EAB_KID
 ```
 
-## Autocert EAB MAC Key
+## Autocert EAB MAC Key {#autocert-eab-mac-key}
 
 **Autocert EAB MAC Key** is the base64-URL-encoded secret key corresponding to the [Autocert EAB Key ID](/docs/reference/autocert).
 
 The Autocert EAB MAC Key setting is required when Autocert EAB Key ID is set.
 
-### How to configure
+### How to configure {#autocert-eab-mac-key-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -250,7 +250,7 @@ Kubernetes users should not use Autocert. See the [cert-manager's guide](https:/
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#autocert-eab-mac-key-examples}
 
 ```yaml
 # config file key
@@ -260,7 +260,7 @@ autocert_eab_key_id: base64-URL-encoded_secret_key
 AUTOCERT_EAB_KEY_ID=base64-URL-encoded_secret_key
 ```
 
-## Autocert Email
+## Autocert Email {#autocert-email}
 
 **Autocert Email** is the email address to use when requesting certificates from an ACME CA or registering an ACME account.
 
@@ -270,7 +270,7 @@ The CA may contact you at this address when, for example, a certificate expires.
 
 :::
 
-### How to configure
+### How to configure {#autocert-email-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -292,7 +292,7 @@ Kubernetes users should not use Autocert. See the [cert-manager's guide](https:/
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#autocert-email-examples}
 
 ```yaml
 # config file key
@@ -302,7 +302,7 @@ autocert_email: example@domain.com
 AUTOCERT_EMAIL=example@domain.com
 ```
 
-## Autocert Must Staple
+## Autocert Must Staple {#autocert-must-staple}
 
 If true, **Autocert Must Staple** forces Autocert to request a certificate with the `status_request` extension (commonly called `Must-Staple`).
 
@@ -316,7 +316,7 @@ The Autocert Must Staple setting will only take effect when you request or renew
 
 :::
 
-### How to configure
+### How to configure {#autocert-must-staple-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -340,7 +340,7 @@ Kubernetes users should not use Autocert. See the [cert-manager's guide](https:/
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#autocert-must-staple-examples}
 
 ```yaml
 # config file key
@@ -350,13 +350,13 @@ autocert_must_staple: true
 AUTOCERT_MUST_STAPLE=true
 ```
 
-## Autocert Trusted Certificate Authority
+## Autocert Trusted Certificate Authority {#autocert-trusted-certificate-authority}
 
 **Autocert Trusted Certificate Authority** is the X.509 CA (bundle) used when communicating with a CA supporting the ACME protocol.
 
 If not set, the system trusted roots will be used to verify TLS connections to the ACME CA.
 
-### How to configure
+### How to configure {#autocert-trusted-certificate-authority-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -379,7 +379,7 @@ Kubernetes users should not use Autocert. See the [cert-manager's guide](https:/
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#autocert-trusted-certificate-authority-examples}
 
 ```yaml
 # config file key
@@ -391,11 +391,11 @@ AUTOCERT_TRUSTED_CA=base64-encoded-string
 AUTOCERT_TRUSTED_CA_FILE=/relative/file/location
 ```
 
-## Autocert Use Staging
+## Autocert Use Staging {#autocert-use-staging}
 
 **Autocert Use Staging** setting allows you to use Let's Encrypt's [staging environment](https://letsencrypt.org/docs/staging-environment/), which has more lenient [usage limits](https://letsencrypt.org/docs/rate-limits/) than the production environment.
 
-### How to configure
+### How to configure {#autocert-use-staging-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -417,7 +417,7 @@ Kubernetes users should not use Autocert. See the [cert-manager's guide](https:/
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#autocert-use-staging-examples}
 
 ```yaml
 # config file key

--- a/content/docs/reference/autocert.mdx
+++ b/content/docs/reference/autocert.mdx
@@ -164,7 +164,7 @@ Kubernetes users should not use Autocert. See the [cert-manager's guide](https:/
 
 ### Examples {#autocert-directory-examples}
 
-#### S3 Bucket {#s3-bucket}
+#### S3 Bucket
 
 An S3 bucket can be used as storage by using a URL like:
 

--- a/content/docs/reference/autocert.mdx
+++ b/content/docs/reference/autocert.mdx
@@ -174,7 +174,7 @@ autocert_dir: s3://your-bucket.s3.us-east-1.amazonaws.com/some/prefix
 
 Credentials are sourced from [the environment](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/config#EnvConfig).
 
-#### GCS Bucket {#gcs-bucket}
+#### GCS Bucket
 
 A Google Cloud Storage bucket can be used as storage by using a URL like:
 

--- a/content/docs/reference/branding/branding.md
+++ b/content/docs/reference/branding/branding.md
@@ -19,11 +19,11 @@ This reference covers all of Pomerium's branding settings:
 - [Logo URL](#logo-url)
 - [Error Message Header](#error-message-header)
 
-## Primary Color
+## Primary Color {#primary-color}
 
 **Primary Color** sets the primary color for the **Enterprise Console** and **Route Error Details** pages when users are in **Light Mode**.
 
-### How to configure
+### How to configure {#primary-color-how-to-configure}
 
 | **Type**   | **Default**                 |
 | :--------- | :-------------------------- |
@@ -31,17 +31,17 @@ This reference covers all of Pomerium's branding settings:
 
 See [Custom Branding / Errors](/docs/capabilities/branding) for more information.
 
-### Examples
+### Examples {#primary-color-examples}
 
 Customize **Primary Color** in the Console:
 
 ![Set custom primary color for light mode](./img/branding-primary-light-mode.png)
 
-## Secondary Color
+## Secondary Color {#secondary-color}
 
 **Secondary Color** sets the primary color for the **Enterprise Console** and **Route Error Details** pages when users are in **Light Mode**.
 
-### How to configure
+### How to configure {#secondary-color-how-to-configure}
 
 | **Type**   | **Default**                 |
 | :--------- | :-------------------------- |
@@ -49,17 +49,17 @@ Customize **Primary Color** in the Console:
 
 See [Custom Branding / Errors](/docs/capabilities/branding) for more information.
 
-### Examples
+### Examples {#secondary-color-examples}
 
 Customize **Secondary Color** in the Console:
 
 ![Set custom secondary color for light mode](./img/branding-secondary-light-mode.png)
 
-## Primary Color (Dark Mode)
+## Primary Color (Dark Mode) {#primary-color-dark-mode}
 
 **Primary Color (Dark Mode)** sets the primary color for the **Enterprise Console** and **Route Error Details** pages when users are in **Dark Mode**.
 
-### How to configure
+### How to configure {#primary-color-dark-mode-how-to-configure}
 
 | **Type**   | **Default**                 |
 | :--------- | :-------------------------- |
@@ -67,17 +67,17 @@ Customize **Secondary Color** in the Console:
 
 See [Custom Branding / Errors](/docs/capabilities/branding) for more information.
 
-### Examples
+### Examples {#primary-color-dark-mode-examples}
 
 Customize **Primary Color (Dark Mode)** in the Console:
 
 ![Set custom primary color for dark mode](./img/branding-dark-mode.png)
 
-## Secondary Color (Dark Mode)
+## Secondary Color (Dark Mode) {#secondary-color-dark-mode}
 
 **Secondary Color (Dark Mode)** sets the secondary color for the **Enterprise Console** and **Route Error Details** pages when users are in **Dark Mode**.
 
-### How to configure
+### How to configure {#secondary-color-dark-mode-how-to-configure}
 
 | **Type**   | **Default**                |
 | :--------- | :------------------------- |
@@ -85,17 +85,17 @@ Customize **Primary Color (Dark Mode)** in the Console:
 
 See [Custom Branding / Errors](/docs/capabilities/branding) for more information.
 
-### Examples
+### Examples {#secondary-color-dark-mode-examples}
 
 Customize **Secondary Color (Dark Mode)** in the Console:
 
 ![Set custom secondary color for dark mode](./img/branding-dark-mode-secondary.png)
 
-## Favicon URL
+## Favicon URL {#favicon-url}
 
 **Favicon URL** customizes the Favicon displayed in the Enterprise Console and Open Source endpoints.
 
-### How to configure
+### How to configure {#favicon-url-how-to-configure}
 
 | **Type** | **Default**      |
 | :------- | :--------------- |
@@ -103,17 +103,17 @@ Customize **Secondary Color (Dark Mode)** in the Console:
 
 See [Custom Branding / Errors](/docs/capabilities/branding) for more information.
 
-### Examples
+### Examples {#favicon-url-examples}
 
 Customize **Favicon URL** in the Console:
 
 ![Replace the Favicon in Pomerium Enterprise](./img/branding-favicon-url.png)
 
-## Logo URL
+## Logo URL {#logo-url}
 
 **Logo URL** customizes the logo displayed in the Enterprise Console and Open Source endpoints.
 
-### How to configure
+### How to configure {#logo-url-how-to-configure}
 
 | **Type** | **Default**   |
 | :------- | :------------ |
@@ -121,19 +121,19 @@ Customize **Favicon URL** in the Console:
 
 See [Custom Branding / Errors](/docs/capabilities/branding) for more information.
 
-### Examples
+### Examples {#logo-url-examples}
 
 Customize **Logo URL** in the Console:
 
 ![Replace the Logo in Pomerium Enterprise](./img/branding-custom-logo.png)
 
-## Error Message Header
+## Error Message Header {#error-message-header}
 
 **Error Message Header** customizes the error message that Pomerium displays on the Error Details page for `403 Unauthorized` errors.
 
 Error messages must be written in plain text or [Markdown](https://www.markdownguide.org/basic-syntax/), and are only applied to routes where the **Show Error Details** setting is enabled.
 
-### How to configure
+### How to configure {#error-message-header-how-to-configure}
 
 | **Type** | **Default**            |
 | :------- | :--------------------- |
@@ -141,7 +141,7 @@ Error messages must be written in plain text or [Markdown](https://www.markdowng
 
 See [Custom Branding / Errors](/docs/capabilities/branding) for more information.
 
-### Examples
+### Examples {#error-message-header-examples}
 
 Customize the **Error Message Header** in the Console:
 

--- a/content/docs/reference/certificates.mdx
+++ b/content/docs/reference/certificates.mdx
@@ -26,7 +26,7 @@ All certificates supplied to Pomerium must be in **PEM** format.
 
 :::
 
-## Certificates
+## Certificates {#certificates}
 
 **Certificates** are the X.509 _public-key_ and _private-key_ pair used to establish secure HTTP and gRPC connections. Any combination of these settings can be used together and are additive. You can also use any of these settings in conjunction with [`Autocert`](/docs/reference/autocert) to get OCSP stapling.
 
@@ -38,7 +38,7 @@ Pomerium will check your system's trust/key store for valid certificates first. 
 
 :::
 
-### How to configure
+### How to configure {#certificates-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -73,7 +73,7 @@ See Kubernetes [Ingress Configuration](/docs/deploy/k8s/reference#spec) for more
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#certificates-examples}
 
 Specify multiple certificates at once:
 
@@ -102,7 +102,7 @@ All certificates supplied to Pomerium must be in **PEM** format.
 
 :::
 
-## Certificate Authority
+## Certificate Authority {#certificate-authority}
 
 **Certificate Authority** defines a set of root certificate authorities (CAs) that Pomerium uses when communicating with other TLS-protected services.
 
@@ -118,7 +118,7 @@ Be sure to include the intermediary certificate.
 
 :::
 
-### How to configure
+### How to configure {#certificate-authority-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -143,7 +143,7 @@ Kubernetes does not support `certificate_authority`
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#certificate-authority-examples}
 
 ```yaml
 # config file key
@@ -153,13 +153,13 @@ certificate_authority: base64-encoded-string
 CERTIFICATE_AUTHORITY_FILE=/relative/file/location
 ```
 
-## Client Certificate Authority
+## Client Certificate Authority {#client-certificate-authority}
 
 **Client Certificate Authority** is the X.509 _public-key_ used to validate [mTLS client certificates](/docs/capabilities/mtls-clients).
 
 If not set, no client certificate will be required.
 
-### How to configure
+### How to configure {#client-certificate-authority-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -182,7 +182,7 @@ Kubernetes does not support `client_certificate_ca`
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#client-certificate-authority-examples}
 
 ```yaml
 client_ca: base64-encoded-string
@@ -192,13 +192,13 @@ CLIENT_CA=/relative/file/location
 CLIENT_CA_FILE=/relative/file/location
 ```
 
-## Client CRL
+## Client CRL {#client-crl}
 
 **Client CRL** is the [certificate revocation list](https://en.wikipedia.org/wiki/Certificate_revocation_list) (in **PEM** format) for client certificates.
 
 If not set, no CRL will be used.
 
-### How to configure
+### How to configure {#client-crl-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -221,7 +221,7 @@ Kubernetes does not support `client_crl`
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#client-crl-examples}
 
 ```yaml
 # config file key

--- a/content/docs/reference/cookies.mdx
+++ b/content/docs/reference/cookies.mdx
@@ -21,11 +21,11 @@ This reference covers all of Pomerium's **Cookies Settings**:
 - [Cookie Same Site](#cookie-samesite)
 - [Cookie Secret File](#cookie-secret-file)
 
-## Cookie Name
+## Cookie Name {#cookie-name}
 
 **Cookie Name** sets the name of the session cookie sent to clients.
 
-### How to configure
+### How to configure {#cookie-name-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -51,7 +51,7 @@ See Kubernetes [Cookie Reference](/docs/deploy/k8s/reference#cookie) for more in
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#cookie-name-examples}
 
 ```yaml
 # config file key
@@ -64,11 +64,11 @@ COOKIE_NAME=cookie_name
 cookie.name: cookie_name
 ```
 
-## Cookie Secret
+## Cookie Secret {#cookie-secret}
 
 **Cookie Secret** is the secret used to encrypt and sign session cookies. If you don't provide a cookie secret, Pomerium will generate one for you.
 
-### How to configure
+### How to configure {#cookie-secret-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -90,7 +90,7 @@ See Kubernetes [bootstrap secrets](/docs/deploy/k8s/configure#bootstrap-secrets)
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#cookie-secret-examples}
 
 Generate a random, base64-encoded key:
 
@@ -106,13 +106,13 @@ cookie_secret: tdkuWzUelRukP/6VYzopfh6kis7y5u5Ldl3MrIq9ZR0=
 COOKIE_SECRET=tdkuWzUelRukP/6VYzopfh6kis7y5u5Ldl3MrIq9ZR0=
 ```
 
-## Cookie Domain
+## Cookie Domain {#cookie-domain}
 
 **Cookie Domain** sets the scope of session cookies issued by Pomerium.
 
 If you specify the domain explicitly, then subdomains would also be included.
 
-### How to configure
+### How to configure {#cookie-domain-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -138,7 +138,7 @@ See Kubernetes [Cookie Reference](/docs/deploy/k8s/reference#cookie) for more in
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#cookie-domain-examples}
 
 ```yaml
 # config file key
@@ -151,7 +151,7 @@ COOKIE_DOMAIN=localhost.pomerium.io
 cookie.domain: localhost.pomerium.io
 ```
 
-## Cookie Secure
+## Cookie Secure {#cookie-secure}
 
 If true, **Cookie Secure** instructs browsers to only send user session cookies over HTTPS.
 
@@ -161,7 +161,7 @@ Setting this to `false` may result in session cookies being sent in clear text.
 
 :::
 
-### How to configure
+### How to configure {#cookie-secure-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -193,7 +193,7 @@ See Kubernetes [Cookie Reference](/docs/deploy/k8s/reference#cookie) for more in
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#cookie-secure-examples}
 
 ```yaml
 # config file key
@@ -206,11 +206,11 @@ COOKIE_SECURE=false
 cookie.secure: false
 ```
 
-## Cookie HTTP Only
+## Cookie HTTP Only {#cookie-http-only}
 
 If true, **Cookie HTTP Only** forbids JavaScript from accessing the cookie.
 
-### How to configure
+### How to configure {#cookie-http-only-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -242,7 +242,7 @@ See Kubernetes [Cookie Reference](/docs/deploy/k8s/reference#cookie) for more in
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#cookie-http-only-examples}
 
 ```yaml
 # config file key
@@ -255,11 +255,11 @@ COOKIE_HTTP_ONLY=false
 cookie.httpOnly: false
 ```
 
-## Cookie Expiration
+## Cookie Expiration {#cookie-expiration}
 
 **Cookie Expiration** sets the lifetime of session cookies. After this interval, users must reauthenticate.
 
-### How to configure
+### How to configure {#cookie-expiration-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -285,7 +285,7 @@ See Kubernetes [Cookie Reference](/docs/deploy/k8s/reference#cookie) for more in
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#cookie-expiration-examples}
 
 ```yaml
 # config file key
@@ -298,11 +298,11 @@ COOKIE_EXPIRATION=13h15m0.5s
 cookie.expiration: 13h15m0.5s
 ```
 
-## Cookie SameSite
+## Cookie SameSite {#cookie-samesite}
 
 **Cookie SameSite** sets the [SameSite](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) option for cookies.
 
-### How to configure
+### How to configure {#cookie-samesite-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -330,7 +330,7 @@ cookie.expiration: 13h15m0.5s
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#cookie-samesite-examples}
 
 ```yaml
 # config file key
@@ -343,11 +343,11 @@ COOKIE_SAME_SITE=Strict
 cookie.sameSite: None
 ```
 
-## Cookie Secret File
+## Cookie Secret File {#cookie-secret-file}
 
 **Cookie Secret File** sets the path to the file containing a secret used to encrypt and sign session cookies.
 
-### How to configure
+### How to configure {#cookie-secret-file-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -369,7 +369,7 @@ See Kubernetes [Secrets reference](/docs/deploy/k8s/reference#spec) for more inf
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#cookie-secret-file-examples}
 
 Generate a random, base64-encoded key:
 

--- a/content/docs/reference/cookies.mdx
+++ b/content/docs/reference/cookies.mdx
@@ -179,7 +179,7 @@ Configure **Cookie Secure** with the **HTTPS only** toggle button in the Console
 - **Checkmark** sets `cookie_secure` to `true`
 - **Empty** sets `cookie_secure` to `false`
 
-![Configure Cookie Secure in the Console](../img/cookies/cookie-settings.png)
+![Configure Cookie Secure in the Console](./img/cookies/cookie-settings.png)
 
 </TabItem>
 <TabItem value="Kubernetes" label="Kubernetes">
@@ -228,7 +228,7 @@ Configure **Cookie HTTP Only** with the **Javascript Security** toggle button in
 - **Checkmark** sets `cookie_http_only` to `true`
 - **Empty** sets `cookie_http_only` to `false`
 
-![Configure Cookie HTTP only in the Console](../img/cookies/cookie-settings.png)
+![Configure Cookie HTTP only in the Console](./img/cookies/cookie-settings.png)
 
 </TabItem>
 <TabItem value="Kubernetes" label="Kubernetes">
@@ -271,7 +271,7 @@ cookie.httpOnly: false
 </TabItem>
 <TabItem value="Enterprise" label="Enterprise">
 
-Set **Cookie Expiration** in the Console: ![Setting the cookie expiration time in Enterprise Console](../img/cookies/cookies-expiration.png)
+Set **Cookie Expiration** in the Console: ![Setting the cookie expiration time in Enterprise Console](./img/cookies/cookies-expiration.png)
 
 </TabItem>
 <TabItem value="Kubernetes" label="Kubernetes">

--- a/content/docs/reference/databroker.mdx
+++ b/content/docs/reference/databroker.mdx
@@ -21,11 +21,11 @@ This reference covers all of Pomerium's **Databroker Settings**:
 - [Databroker Storage TLS Skip Verify](#databroker-storage-tls-skip-verify)
 - [Databroker Storage Type](#databroker-storage-type)
 
-## Databroker Service
+## Databroker Service {#databroker-service}
 
 The **Databroker Service** stores user session data.
 
-### How to configure
+### How to configure {#databroker-service-how-to-configure}
 
 By default, the `databroker` service uses an in-memory databroker.
 
@@ -35,11 +35,11 @@ For an example implementation, see the in-memory database used by the databroker
 
 - [pkg/storage](https://github.com/pomerium/pomerium/tree/main/pkg/storage/inmemory)
 
-## Databroker Service URL
+## Databroker Service URL {#databroker-service-url}
 
 **Databroker Service URL** points to a data broker which is responsible for storing associated authorization context (for example, sessions, users, and user groups).
 
-### How to configure
+### How to configure {#databroker-service-url-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -62,7 +62,7 @@ For an example implementation, see the in-memory database used by the databroker
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#databroker-service-url-examples}
 
 ```yaml
 databroker_service_urls:
@@ -72,11 +72,11 @@ databroker_service_urls:
 DATABROKER_SERVICE_URL=https://databroker.corp.example.com
 ```
 
-## Databroker Internal Service URL
+## Databroker Internal Service URL {#databroker-internal-service-url}
 
 **Databroker Internal Service URL** overrides [`databroker_service_url`](/docs/reference/databroker) when determining the TLS Certificate for the Databroker service to listen with.
 
-### How to configure
+### How to configure {#databroker-internal-service-url-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -99,7 +99,7 @@ DATABROKER_SERVICE_URL=https://databroker.corp.example.com
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#databroker-internal-service-url-examples}
 
 ```yaml
 databroker_internal_service_urls:
@@ -109,11 +109,11 @@ databroker_internal_service_urls:
 DATABROKER_INTERNAL_SERVICE_URL=http://localhost:5443
 ```
 
-## Databroker Storage Certificate Authority
+## Databroker Storage Certificate Authority {#databroker-storage-certificate-authority}
 
 **Databroker Storage Certificate Authority** defines the set of root certificates used when verifying storage server connections.
 
-### How to configure
+### How to configure {#databroker-storage-certificate-authority-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -135,7 +135,7 @@ See Kubernetes [Storage reference](/docs/deploy/k8s/reference#storage) for more 
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#databroker-storage-certificate-authority-examples}
 
 ```yaml
 databroker_storage_ca_file: /relative/file/location
@@ -143,11 +143,11 @@ databroker_storage_ca_file: /relative/file/location
 DATABROKER_STORAGE_CA_FILE=/relative/file/location
 ```
 
-## Databroker Storage Certificate File
+## Databroker Storage Certificate File {#databroker-storage-certificate-file}
 
 **Databroker Storage Certificate File** stores the certificate used to connect to a storage backend.
 
-### How to configure
+### How to configure {#databroker-storage-certificate-file-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -169,7 +169,7 @@ See Kubernetes [Storage reference](/docs/deploy/k8s/reference#storage) for more 
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#databroker-storage-certificate-file-examples}
 
 ```yaml
 databroker_storage_cert_file: /relative/file/location
@@ -177,11 +177,11 @@ databroker_storage_cert_file: /relative/file/location
 DATABROKER_STORAGE_CERT_FILE=/relative/file/location
 ```
 
-## Databroker Storage Certificate Key File
+## Databroker Storage Certificate Key File {#databroker-storage-certificate-key-file}
 
 **Databroker Storage Certificate Key File** stores the certificate key used to connect to a storage backend.
 
-### How to configure
+### How to configure {#databroker-storage-certificate-key-file-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -203,18 +203,18 @@ See Kubernetes [Storage reference](/docs/deploy/k8s/reference#storage) for more 
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#databroker-storage-certificate-key-file-examples}
 
 ```yaml
 databroker_storage_key_file: /relative/file/location
 DATABROKER_STORAGE_KEY_FILE=/relative/file/location
 ```
 
-## Databroker Storage Connection String
+## Databroker Storage Connection String {#databroker-storage-connection-string}
 
 **Databroker Storage Connection String** sets the Postgres connection string that the Databroker service uses to connect to storage backend.
 
-### How to configure
+### How to configure {#databroker-storage-connection-string-how-to-configure}
 
 For Postgres, the following URL types are supported:
 
@@ -243,7 +243,7 @@ See Kubernetes [Storage reference](/docs/deploy/k8s/reference#storage) for more 
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#databroker-storage-connection-string-examples}
 
 ```yaml
 databroker_storage_connection_string: postgresql://postgres:postgres@database/postgres?sslmode=disable
@@ -257,11 +257,11 @@ When using multiple hosts make sure to specify `target_session_attrs=read-write`
 
 :::
 
-## Databroker Storage TLS Skip Verify
+## Databroker Storage TLS Skip Verify {#databroker-storage-tls-skip-verify}
 
 If **Databroker Storage TLS Skip Verify** is set, the TLS connection to the storage backend will not be verified.
 
-### How to configure
+### How to configure {#databroker-storage-tls-skip-verify-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -283,7 +283,7 @@ See Kubernetes [Storage reference](/docs/deploy/k8s/reference#storage) for more 
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#databroker-storage-tls-skip-verify-examples}
 
 ```yaml
 databroker_storage_tls_skip_verify: /relative/file/location
@@ -291,13 +291,13 @@ databroker_storage_tls_skip_verify: /relative/file/location
 DATABROKER_STORAGE_TLS_SKIP_VERIFY=/relative/file/location
 ```
 
-## Databroker Storage Type
+## Databroker Storage Type {#databroker-storage-type}
 
 **Databroker Storage Type** sets the backend storage that the Databroker server will use.
 
 Only `memory` and `postgres` are supported.
 
-### How to configure
+### How to configure {#databroker-storage-type-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -319,7 +319,7 @@ See Kubernetes [Storage reference](/docs/deploy/k8s/reference#storage) for more 
 </TabItem>
 </Tabs>
 
-### Example
+### Example {#databroker-storage-type-example}
 
 ```yaml
 databroker_storage_type: postgres

--- a/content/docs/reference/identity-provider-settings.mdx
+++ b/content/docs/reference/identity-provider-settings.mdx
@@ -31,17 +31,17 @@ See [**Self-Hosted Authenticate Service**](/docs/capabilities/self-hosted-authen
 
 :::
 
-## Supported identity providers
+## Supported identity providers {#supported-identity-providers}
 
 Pomerium supports all major single-sign on (SSO) identity providers. See the [identity providers](/docs/identity-providers) page for a list of supported SSO providers and guides to integrate each provider with Pomerium.
 
 Pomerium can also integrate with any identity provider that supports OAuth 2.0 and OIDC protocols.
 
-## Identity Provider Client ID
+## Identity Provider Client ID {#identity-provider-client-id}
 
 **Identity Provider Client ID** is the OAuth 2.0 Client Identifier retrieved from your identity provider. See your identity provider's documentation, and Pomerium's [identity provider](/docs/identity-providers/) docs for details.
 
-### How to configure
+### How to configure {#identity-provider-client-id-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -65,7 +65,7 @@ See [`identityProvider.secret`](/docs/deploy/k8s/reference#identityprovider)
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#identity-provider-client-id-examples}
 
 ```yaml
 # config file key
@@ -75,11 +75,11 @@ idp_client_id: idp_client_id
 IDP_CLIENT_ID=idp_client_id
 ```
 
-## Identity Provider Client Secret
+## Identity Provider Client Secret {#identity-provider-client-secret}
 
 **Identity Provider Client Secret** is the OAuth 2.0 Secret Identifier retrieved from your identity provider. See your identity provider's documentation, and Pomerium's [identity provider](/docs/identity-providers/) docs for details.
 
-### How to configure
+### How to configure {#identity-provider-client-secret-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -103,7 +103,7 @@ See [`identityProvider.secret`](/docs/deploy/k8s/reference#identityprovider) for
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#identity-provider-client-secret-examples}
 
 ```yaml
 # config file key
@@ -113,13 +113,13 @@ idp_client_secret: idp_client_secret
 IDP_CLIENT_SECRET=idp_client_secret
 ```
 
-## Identity Provider Client Secret File
+## Identity Provider Client Secret File {#identity-provider-client-secret-file}
 
 **Identity Provider Client Secret File** is the OAuth 2.0 Secret Identifier retrieved from your identity provider. See your identity provider's documentation, and Pomerium's [identity provider](/docs/identity-providers/) docs for details.
 
 The identity provider client secret file points to a file containing the secret. This is useful when deploying in environments that provide secret management like [Docker Swarm](https://docs.docker.com/engine/swarm/secrets/).
 
-### How to configure
+### How to configure {#identity-provider-client-secret-file-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -141,7 +141,7 @@ See [`identityProvider.secret`](/docs/deploy/k8s/reference#identityprovider) for
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#identity-provider-client-secret-file-examples}
 
 ```yaml
 # config file key
@@ -151,7 +151,7 @@ idp_client_secret_file: '/run/secrets/POMERIUM_CLIENT_SECRET'
 IDP_CLIENT_SECRET_FILE='/run/secrets/POMERIUM_CLIENT_SECRET'
 ```
 
-## Identity Provider Name
+## Identity Provider Name {#identity-provider-name}
 
 **Identity Provider Name** is the short-hand name of a built-in OpenID Connect (OIDC) identity provider used for authentication.
 
@@ -171,7 +171,7 @@ The supported values for this setting are:
 - `onelogin`
 - `ping`
 
-### How to configure
+### How to configure {#identity-provider-name-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -195,7 +195,7 @@ See [`identityProvider.provider`](/docs/deploy/k8s/reference#identityprovider) f
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#identity-provider-name-examples}
 
 ```yaml
 # config file key
@@ -205,11 +205,11 @@ idp_provider: auth0
 IDP_PROVIDER=github
 ```
 
-## Identity Provider Request Params
+## Identity Provider Request Params {#identity-provider-request-params}
 
 **Identity Provider Request Params** lists the parameters you want to include as part of a sign-in request using the OAuth 2.0 code flow.
 
-### How to configure
+### How to configure {#identity-provider-request-params-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -233,7 +233,7 @@ See Kubernetes [`identityProvider.requestParams` and `identityProvider.requestPa
 </TabItem>
 </Tabs>
 
-### Defaults
+### Defaults {#identity-provider-request-params-defaults}
 
 Pomerium includes some default parameters for specific identity providers. Setting this configuration option will replace these default parameters. To remove the default parameters entirely, set this option to an empty map\* (e.g. `idp_request_params: {}` in the config file).
 
@@ -249,7 +249,7 @@ Pomerium includes some default parameters for specific identity providers. Setti
 
 :::
 
-### Examples
+### Examples {#identity-provider-request-params-examples}
 
 ```yaml
 # config file key
@@ -272,7 +272,7 @@ For more information, see:
 - [Microsoft Azure Request params](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-authorization-code)
 - [Google Authentication URI parameters](https://developers.google.com/identity/protocols/oauth2/openid-connect)
 
-## Identity Provider Scopes
+## Identity Provider Scopes {#identity-provider-scopes}
 
 **Identity Provider Scopes** correspond to access privilege scopes as defined in [Section 3.3](https://www.rfc-editor.org/rfc/rfc6749#section-3.3) of OAuth 2.0 RFC6749\.
 
@@ -286,7 +286,7 @@ Some providers, like Amazon Cognito, _do not_ support the `offline_access` scope
 
 :::
 
-### How to configure
+### How to configure {#identity-provider-scopes-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -310,7 +310,7 @@ See Kubernetes [`identityProvider.scopes`](/docs/deploy/k8s/reference#identitypr
 </TabItem>
 </Tabs>
 
-### Defaults
+### Defaults {#identity-provider-scopes-defaults}
 
 | **Defaults**     |
 | :--------------- |
@@ -319,7 +319,7 @@ See Kubernetes [`identityProvider.scopes`](/docs/deploy/k8s/reference#identitypr
 | `email`          |
 | `offline_access` |
 
-### Examples
+### Examples {#identity-provider-scopes-examples}
 
 ```yaml
 # config file key
@@ -329,13 +329,13 @@ idp_scopes: openid, profile, offline_access, email
 IDP_SCOPES=openid, profile, offline_access, email
 ```
 
-## Identity Provider URL
+## Identity Provider URL {#identity-provider-url}
 
 **Identity Provider URL** is the base path to an identity provider's [OpenID connect discovery document](https://openid.net/specs/openid-connect-discovery-1_0.html). An example Azure URL would be `https://login.microsoftonline.com/common/v2.0` for [their discovery document](https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration).
 
 "Base path" is defined as the section of the URL to the discovery document up to (but not including) `/.well-known/openid-configuration`.
 
-### How to configure
+### How to configure {#identity-provider-url-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
@@ -359,7 +359,7 @@ See Kubernetes [`identityProvider.url`](/docs/deploy/k8s/reference#identityprovi
 </TabItem>
 </Tabs>
 
-### Examples
+### Examples {#identity-provider-url-examples}
 
 ```yaml
 # config file key
@@ -369,13 +369,13 @@ idp_provider_url: 'https://awesome-company.auth0.com'
 IDP_PROVIDER_URL='https://awesome-company.auth0.com'
 ```
 
-## Identity Provider Polling Min/Max Delay
+## Identity Provider Polling Min/Max Delay {#identity-provider-polling-minmax-delay}
 
 Identity provider **Polling Minimum Delay** and **Polling Maximum Delay** settings define the minimum and maximum delay times between requests to the identity provider data source.
 
 A job starts with the **minimum delay** intervals. If the job fails to complete within the minimum delay period, it will be interrupted and the job will restart. If the job is interrupted due to timeout or an error, it will restart with increasing intervals up to the **maximum delay** period.
 
-### How to configure
+### How to configure {#identity-provider-polling-minmax-delay-how-to-configure}
 
 Set the **Identity Provider Max/Min Delay** settings in the Console:
 
@@ -387,7 +387,7 @@ The `minimum_delay` and `maximum_delay` settings are an [Enterprise Console](htt
 
 :::
 
-### Defaults
+### Defaults {#identity-provider-polling-minmax-delay-defaults}
 
 While minimum and maximum polling time defaults are set for any Console installation, the required durations will vary depending on your identity provider and the size or your organization's directory.
 
@@ -395,17 +395,17 @@ If the job fails before completing, increase the minimum and maximum durations u
 
 Keep in mind that large directories may take several hours to complete.
 
-### Monitor directory sync
+### Monitor directory sync {#monitor-directory-sync}
 
-To determine the appropriate durations required to sync your directory, check your Console logs and the **Last Error** and **Request Duration** sections of the Console GUI to determine the source of the failure.
+To determine the appropriate durations required to sync your directory, check your Console logs and the **Last Error** and **Request Duration** sections of the Console GUI.
 
-#### Last error
+#### Last error {#last-error}
 
 You can check if an error interrupted a job by checking **External Data** > **Last Error**.
 
 ![Check for external data sync errors](./img/idp_options/external-data-last-error.png)
 
-#### Request duration
+#### Request duration {#request-duration}
 
 You can also check **External Data** > **Metrics** to view request durations.
 


### PR DESCRIPTION
This PR adds [explicit heading IDs](https://docusaurus.io/docs/next/markdown-features/toc#heading-ids) to the following reference settings pages:
- Autocert settings
- Branding settings
- Certificates settings
- Cookies settings
- Databroker settings
- IdP settings

Resolves #770