### PR TITLE
update Go SDK example

### DIFF
--- a/content/examples/go-sdk/go-app.md
+++ b/content/examples/go-sdk/go-app.md
@@ -1,5 +1,5 @@
 ---
-# cSpell:ignore gopkg Fatalln Fprintln Fprintf struct
+# cSpell:ignore Fatalln Fprintln Fprintf struct
 ---
 
 ```go
@@ -11,20 +11,18 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/hashicorp/golang-lru"
+	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/pomerium/sdk-go"
-	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 func main() {
 	verifier, err := sdk.New(&sdk.Options{
 		Expected: &jwt.Expected{
-            // Replace the following with the domain for your service:
+			// Replace the following with the domain for your service:
 			Issuer: "sdk-example.localhost.pomerium.io",
 			Audience: jwt.Audience([]string{
 				"sdk-example.localhost.pomerium.io"}),
 		},
-		Datastore: newCache(),
 	})
 	if err != nil {
 		log.Fatalln(err)
@@ -45,22 +43,5 @@ func (handler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	}
 
 	fmt.Fprintf(res, "verified user identity (email %s)\n", id.Email)
-}
-
-type cache struct {
-	lru *lru.Cache
-}
-
-func newCache() cache {
-       lru, _ := lru.New(10)
-       return cache{lru}
-}
-
-func (c cache) Get(key interface{}) (value interface{}, ok bool) {
-       return c.lru.Get(key)
-}
-
-func (c cache) Add(key, value interface{}) {
-       c.lru.Add(key, value)
 }
 ```


### PR DESCRIPTION
Update the Go SDK example to account for API changes in the v0.0.9 Go SDK release.