### PR TITLE
Docs: fix v20 release headers

### DIFF
--- a/content/docs/releases/upgrading.mdx
+++ b/content/docs/releases/upgrading.mdx
@@ -11,7 +11,7 @@ sidebar_position: 10
 
 # Upgrade guide
 
-## Since 0.19.0
+## 0.20.0
 
 ### Breaking
 
@@ -58,7 +58,7 @@ Pomerium Core would only perform user authentication and session refresh with th
 
 ![idp_enterprise](./img/upgrading/idp_enterprise.png)
 
-## Since 0.16.0
+## 0.17.0
 
 ### New
 
@@ -76,7 +76,7 @@ The `.pomerium` user info page has been redesigned to better structure data arou
 
 Pomerium policy now supports group members from outside of your organization.
 
-## Since 0.15.0
+## 0.16.0
 
 ### New
 
@@ -120,7 +120,7 @@ To improve performance, IdP directory synchronization for GitHub now uses the Gr
 
 Please see the [updated install instructions](/docs/releases/pomerium-cli) for additional details.
 
-## Since 0.14.0
+## 0.15.0
 
 ### Breaking
 
@@ -145,7 +145,7 @@ Routes and policies may now be configured under a new top level key - `routes`
 
 `pomerium-cli` now respects proxy related environmental variables.
 
-## Since 0.13.0
+## 0.14.0
 
 ### New
 
@@ -177,7 +177,7 @@ When specifying `allowed_users` by ID, the identity provider is no longer part o
 
 To update your policies for v0.14, please remove any identity provider prefix. Example: `okta/00usi7mc8XC8SwFxT4x6` becomes `00usi7mc8XC8SwFxT4x6`.
 
-## Since 0.12.0
+## 0.13.0
 
 ### New
 
@@ -217,7 +217,7 @@ Prior to the v0.13 release, it was possible to create service accounts via Pomer
 
 The `administrators` configuration option has been removed.
 
-## Since 0.11.0
+## 0.12.0
 
 ### New
 
@@ -229,7 +229,7 @@ Pomerium can now be used for non-HTTP services. See [documentation](/docs/capabi
 
 Datadog has been added as a natively supported [tracing backend](/docs/reference/tracing#datadog)
 
-## Since 0.10.0
+## 0.11.0
 
 ### Breaking
 
@@ -247,7 +247,7 @@ The `cache_service_url` parameter has been deprecated since v0.10.0 and is now r
 
 With the v0.11.0 release, Pomerium docker images are multi-arch for `arm64` and `amd64`. Individual images for each architecture will continue to be published.
 
-## Since 0.9.0
+## 0.10.0
 
 ### Breaking
 
@@ -292,7 +292,7 @@ Please see the following interfaces for reference to implement your storage back
 
 With this release, pomerium will not insert identity headers (X-Pomerium-Jwt-Assertion/X-Pomerium-Claim-\*) by default. To get pre 0.9.0 behavior, you can set `pass_identity_headers` to true on a per-policy basis.
 
-## Since 0.8.0
+## 0.9.0
 
 ### Breaking
 
@@ -341,7 +341,7 @@ With this release we now use an embedded [envoy](https://www.envoyproxy.io/) bin
 
 - Due to this change, data plane metric names and labels have changed to adopt envoy's internal data model. [Details](https://www.pomerium.io/configuration/#envoy-proxy-metrics)
 
-## Since 0.7.0
+## 0.8.0
 
 ### Breaking
 
@@ -381,7 +381,7 @@ policy:
     prefix: '/some/path'
 ```
 
-## Since 0.6.0
+## 0.7.0
 
 ### Breaking
 
@@ -401,7 +401,7 @@ If you still rely on individual claim headers, please see the `jwt_claims_header
 
 Non-standard port users (e.g. those not using `443`/`80` where the port _would_ be part of the client's request) will have to clear their user's session before upgrading. Starting with version v0.7.0, audience (`aud`) and issuer (`iss`) claims will be port specific.
 
-## Since 0.5.0
+## 0.6.0
 
 ### Breaking
 
@@ -433,7 +433,7 @@ For a concrete example of the required changes, consider the following changes f
 
 Please see the updated examples, and [cache service docs] as a reference and for the available cache stores. For more details as to why this was necessary, please see [PR438](https://github.com/pomerium/pomerium/pull/438) and [PR457](https://github.com/pomerium/pomerium/pull/457).
 
-## Since 0.4.0
+## 0.5.0
 
 ### Breaking
 
@@ -478,7 +478,7 @@ For example, in nginx this would look like:
 +    nginx.ingress.kubernetes.io/auth-signin: https://forwardauth.corp.example.com?uri=$scheme://$host$request_uri
 ```
 
-## Since 0.3.0
+## 0.4.0
 
 ### Breaking
 
@@ -524,15 +524,15 @@ livenessProbe:
 
 If service mode (`SERVICES`/`services`) is set to `all`, gRPC communication with the Authorize service will by default occur over localhost, on port `:5443`.
 
-## Since 0.2.0
+## 0.3.0
 
 Pomerium `v0.3.0` has no known breaking changes compared to `v0.2.0`.
 
-## Since 0.1.0
+## 0.2.0
 
 Pomerium `v0.2.0` has no known breaking changes compared to `v0.1.0`.
 
-## Since 0.0.5
+## 0.0.6
 
 This page contains the list of deprecations and important or breaking changes for pomerium `v0.1.0` compared to `v0.0.5`. Please read it carefully.
 
@@ -570,7 +570,7 @@ policy:
     allow_public_unauthenticated_access: true
 ```
 
-## Since 0.0.4
+## 0.0.5
 
 This page contains the list of deprecations and important or breaking changes for pomerium `v0.0.5` compared to `v0.0.4`. Please read it carefully.
 


### PR DESCRIPTION
Updates v20 Core Upgrade guide headers so they match v23's. 

Related to https://github.com/pomerium/documentation/pull/981