### PR TITLE
update logs fields pages

### DIFF
--- a/content/docs/reference/access-log-fields.mdx
+++ b/content/docs/reference/access-log-fields.mdx
@@ -11,7 +11,9 @@ import TabItem from '@theme/TabItem';
 
 ## Summary
 
-The **Access Log Fields** setting displays HTTP request logs from the proxy service with a message of the type `http-request`.
+The **Access Log Fields** setting controls which fields will be included in the access logs. For each incoming request, the proxy service will emit a log entry with the message `http-request` containing these fields.
+
+The default log fields should be appropriate for most deployments.
 
 ## How to Configure
 
@@ -65,6 +67,12 @@ The table below lists all available access log fields:
 | \* [`headers.{CustomHeaderName}`](#custom-headers-fields) | An HTTP Request Header identified by the `HeaderName` (for example, `headers.X-Amzn-Trace-Id` might return `Root=1-64c03960-37809588421513e42f260f56`) | No |
 
 \* The `headers.{CustomHeaderName}` field is only available in **Core** and **Enterprise**, not Kubernetes.
+
+:::danger
+
+Query parameters often contain sensitive information. Do not enable the `query` log field without careful consideration.
+
+:::
 
 ## Access log behavior
 

--- a/content/docs/reference/authorize-log-fields.mdx
+++ b/content/docs/reference/authorize-log-fields.mdx
@@ -12,7 +12,9 @@ import TabItem from '@theme/TabItem';
 
 ## Summary
 
-The **Authorize Log Fields** setting displays HTTP request logs from the authorize service with a message of the type `authorize check`.
+The **Authorize Log Fields** setting controls which fields will be included in the authorize logs. For each incoming request, the authorize service will emit a log entry with the message `authorize check` containing the policy evaluation result and these additional log fields.
+
+The default log fields should be appropriate for most deployments.
 
 ## How to Configure
 
@@ -54,13 +56,13 @@ The table below lists all available authorize log fields:
 | `email` | The logged-in user's email address | Yes |
 | `headers` | The complete set of HTTP request headers | No |
 | \* `headers.{CustomHeaderName}` | An HTTP Request Header identified by the `HeaderName` | No |
-| \* `host` | The HTTP request `:authority` or `Host` header value. Can be a domain name or IP address and may contain a port number (for example, `www.example.com`) | Yes |
+| `host` | The HTTP request `:authority` or `Host` header value. Can be a domain name or IP address and may contain a port number (for example, `www.example.com`) | Yes |
 | `id-token` | The user's ID token | No |
 | `id-token-claims` | The user's ID token claims | No |
 | `impersonate-email` | If [impersonating](/docs/capabilities/impersonation), the impersonated email | Yes |
 | `impersonate-session-id` | If [impersonating](/docs/capabilities/impersonation), the impersonated session ID | Yes |
 | `impersonate-user-id` | If [impersonating](/docs/capabilities/impersonation), the impersonated user ID | Yes |
-| `ip` | The user's IP address | Yes |
+| `ip` | The user's IP address. Note that this depends on setting the [`xff_num_trusted_hops`](/docs/reference/the-number-of-trusted-hops) option appropriately. | Yes |
 | `method` | The HTTP request method, such as `GET`, `POST`, or `PUT` | Yes |
 | `path` | The HTTP request path (for example, `/some/path`) | Yes |
 | `query` | The HTTP request query (for example, `?test=one&other=13`) | No |
@@ -69,9 +71,13 @@ The table below lists all available authorize log fields:
 | `session-id` | the session ID | Yes |
 | `user` | The user's ID | Yes |
 
-\* The actual value of the `:authority` or `Host` header may vary depending on the [`xff_num_trusted_hops`](/docs/reference/the-number-of-trusted-hops) setting.
-
 \* The `headers.{CustomHeaderName}` field is only available in **Core** and **Enterprise**, not Kubernetes.
+
+:::danger
+
+Query parameters often contain sensitive information. Do not enable the `query` log field without careful consideration.
+
+:::
 
 ## Authorize log behavior
 


### PR DESCRIPTION
Tweak the summaries of the Access Log Fields and Authorize Log Fields reference pages to emphasize that these customize the existing logging behavior.

Move the note about `xff_num_trusted_hops` to the IP address field, not the host field.

Add a warning about the `query` log field: this should not be enabled without careful consideration.