### PR TITLE
Docs: terminate long running connections

### DIFF
--- a/content/docs/capabilities/tcp.mdx
+++ b/content/docs/capabilities/tcp.mdx
@@ -81,6 +81,20 @@ localhost:52046> keys *
 localhost:52046>
 ```
 
+:::info long-running socket connection behavior
+
+**When you open long-running socket connections in Pomerium, the connections aren’t terminated with the user session.**
+
+Socket connections include **TCP connections** and long-running **Websocket** and  **gRPC connections** (HTTP streams).
+
+When you offboard a user and remove them from your identity provider directory, Pomerium stops refreshing the user’s HTTP sessions. As a result, their requests will no longer be authorized.
+
+However, Pomerium doesn’t terminate a user’s long-running, streaming connections when you remove them from your identity provider directory.
+
+At the moment, the best way to terminate these connections is to restart your Pomerium proxy service.
+
+:::
+
 ## Advanced Usage
 
 ### Listen Configuration

--- a/content/docs/capabilities/tcp.mdx
+++ b/content/docs/capabilities/tcp.mdx
@@ -85,7 +85,7 @@ localhost:52046>
 
 **When you open long-running socket connections in Pomerium, the connections aren’t terminated with the user session.**
 
-Socket connections include **TCP connections** and long-running **Websocket** and  **gRPC connections** (HTTP streams).
+Socket connections include **TCP connections** and long-running **Websocket** and **gRPC connections** (HTTP streams).
 
 When you offboard a user and remove them from your identity provider directory, Pomerium stops refreshing the user’s HTTP sessions. As a result, their requests will no longer be authorized.
 

--- a/content/docs/capabilities/tcp/client.mdx
+++ b/content/docs/capabilities/tcp/client.mdx
@@ -122,6 +122,20 @@ KDE's documentation covers auto-starting applications well: see [System Settings
 
 ![A new connection to an SSH gateway](examples/img/desktop/demo-new-connection.png)
 
+:::info long-running socket connection behavior
+
+**When you open long-running socket connections in Pomerium, the connections aren’t terminated with the user session.**
+
+Socket connections include **TCP connections** and long-running **Websocket** and  **gRPC connections** (HTTP streams).
+
+When you offboard a user and remove them from your identity provider directory, Pomerium stops refreshing the user’s HTTP sessions. As a result, their requests will no longer be authorized.
+
+However, Pomerium doesn’t terminate a user’s long-running, streaming connections when you remove them from your identity provider directory.
+
+At the moment, the best way to terminate these connections is to restart your Pomerium proxy service.
+
+:::
+
 **Name**: A local name for the route.
 
 **Destination**: Matches the [From](/docs/reference/routes/from) value of the route, without the protocol. Always include the port specified in the route, and do not include the `https://` protocol.

--- a/content/docs/capabilities/tcp/client.mdx
+++ b/content/docs/capabilities/tcp/client.mdx
@@ -126,7 +126,7 @@ KDE's documentation covers auto-starting applications well: see [System Settings
 
 **When you open long-running socket connections in Pomerium, the connections aren’t terminated with the user session.**
 
-Socket connections include **TCP connections** and long-running **Websocket** and  **gRPC connections** (HTTP streams).
+Socket connections include **TCP connections** and long-running **Websocket** and **gRPC connections** (HTTP streams).
 
 When you offboard a user and remove them from your identity provider directory, Pomerium stops refreshing the user’s HTTP sessions. As a result, their requests will no longer be authorized.
 

--- a/content/docs/capabilities/tcp/examples/git.mdx
+++ b/content/docs/capabilities/tcp/examples/git.mdx
@@ -10,6 +10,20 @@ import TabItem from '@theme/TabItem';
 
 When hosting a self-hosted Git server like [GitLab](/docs/guides/gitlab) behind Pomerium, you can protect desktop client access to the source code with the same identity-aware access as the web interface using an encrypted TCP tunnel.
 
+:::info long-running socket connection behavior
+
+**When you open long-running socket connections in Pomerium, the connections aren’t terminated with the user session.**
+
+Socket connections include **TCP connections** and long-running **Websocket** and  **gRPC connections** (HTTP streams).
+
+When you offboard a user and remove them from your identity provider directory, Pomerium stops refreshing the user’s HTTP sessions. As a result, their requests will no longer be authorized.
+
+However, Pomerium doesn’t terminate a user’s long-running, streaming connections when you remove them from your identity provider directory.
+
+At the moment, the best way to terminate these connections is to restart your Pomerium proxy service.
+
+:::
+
 :::tip
 This example assumes you've already [created a TCP route](/docs/capabilities/tcp#configure-routes) for this service.
 :::

