### PR TITLE
PPL: fix Device Matcher example

### DIFF
--- a/content/docs/capabilities/ppl.mdx
+++ b/content/docs/capabilities/ppl.mdx
@@ -165,7 +165,6 @@ Compare to a policy that only allows a set of specific devices:
     or:
       - device:
           is: "5Vn3...C1RS"
-    or:
       - device:
           is: "GAtL...doqu"
 ```


### PR DESCRIPTION
Remove an extra "or" from the Device Matcher example.

I think trying to use this example snippet as is will lead to an error like this:
> failed to read config: While parsing config: yaml: unmarshal errors:
>  line 84: mapping key "or" already defined at line 81