### PR TITLE
update Set Request Headers help text

### DIFF
--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -1104,8 +1104,8 @@
     "path": "/routes/headers#set-request-headers",
     "services": ["proxy"],
     "type": "map of strings key value pairs",
-    "description": "Map of key value pairs. Using $pomerium.id_token or $pomerium.access_token for the value will autopopulate the correct token.",
-    "short_description": "Value should be a string or use $pomerium.id_token and $pomerium.access_token to auto-populate"
+    "description": "Map of key value pairs. Use ${pomerium.id_token} or ${pomerium.access_token} within a value to substitute the corresponding token.",
+    "short_description": "Value should be a string. Available substitutions: ${pomerium.id_token}, ${pomerium.access_token}, ${pomerium.client_cert_fingerprint}."
   },
   "show-error-details": {
     "id": "show-error-details",


### PR DESCRIPTION
I did not properly realize that the reference.json file is the source of truth for the Console help links, and so I mistakenly updated the Console copy of this file directly (in https://github.com/pomerium/pomerium-console/pull/3570).

Let's make the corresponding change here, so that the Console help text does not revert when this file is next synced.