--- a/content/docs/capabilities/tcp/examples/ms-sql.mdx
+++ b/content/docs/capabilities/tcp/examples/ms-sql.mdx
@@ -12,6 +12,20 @@ import TabItem from '@theme/TabItem';
 
 This document explains how to connect to a Microsoft SQL database through an encrypted TCP tunnel. We use the `sqlcmd` command line utility, but the same tunnel can be used by GUI tools.
 
+:::info long-running socket connection behavior
+
+**When you open long-running socket connections in Pomerium, the connections aren’t terminated with the user session.**
+
+Socket connections include **TCP connections** and long-running **Websocket** and  **gRPC connections** (HTTP streams).
+
+When you offboard a user and remove them from your identity provider directory, Pomerium stops refreshing the user’s HTTP sessions. As a result, their requests will no longer be authorized.
+
+However, Pomerium doesn’t terminate a user’s long-running, streaming connections when you remove them from your identity provider directory.
+
+At the moment, the best way to terminate these connections is to restart your Pomerium proxy service.
+
+:::
+
 :::tip
 This example assumes you've already [created a TCP route](/docs/capabilities/tcp#configure-routes) for this service.
 :::

--- a/content/docs/capabilities/tcp/examples/mysql.mdx
+++ b/content/docs/capabilities/tcp/examples/mysql.mdx
@@ -10,6 +10,20 @@ import TabItem from '@theme/TabItem';
 
 This document explains how to connect to a MySQL or MariaDB database through an encrypted TCP tunnel. We use the `mysql` command line utility, but the same tunnel can be used by GUI tools.
 
+:::info long-running socket connection behavior
+
+**When you open long-running socket connections in Pomerium, the connections aren’t terminated with the user session.**
+
+Socket connections include **TCP connections** and long-running **Websocket** and  **gRPC connections** (HTTP streams).
+
+When you offboard a user and remove them from your identity provider directory, Pomerium stops refreshing the user’s HTTP sessions. As a result, their requests will no longer be authorized.
+
+However, Pomerium doesn’t terminate a user’s long-running, streaming connections when you remove them from your identity provider directory.
+
+At the moment, the best way to terminate these connections is to restart your Pomerium proxy service.
+
+:::
+
 :::tip
 This example assumes you've already [created a TCP route](/docs/capabilities/tcp#configure-routes) for this service.
 :::

--- a/content/docs/capabilities/tcp/examples/rdp.mdx
+++ b/content/docs/capabilities/tcp/examples/rdp.mdx
@@ -11,6 +11,20 @@ import TunnelExample from '@site/content/examples/tcp/pomerium-tunnel.sh.md'
 
 Remote Desktop Protocol (**RDP**) is a standard for using a desktop computer remotely. It was released by Microsoft and is most commonly used to access Windows systems, but can be used for macOS and Linux systems as well.
 
+:::info long-running socket connection behavior
+
+**When you open long-running socket connections in Pomerium, the connections aren’t terminated with the user session.**
+
+Socket connections include **TCP connections** and long-running **Websocket** and  **gRPC connections** (HTTP streams).
+
+When you offboard a user and remove them from your identity provider directory, Pomerium stops refreshing the user’s HTTP sessions. As a result, their requests will no longer be authorized.
+
+However, Pomerium doesn’t terminate a user’s long-running, streaming connections when you remove them from your identity provider directory.
+
+At the moment, the best way to terminate these connections is to restart your Pomerium proxy service.
+
+:::
+
 :::tip
 This example assumes you've already [created a TCP route](/docs/capabilities/tcp#configure-routes) for this service.
 :::

--- a/content/docs/capabilities/tcp/examples/redis.mdx
+++ b/content/docs/capabilities/tcp/examples/redis.mdx
@@ -10,6 +10,20 @@ import TabItem from '@theme/TabItem';
 
 Redis is a popular in-memory data structure store. It can be run locally or configured as a single or distributed standalone service.
 
+:::info long-running socket connection behavior
+
+**When you open long-running socket connections in Pomerium, the connections aren’t terminated with the user session.**
+
+Socket connections include **TCP connections** and long-running **Websocket** and  **gRPC connections** (HTTP streams).
+
+When you offboard a user and remove them from your identity provider directory, Pomerium stops refreshing the user’s HTTP sessions. As a result, their requests will no longer be authorized.
+
+However, Pomerium doesn’t terminate a user’s long-running, streaming connections when you remove them from your identity provider directory.
+
+At the moment, the best way to terminate these connections is to restart your Pomerium proxy service.
+
+:::
+
 :::tip
 This example assumes you've already [created a TCP route](/docs/capabilities/tcp#configure-routes) for this service.
 :::

