### PR TITLE
Docs: add k8s proxy protocol

### DIFF
--- a/content/docs/deploy/k8s/ingress.md
+++ b/content/docs/deploy/k8s/ingress.md
@@ -347,6 +347,16 @@ For performance reasons, by default, Pomerium routes traffic directly to the ref
 ingress.pomerium.io/service_proxy_upstream: 'true'
 ```
 
+### HAProxy Proxy Protocol
+
+Setting **Use Proxy Protocol** will configure Pomerium to require the [HAProxy proxy protocol](https://www.haproxy.org/download/1.9/doc/proxy-protocol.txt) on incoming connections. Versions 1 and 2 of the protocol are supported.
+
+To enforce **Use Proxy Protocol**, set the following annotation to the Ingress:
+
+```yaml
+ingress.pomerium.io/use_proxy_protocol: 'true'
+```
+
 ### Load Balancing
 
 Unless you disabled direct traffic to Endpoints, Pomerium would load balance the requests to the upstream endpoints. See the [Load Balancing](/docs/capabilities/load-balancing) guide for details, and use relevant Ingress annotations to fine tune load balancing and health checks.

--- a/content/docs/deploy/k8s/ingress.md
+++ b/content/docs/deploy/k8s/ingress.md
@@ -347,20 +347,6 @@ For performance reasons, by default, Pomerium routes traffic directly to the ref
 ingress.pomerium.io/service_proxy_upstream: 'true'
 ```
 
