### PR TITLE
mtls: note client_ca is deprecated 

### DIFF
--- a/content/docs/reference/certificates.mdx
+++ b/content/docs/reference/certificates.mdx
@@ -155,6 +155,14 @@ CERTIFICATE_AUTHORITY_FILE=/relative/file/location
 
 ## Client Certificate Authority {#client-certificate-authority}
 
+:::caution
+
+This setting is deprecated; it has been moved to a new **Downstream mTLS Settings** group (see the [**Certificate Authority**](/docs/reference/downstream-mtls-settings#ca) setting there).
+
+This setting will be treated as an alias for the new setting, but will be removed in a future Pomerium release.
+
+:::
+
 **Client Certificate Authority** is the X.509 _public-key_ used to validate [mTLS client certificates](/docs/capabilities/mtls-clients).
 
 If not set, no client certificate will be required.


### PR DESCRIPTION
Add a note that the `client_ca` setting is deprecated in favor of the new `downstream_mtls.ca` setting.

Remove the `client_crl` setting entirely, as this doesn't work in current Pomerium releases.