### PR TITLE
document access log 'ip' field option

### DIFF
--- a/content/docs/reference/access-log-fields.mdx
+++ b/content/docs/reference/access-log-fields.mdx
@@ -53,7 +53,8 @@ The table below lists all available access log fields:
 | :-- | :-- | :-- |
 | `authority` | The HTTP request `:authority` or `Host` header value. Can be a domain name or IP address and may contain a port number (for example, `www.example.com`) | Yes |
 | `duration` | The amount of time the request takes to complete in seconds | Yes |
-| `forwarded-for` | Identifies the originating IP address of the client (this field is the value of the [`X-Forwarded-For`](/docs/reference/x-forwarded-for-http-header) header as sent to the upstream service) | Yes |
+| `forwarded-for` | This is the value of the [`X-Forwarded-For`](/docs/reference/x-forwarded-for-http-header) header (as sent to the upstream service) | Yes |
+| `ip` | The user's IP address. Note that this depends on setting the [`xff_num_trusted_hops`](/docs/reference/the-number-of-trusted-hops) option appropriately. | No |
 | `method` | The HTTP request method, such as `GET`, `POST`, or `PUT` | Yes |
 | `path` | The HTTP request path (for example, `/some/path`) | Yes |
 | `referer` | The HTTP request referer, or the address of the web page from which the resource has been requested | Yes |


### PR DESCRIPTION
https://github.com/pomerium/pomerium/pull/4391 added support for an `ip` access field. Update the Access Log Fields reference page accordingly.