### PR TITLE
Docs: changes /audit-log entry to object in sidebars.js

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -63,7 +63,11 @@ const sidebars = {
         'docs/capabilities/ppl',
         'docs/capabilities/routing',
         // secondary capabilities
-        'docs/capabilities/audit-logs',
+        {
+          type: 'doc',
+          label: 'Audit Logs',
+          id: 'docs/capabilities/audit-logs'
+        },
         'docs/capabilities/hosted-authenticate-service',
         'docs/capabilities/self-hosted-authenticate-service',
         'docs/capabilities/jwt-verification',


### PR DESCRIPTION
Fixes #827 

SEMrush detected markup issues on a lot of docs pages. The error claims there are issues with Breadcrumbs. This PR is a test to see if changing the URL path to an object in sidebars.js will fix the issue. If the fix works, we will apply it to all flagged pages with the issue. 