### PR TITLE
Docs: Fixes backport to v20 broken links issue

### DIFF
--- a/content/docs/releases/enterprise/upgrading.mdx
+++ b/content/docs/releases/enterprise/upgrading.mdx
@@ -28,7 +28,7 @@ Pomerium Core would only perform user authentication and session refresh with th
 
 ### No changes required to upgrade
 
-- This release has no breaking changes. Review the [v19 Changelog](/docs/deploy/enterprise/changelog#0190) for more information.
+- This release has no breaking changes. Review the [v19 Changelog](/docs/releases/enterprise/changelog#0190) for more information.
 
 ## 0.18.0
 

--- a/content/docs/releases/enterprise/upgrading.mdx
+++ b/content/docs/releases/enterprise/upgrading.mdx
@@ -24,6 +24,12 @@ IdP directory sync has been moved to be part of the [External Data Sources integ
 
 Pomerium Core would only perform user authentication and session refresh with the IdP provider, and would not try to synchronize user details and groups, which is now part of [External Data Sources](/docs/integrations/). Please review your [identity provider's](/docs/identity-providers/) docs for instructions specific to your IdP (e.g. `Identity Providers` -> `Google` -> `Directory Sync (Enterprise)`).
 
+## 0.19.0
+
+### No changes required to upgrade
+
+- This release has no breaking changes. Review the [v19 Changelog](/docs/deploy/enterprise/changelog#0190) for more information.
+
 ## 0.18.0
 
 ### Before You Upgrade

--- a/content/docs/releases/upgrading.mdx
+++ b/content/docs/releases/upgrading.mdx
@@ -62,13 +62,13 @@ Pomerium Core would only perform user authentication and session refresh with th
 
 ### No changes required to upgrade
 
-- This release has no breaking changes. Review the [v19 Changelog](/docs/deploy/core/changelog#v0190-2022-09-01) for more information.
+- This release has no breaking changes. Review the [v19 Changelog](/docs/releases/changelog#v0190-2022-09-01) for more information.
 
 ## 0.18.0
 
 ### No changes required to upgrade
 
-- This release has no breaking changes. Review the [v18 Changelog](/docs/deploy/core/changelog#v0180-2022-07-27) for more information.
+- This release has no breaking changes. Review the [v18 Changelog](/docs/releases/changelog#v0180-2022-07-27) for more information.
 
 ## 0.17.0
 

--- a/content/docs/releases/upgrading.mdx
+++ b/content/docs/releases/upgrading.mdx
@@ -58,6 +58,18 @@ Pomerium Core would only perform user authentication and session refresh with th
 
 ![idp_enterprise](./img/upgrading/idp_enterprise.png)
 
+## 0.19.0
+
+### No changes required to upgrade
+
+- This release has no breaking changes. Review the [v19 Changelog](/docs/deploy/core/changelog#v0190-2022-09-01) for more information.
+
+## 0.18.0
+
+### No changes required to upgrade
+
+- This release has no breaking changes. Review the [v18 Changelog](/docs/deploy/core/changelog#v0180-2022-07-27) for more information.
+
 ## 0.17.0
 
 ### New


### PR DESCRIPTION
Fixes broken links, which caused checks to fail in the [original backport](https://github.com/pomerium/documentation/pull/986)