### PR TITLE
add note about conflicting cookie settings

### DIFF
--- a/content/docs/reference/cookies.mdx
+++ b/content/docs/reference/cookies.mdx
@@ -161,6 +161,8 @@ Setting this to `false` may result in session cookies being sent in clear text.
 
 :::
 
+Note: this cannot be set to `false` if [**Cookie SameSite**](#cookie-samesite) is set to `None`.
+
 ### How to configure {#cookie-secure-how-to-configure}
 
 <Tabs>


### PR DESCRIPTION
Add a note to the Cookies Secure reference to explain that `cookie_secure: false` may not be used in combination with `cookie_same_site: none`.

See https://github.com/pomerium/pomerium/issues/4482.