### PR TITLE
add a border around the tabs container

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -219,3 +219,12 @@ select:focus {
 td > .theme-code-block:last-child {
   margin-bottom: 0;
 }
+
+.tabs-container {
+  border-radius: 8px;
+  box-shadow: 0 0 2px #aaa;
+  padding: 16px;
+}
+.tabs-container .tabs {
+  margin: -12px -12px 0;
+}


### PR DESCRIPTION
Related to https://github.com/pomerium/documentation/issues/912: if we start moving the 'Examples' sub-headings inside the different tabs for Core / Console / Ingress Controller, it might make sense to demarcate the bottom of the tabs container more clearly. This change tweaks the CSS to add a rounded border around each tabs contanier.