--- a/content/docs/capabilities/tcp/examples/ssh.mdx
+++ b/content/docs/capabilities/tcp/examples/ssh.mdx
@@ -17,6 +17,20 @@ By tunneling SSH connections through your Pomerium service:
  - The SSH service can remain closed to the internet, or even restricted to only accept connections from the Pomerium Proxy service
  - Authentication and authorization is managed by Pomerium, using your IdP for identity, and can be easily managed at scale.
 
+:::info long-running socket connection behavior
+
+**When you open long-running socket connections in Pomerium, the connections aren’t terminated with the user session.**
+
+Socket connections include **TCP connections** and long-running **Websocket** and  **gRPC connections** (HTTP streams).
+
+When you offboard a user and remove them from your identity provider directory, Pomerium stops refreshing the user’s HTTP sessions. As a result, their requests will no longer be authorized.
+
+However, Pomerium doesn’t terminate a user’s long-running, streaming connections when you remove them from your identity provider directory.
+
+At the moment, the best way to terminate these connections is to restart your Pomerium proxy service.
+
+:::
+
 :::tip
 This example assumes you've already [created a TCP route](/docs/capabilities/tcp#configure-routes) for this service.
 :::

--- a/content/docs/internals/connection.md
+++ b/content/docs/internals/connection.md
@@ -78,6 +78,20 @@ Most browser HTTP requests are relatively short-lived. However, certain upstream
 
 From the perspective of HTTP request management, once such a request is initiated, timeouts will apply, potentially terminating the long-lived request. For [TCP routes](/docs/capabilities/tcp) and HTTP routes marked for [`allow_websockets`](/docs/reference/routes/timeouts#websocket-connections), timeouts adjust automatically. For connections involving long-lived requests, such as gRPC streaming API or server-sent events, you need to set the route [`idle_timeout`](/docs/reference/routes/timeouts#idle-timeout) to `0` to disable it.
 
+:::info long-running socket connection behavior
+
+**When you open long-running socket connections in Pomerium, the connections aren’t terminated with the user session.** 
+
+Socket connections include **TCP connections** and long-running **Websocket** and  **gRPC connections** (HTTP streams). 
+
+When you offboard a user and remove them from your identity provider directory, Pomerium stops refreshing the user’s HTTP sessions. As a result, their requests will no longer be authorized.
+
+However, Pomerium doesn’t terminate a user’s long-running, streaming connections when you remove them from your identity provider directory. 
+
+At the moment, the best way to terminate these connections is to restart your Pomerium proxy service. 
+
+:::
+
 ## Draining connections
 
 Most configuration changes (for example, adding or editing a route) are handled seamlessly and do not impact long-lived connections.

--- a/content/docs/internals/connection.md
+++ b/content/docs/internals/connection.md
@@ -80,15 +80,15 @@ From the perspective of HTTP request management, once such a request is initiate
 
 :::info long-running socket connection behavior
 
-**When you open long-running socket connections in Pomerium, the connections aren’t terminated with the user session.** 
+**When you open long-running socket connections in Pomerium, the connections aren’t terminated with the user session.**
 
-Socket connections include **TCP connections** and long-running **Websocket** and  **gRPC connections** (HTTP streams). 
+Socket connections include **TCP connections** and long-running **Websocket** and **gRPC connections** (HTTP streams).
 
 When you offboard a user and remove them from your identity provider directory, Pomerium stops refreshing the user’s HTTP sessions. As a result, their requests will no longer be authorized.
 
-However, Pomerium doesn’t terminate a user’s long-running, streaming connections when you remove them from your identity provider directory. 
+However, Pomerium doesn’t terminate a user’s long-running, streaming connections when you remove them from your identity provider directory.
 
-At the moment, the best way to terminate these connections is to restart your Pomerium proxy service. 
+At the moment, the best way to terminate these connections is to restart your Pomerium proxy service.
 
 :::
 

--- a/cspell.json
+++ b/cspell.json
@@ -98,6 +98,7 @@
     "nosniff",
     "noout",
     "ocsp",
+    "offboard",
     "oidc",
     "onelogin",
     "openAPIV3Schema",


### PR DESCRIPTION
Resolves #795 

Is this missing anything? Does it make sense to apply it to each TCP page? 