### PR TITLE
fix authorize log 'ip' field note

### DIFF
--- a/content/docs/reference/authorize-log-fields.mdx
+++ b/content/docs/reference/authorize-log-fields.mdx
@@ -62,7 +62,7 @@ The table below lists all available authorize log fields:
 | `impersonate-email` | If [impersonating](/docs/capabilities/impersonation), the impersonated email | Yes |
 | `impersonate-session-id` | If [impersonating](/docs/capabilities/impersonation), the impersonated session ID | Yes |
 | `impersonate-user-id` | If [impersonating](/docs/capabilities/impersonation), the impersonated user ID | Yes |
-| `ip` | The user's IP address. Note that this depends on setting the [`xff_num_trusted_hops`](/docs/reference/the-number-of-trusted-hops) option appropriately. | Yes |
+| `ip` | The IP address of the direct downstream client. If Pomerium is deployed behind a load balancer or other proxy, this will not be the IP address of the end user. | Yes |
 | `method` | The HTTP request method, such as `GET`, `POST`, or `PUT` | Yes |
 | `path` | The HTTP request path (for example, `/some/path`) | Yes |
 | `query` | The HTTP request query (for example, `?test=one&other=13`) | No |


### PR DESCRIPTION
I believe I mixed up the behavior of the access log and the behavior of the authorize log when I added a note about `xff_num_trusted_hops` in #944.

My current understanding is that `xff_num_trusted_hops` will affect the `ip` field in the access logs, but not the `ip` field in the authorize logs.

For example, with an nginx reverse proxy in front of Pomerium and `xff_num_trusted_hops: 1`, I see log entries like this:

> all-in-one-pomerium-1  | {"level":"info","service":"authorize",**"ip":"172.25.0.4"**,"path":"/","allow":true,"allow-why-true":["user-ok"],"deny":false,"deny-why-false":[],"time":"2023-08-30T17:59:36Z","message":"authorize check"}
> all-in-one-pomerium-1  | {"level":"info","service":"envoy",**"ip":"172.25.0.1","forwarded-for":"172.25.0.1,172.25.0.4"**,"path":"/","time":"2023-08-30T17:59:36Z","message":"http-request"}

The authorize log shows the nginx IP address, while the access log shows the IP address of the client downstream from nginx.

I briefly looked into changing the authorize log behavior to match the current note in the documentation, but this appears to be non-trivial, so I think we should document the current behavior for now.