### PR TITLE
Docs: adds v18 and v19 notices to core and console upgrade guides

### DIFF
--- a/content/docs/deploy/core/upgrading.mdx
+++ b/content/docs/deploy/core/upgrading.mdx
@@ -218,6 +218,18 @@ Pomerium Core would only perform user authentication and session refresh with th
 
 ![idp_enterprise](../enterprise/img/upgrading/policy_groups_enterprise.png)
 
+## 0.19.0
+
+### No changes required to upgrade
+
+- This release has no breaking changes. Review the [v19 Changelog](/docs/deploy/core/changelog#v0190-2022-09-01) for more information.
+
+## 0.18.0
+
+### No changes required to upgrade
+
+- This release has no breaking changes. Review the [v18 Changelog](/docs/deploy/core/changelog#v0180-2022-07-27) for more information.
+
 ## 0.17.0
 
 ### New

--- a/content/docs/deploy/enterprise/upgrading.mdx
+++ b/content/docs/deploy/enterprise/upgrading.mdx
@@ -88,6 +88,12 @@ IdP directory sync has been moved to be part of the [External Data Sources integ
 
 Pomerium Core would only perform user authentication and session refresh with the IdP provider, and would not try to synchronize user details and groups, which is now part of [External Data Sources](/docs/integrations/). Please review your [identity provider's](/docs/identity-providers/) docs for instructions specific to your IdP (e.g. `Identity Providers` -> `Google` -> `Directory Sync (Enterprise)`).
 
+## 0.19.0
+
+### No changes required to upgrade
+
+- This release has no breaking changes. Review the [v19 Changelog](/docs/deploy/enterprise/changelog#0190) for more information.
+
 ## 0.18.0
 
 ### Before You Upgrade


### PR DESCRIPTION
Fixes https://github.com/pomerium/internal/issues/1526

