### PR TITLE
Docs: updates deprecated idp refresh directory settings to point to upgrade guide

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -362,7 +362,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/reference/identity-provider-request-params /docs/reference/identity-provider-settings#identity-provider-request-params
 /docs/reference/identity-provider-scopes /docs/reference/identity-provider-settings#identity-provider-scopes
 /docs/reference/identity-provider-url /docs/reference/identity-provider-settings#identity-provider-url
-/docs/reference/identity-provider-refresh-directory-settings /docs/reference/identity-provider-settings#identity-provider-refresh-directory-settings
+/docs/reference/identity-provider-refresh-directory-settings https://0-21-0.docs.pomerium.com/docs/releases/upgrading#idp-directory-sync
 
 # Certificates
 /docs/reference/certificate-authority /docs/reference/certificates#certificate-authority

--- a/static/_redirects
+++ b/static/_redirects
@@ -362,7 +362,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/reference/identity-provider-request-params /docs/reference/identity-provider-settings#identity-provider-request-params
 /docs/reference/identity-provider-scopes /docs/reference/identity-provider-settings#identity-provider-scopes
 /docs/reference/identity-provider-url /docs/reference/identity-provider-settings#identity-provider-url
-/docs/reference/identity-provider-refresh-directory-settings https://0-21-0.docs.pomerium.com/docs/releases/upgrading#idp-directory-sync
+/docs/reference/identity-provider-refresh-directory-settings /docs/releases/upgrading#idp-directory-sync
 
 # Certificates
 /docs/reference/certificate-authority /docs/reference/certificates#certificate-authority


### PR DESCRIPTION
In this [PR](https://github.com/pomerium/documentation/pull/853), the `idp_refresh_directory_settings` points to the new idp reference page. This particular setting has been deprecated and should point to the v19 upgrade guide, where an explanation for the changes and instructions to upgrade are included. 