### PR TITLE
mtls: use "downstream" and "upstream" in sidebar

### DIFF
--- a/content/docs/capabilities/mtls-clients.mdx
+++ b/content/docs/capabilities/mtls-clients.mdx
@@ -1,8 +1,8 @@
 ---
 # cSpell:ignore caroot changeit
 
-title: Client-Side mutual TLS (mTLS) With Pomerium
-sidebar_label: mTLS - Clients
+title: Downstream mutual TLS (mTLS) with Pomerium
+sidebar_label: Downstream mTLS (clients)
 lang: en-US
 keywords:
   [

--- a/content/docs/capabilities/mtls-services.mdx
+++ b/content/docs/capabilities/mtls-services.mdx
@@ -1,6 +1,6 @@
 ---
 title: Upstream mutual TLS (mTLS) with Pomerium
-sidebar_label: mTLS - Services
+sidebar_label: Upstream mTLS (services)
 lang: en-US
 keywords:
   [


### PR DESCRIPTION
Update the mTLS pages in the "Capabilities" section to use the terms "downstream" and "upstream".