### PR TITLE
Docs: removes invalid syntax from example

### DIFF
--- a/content/docs/reference/identity-provider-settings.mdx
+++ b/content/docs/reference/identity-provider-settings.mdx
@@ -216,7 +216,7 @@ IDP_PROVIDER=github
 
 | **Config file keys** | **Environment variables** | **Type** | **Usage** |
 | :-- | :-- | :-- | :-- |
-| `idp_request_params` | `IDP_REQUEST_PARAMS` | `string` (map of key-value pairs) | **optional** |
+| `idp_request_params` | `n/a` | `string` (map of key-value pairs) | **optional** |
 
 </TabItem>
 <TabItem value="Enterprise" label="Enterprise">

--- a/content/docs/reference/identity-provider-settings.mdx
+++ b/content/docs/reference/identity-provider-settings.mdx
@@ -254,9 +254,9 @@ Pomerium includes some default parameters for specific identity providers. Setti
 ```yaml
 # config file key
 idp_request_params:
-    client_id: client_id
-    response_type: response_type
-    redirect_uri: redirect_uri
+  client_id: client_id
+  response_type: response_type
+  redirect_uri: redirect_uri
 ```
 
 For more information, see:

--- a/content/docs/reference/identity-provider-settings.mdx
+++ b/content/docs/reference/identity-provider-settings.mdx
@@ -257,12 +257,6 @@ idp_request_params:
     client_id: client_id
     response_type: response_type
     redirect_uri: redirect_uri
-
-# environment variable
-IDP_REQUEST_PARAMS=
-    client_id: client_id
-    response_type: response_type
-    redirect_uri: redirect_uri
 ```
 
 For more information, see:


### PR DESCRIPTION
Fixes https://github.com/pomerium/pomerium/issues/4342

@kenjenkins do you think it would be helpful to add a temporary admonition below the example until you've had a chance to investigate the issue?