### PR TITLE
add note about ID/access tokens

### DIFF
--- a/content/docs/reference/routes/headers.mdx
+++ b/content/docs/reference/routes/headers.mdx
@@ -146,9 +146,11 @@ The following token substitutions are available:
 
 | **Token** | **Value** |
 | :-- | :-- |
-| `${pomerium.id_token}` | OIDC ID token from the identity provider |
-| `${pomerium.access_token}` | OAuth access token from the identity provider |
+| `${pomerium.id_token}` | OIDC ID token from the identity provider\* |
+| `${pomerium.access_token}` | OAuth access token from the identity provider\* |
 | `${pomerium.client_cert_fingerprint}` | Short form SHA-256 fingerprint of the presented client certificate (if [downstream mTLS](/docs/capabilities/mtls-clients) is enabled) |
+
+\*The ID token and access token are not available when using the [Hosted Authenticate](/docs/capabilities/hosted-authenticate-service) service.
 
 **Note:** Token values must use the `${pomerium.<token>}` syntax. To include a literal `$` character in a header value, use `$$`.
 


### PR DESCRIPTION
Add a note to the Set Request Headers reference that the ID token and access token substitutions are not available when using the hosted authenticate service.