### PR TITLE
ppl: note certificate matcher is beta

### DIFF
--- a/content/docs/capabilities/ppl.mdx
+++ b/content/docs/capabilities/ppl.mdx
@@ -116,6 +116,12 @@ PPL supports many different criteria:
 
 ### Certificate Matcher
 
+:::caution
+
+The certificate matcher is a beta feature. The syntax and capabilities are subject to change in a future Pomerium release.
+
+:::
+
 A certificate matcher can be used to allow or deny specific TLS certificates, based on either the certificate fingerprint or Subject Public Key Info (SPKI) hash. This matcher is represented as an object that may have the following key/value entries:
 
 | Key Name | Value Type | Description |


### PR DESCRIPTION
Add a caution note to the Certificate Matcher section of the PPL page to explain that the syntax is subject to change.