### PR TITLE
Docs: adds mtls and request audit logs videos

### DIFF
--- a/content/docs/capabilities/audit-logs.mdx
+++ b/content/docs/capabilities/audit-logs.mdx
@@ -10,7 +10,14 @@ sidebar_class_name: enterprise
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Audit logs
+<iframe
+  width="100%"
+  height="450"
+  src="https://www.youtube.com/embed/-VJ1uxJzMcU"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  allowfullscreen></iframe>
 
 Pomerium provides verbose logging to help users audit, manage, and troubleshoot their configurations. The amount of logs output can be overwhelming, so on this page we'll cover how to sort for and understand logs from the authorization service. These logs often provide the most helpful information when first configuring Pomerium.
 

--- a/content/docs/capabilities/mtls-services.mdx
+++ b/content/docs/capabilities/mtls-services.mdx
@@ -16,6 +16,15 @@ description: This guide covers how to configure Pomerium to provide mutual authe
 
 import InstallMkcert from '@site/content/_install-mkcert.md';
 
+<iframe
+  width="100%"
+  height="450"
+  src="https://www.youtube.com/embed/ndYMzRRgLiA"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  allowfullscreen></iframe>
+
 As a reverse proxy, Pomerium is designed to manage access to your applications and services. At a minimum, Pomerium authenticates and authorizes each request to access these upstream resources.
 
 While this will keep unauthorized users from accessing your upstream applications, it does not authenticate the upstream service itself. Part of creating a zero-trust security model means securing communication between your identity-aware access proxy (Pomerium) and the upstream service it provides access to.


### PR DESCRIPTION
Adds mTLS and Audit Logs videos to `/docs/capabilities/mtls-services` and `docs/capabilities/audit-logs`. 

Related to this [Epic](https://github.com/pomerium/internal/issues/1454) 