-### HAProxy Proxy Protocol
-
-Setting **Use Proxy Protocol** will configure Pomerium to require the [HAProxy proxy protocol](https://www.haproxy.org/download/1.9/doc/proxy-protocol.txt) on incoming connections. Versions 1 and 2 of the protocol are supported.
-
-| **Annotation name**  | **Type**  | **Usage**    | **Default** |
-| :------------------- | :-------- | :----------- | :---------- |
-| `use_proxy_protocol` | `boolean` | **optional** | `false`     |
-
-To enforce **Use Proxy Protocol**, set the following annotation to the Ingress:
-
-```yaml
-ingress.pomerium.io/use_proxy_protocol: 'true'
-```
-
 ### Load Balancing
 
 Unless you disabled direct traffic to Endpoints, Pomerium would load balance the requests to the upstream endpoints. See the [Load Balancing](/docs/capabilities/load-balancing) guide for details, and use relevant Ingress annotations to fine tune load balancing and health checks.

--- a/content/docs/deploy/k8s/ingress.md
+++ b/content/docs/deploy/k8s/ingress.md
@@ -351,9 +351,9 @@ ingress.pomerium.io/service_proxy_upstream: 'true'
 
 Setting **Use Proxy Protocol** will configure Pomerium to require the [HAProxy proxy protocol](https://www.haproxy.org/download/1.9/doc/proxy-protocol.txt) on incoming connections. Versions 1 and 2 of the protocol are supported.
 
-| **Annotation name** | **Type** | **Usage** | **Default** |
-| :-- | :-- | :-- | :-- |
-| `use_proxy_protocol` | `boolean` | **optional** | `false` |
+| **Annotation name**  | **Type**  | **Usage**    | **Default** |
+| :------------------- | :-------- | :----------- | :---------- |
+| `use_proxy_protocol` | `boolean` | **optional** | `false`     |
 
 To enforce **Use Proxy Protocol**, set the following annotation to the Ingress:
 

--- a/content/docs/deploy/k8s/ingress.md
+++ b/content/docs/deploy/k8s/ingress.md
@@ -351,6 +351,10 @@ ingress.pomerium.io/service_proxy_upstream: 'true'
 
 Setting **Use Proxy Protocol** will configure Pomerium to require the [HAProxy proxy protocol](https://www.haproxy.org/download/1.9/doc/proxy-protocol.txt) on incoming connections. Versions 1 and 2 of the protocol are supported.
 
+| **Annotation name** | **Type** | **Usage** | **Default** |
+| :-- | :-- | :-- | :-- |
+| `use_proxy_protocol` | `boolean` | **optional** | `false` |
+
 To enforce **Use Proxy Protocol**, set the following annotation to the Ingress:
 
 ```yaml

--- a/content/docs/deploy/k8s/reference.md
+++ b/content/docs/deploy/k8s/reference.md
@@ -4,10 +4,10 @@ sidebar_label: Reference
 description: Reference for Pomerium settings in Kubernetes deployments.
 ---
 
-Pomerium-specific parameters should be configured via the `ingress.pomerium.io/Pomerium` CRD.
-The default Pomerium deployment is listening to the CRD `global`, that may be customized via command line parameters.
+Pomerium-specific parameters should be configured via the `ingress.pomerium.io/Pomerium` CRD. The default Pomerium deployment is listening to the CRD `global`, that may be customized via command line parameters.
 
 Pomerium posts updates to the CRD <a href="#status">`/status`</a>:
+
 ```shell
 kubectl describe pomerium
 ```
@@ -230,8 +230,6 @@ PomeriumSpec defines Pomerium-specific configuration parameters.
     </tbody>
 </table>
 
-
-
 ### `authenticate`
 
 Authenticate sets authenticate service parameters. If not specified, a Pomerium-hosted authenticate service would be used.
@@ -280,8 +278,6 @@ Authenticate sets authenticate service parameters. If not specified, a Pomerium-
     
     </tbody>
 </table>
-
-
 
 ### `cookie`
 
@@ -393,8 +389,6 @@ Cookie defines Pomerium session cookie options.
     
     </tbody>
 </table>
-
-
 
 ### `identityProvider`
 
@@ -546,8 +540,6 @@ IdentityProvider configure single-sign-on authentication and user identity detai
     </tbody>
 </table>
 
-
-
 ### `postgres`
 
 Postgres specifies PostgreSQL database connection parameters
@@ -616,8 +608,6 @@ Postgres specifies PostgreSQL database connection parameters
     
     </tbody>
 </table>
-
-
 
 ### `redis`
 
@@ -704,8 +694,6 @@ Redis defines REDIS connection parameters
     </tbody>
 </table>
 
-
-
 ### `refreshDirectory`
 
 RefreshDirectory is no longer supported, please see <a href="https://docs.pomerium.com/docs/overview/upgrading#idp-directory-sync">Upgrade Guide</a>.
@@ -756,8 +744,6 @@ RefreshDirectory is no longer supported, please see <a href="https://docs.pomeri
     </tbody>
 </table>
 
-
-
 ### `storage`
 
 Storage defines persistent storage for sessions and other data. See <a href="https://www.pomerium.com/docs/topics/data-storage">Storage</a> for details. If no storage is specified, Pomerium would use a transient in-memory storage (not recommended for production).
@@ -803,8 +789,6 @@ Storage defines persistent storage for sessions and other data. See <a href="htt
     
     </tbody>
 </table>
-
-
 
 ### `timeouts`
 
@@ -875,8 +859,6 @@ Timeout specifies the <a href="https://www.pomerium.com/docs/reference/global-ti
     </tbody>
 </table>
 
-
-
 ## Status
 
 PomeriumStatus represents configuration and Ingress status.
@@ -922,8 +904,6 @@ PomeriumStatus represents configuration and Ingress status.
     
     </tbody>
 </table>
-
-
 
 ### `ingress`
 
@@ -1020,8 +1000,6 @@ ResourceStatus represents the outcome of the latest attempt to reconcile relevan
     </tbody>
 </table>
 
-
-
 ### `settingsStatus`
 
 SettingsStatus represent most recent main configuration reconciliation status.
@@ -1116,6 +1094,3 @@ SettingsStatus represent most recent main configuration reconciliation status.
     
     </tbody>
 </table>
-
-
-

--- a/content/docs/reference/use-proxy-protocol.mdx
+++ b/content/docs/reference/use-proxy-protocol.mdx
@@ -38,7 +38,7 @@ Setting **Use Proxy Protocol** will configure Pomerium to require the [HAProxy p
 | :-- | :-- | :-- | :-- |
 | `ingress.pomerium.io/use_proxy_protocol` | `boolean` | **optional** | `false` |
 
-See Kubernetes [Ingress](/docs/deploy/k8s/ingress#haproxy-proxy-protocol) for more information.
+See Kubernetes [Ingress](/docs/deploy/k8s/ingress) for more information.
 
 </TabItem>
 </Tabs>

--- a/content/docs/reference/use-proxy-protocol.mdx
+++ b/content/docs/reference/use-proxy-protocol.mdx
@@ -38,7 +38,7 @@ Setting **Use Proxy Protocol** will configure Pomerium to require the [HAProxy p
 | :-- | :-- | :-- | :-- |
 | `ingress.pomerium.io/use_proxy_protocol` | `boolean` | **optional** | `false` |
 
-See Kubernetes [Ingress](/docs/deploy/k8s/ingress) for more information.
+See Kubernetes [Ingress](/docs/deploy/k8s/ingress#haproxy-proxy-protocol) for more information.
 
 </TabItem>
 </Tabs>

--- a/content/docs/reference/use-proxy-protocol.mdx
+++ b/content/docs/reference/use-proxy-protocol.mdx
@@ -34,7 +34,11 @@ Setting **Use Proxy Protocol** will configure Pomerium to require the [HAProxy p
 </TabItem>
 <TabItem value="Kubernetes" label="Kubernetes">
 
-Kubernetes does not support `use_proxy_protocol`
+| **Annotation name** | **Type** | **Usage** | **Default** |
+| :-- | :-- | :-- | :-- |
+| `ingress.pomerium.io/use_proxy_protocol` | `boolean` | **optional** | `false` |
+
+See Kubernetes [Ingress](/docs/deploy/k8s/ingress) for more information.
 
 </TabItem>
 </Tabs>

--- a/content/docs/reference/use-proxy-protocol.mdx
+++ b/content/docs/reference/use-proxy-protocol.mdx
@@ -34,9 +34,9 @@ Setting **Use Proxy Protocol** will configure Pomerium to require the [HAProxy p
 </TabItem>
 <TabItem value="Kubernetes" label="Kubernetes">
 
-| **Name** | **Type** | **Usage** | **Default** |
-| :-- | :-- | :-- | :-- |
-| `useProxyProtocol` | `boolean` | **optional** | `false` |
+| **Name**           | **Type**  | **Usage**    | **Default** |
+| :----------------- | :-------- | :----------- | :---------- |
+| `useProxyProtocol` | `boolean` | **optional** | `false`     |
 
 See Kubernetes [Reference](/docs/deploy/k8s/reference#spec) for more information.
 

--- a/content/docs/reference/use-proxy-protocol.mdx
+++ b/content/docs/reference/use-proxy-protocol.mdx
@@ -34,11 +34,11 @@ Setting **Use Proxy Protocol** will configure Pomerium to require the [HAProxy p
 </TabItem>
 <TabItem value="Kubernetes" label="Kubernetes">
 
-| **Annotation name** | **Type** | **Usage** | **Default** |
+| **Name** | **Type** | **Usage** | **Default** |
 | :-- | :-- | :-- | :-- |
-| `ingress.pomerium.io/use_proxy_protocol` | `boolean` | **optional** | `false` |
+| `useProxyProtocol` | `boolean` | **optional** | `false` |
 
-See Kubernetes [Ingress](/docs/deploy/k8s/ingress) for more information.
+See Kubernetes [Reference](/docs/deploy/k8s/reference#spec) for more information.
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
Resolves #797 

This PR adds the K8s annotation to `/docs/reference/use-proxy-protocol` and to `/docs/deploy/k8s/ingress`.  @wasaga Not sure about the location for this entry on the Ingress page; please let me know if it should go somewhere else. 

