### PR TITLE
note tls_downstream_client_ca is deprecated

### DIFF
--- a/content/docs/reference/routes/tls.mdx
+++ b/content/docs/reference/routes/tls.mdx
@@ -101,7 +101,19 @@ tls_custom_ca_file: /relative/file/location
 
 ## TLS Downstream Client Certificate Authority {#tls-downstream-client-certificate-authority}
 
-If specified, downstream clients (like a user's browser) will be required to provide a valid client TLS certificate. This overrides the global `client_ca` option for this route.
+:::caution
+
+This setting is deprecated, and will be removed in a future release.
+
+If you previously used this setting to require client certificates only on certain routes, you can achieve this same behavior by setting the new downstream mTLS [**Enforcement Mode**](/docs/reference/downstream-mtls-settings#enforcement-mode) option to the value `policy` and adding a policy deny rule with the `invalid_client_certificate` criterion on all routes that should require client certificates.
+
+If you want to enforce an allowlist or denylist of specific certificates on a particular route, you can use the new [`client_certificate`](/docs/capabilities/ppl#certificate-matcher) policy criterion.
+
+If you do need to set completely different trusted client CAs for different routes, we recommend running separate Pomerium clusters for each set of trusted client CAs.
+
+:::
+
+If specified, downstream clients (like a user's browser) will be required to provide a valid client TLS certificate. This overrides the global `downstream_mtls.ca` option for this route.
 
 See [Client-Side mTLS With Pomerium](/docs/concepts/mutual-auth.md) for more information.
 


### PR DESCRIPTION
Add an admonition to the TLS Downstream Client CA setting reference explaining that it is deprecated and suggesting some alternatives (see pomerium/pomerium#4356).