### PR TITLE
Docs: backport 981 to 0 21 0

### DIFF
--- a/content/docs/releases/enterprise/upgrading.mdx
+++ b/content/docs/releases/enterprise/upgrading.mdx
@@ -46,6 +46,12 @@ IdP directory sync has been moved to be part of the [External Data Sources integ
 
 Pomerium Core would only perform user authentication and session refresh with the IdP provider, and would not try to synchronize user details and groups, which is now part of [External Data Sources](/docs/integrations/). Please review your [identity provider's](/docs/identity-providers/) docs for instructions specific to your IdP (e.g. `Identity Providers` -> `Google` -> `Directory Sync (Enterprise)`).
 
+## 0.19.0
+
+### No changes required to upgrade
+
+- This release has no breaking changes. Review the [v19 Changelog](/docs/deploy/enterprise/changelog#0190) for more information.
+
 ## 0.18.0
 
 ### Before You Upgrade

--- a/content/docs/releases/enterprise/upgrading.mdx
+++ b/content/docs/releases/enterprise/upgrading.mdx
@@ -50,7 +50,7 @@ Pomerium Core would only perform user authentication and session refresh with th
 
 ### No changes required to upgrade
 
-- This release has no breaking changes. Review the [v19 Changelog](/docs/deploy/enterprise/changelog#0190) for more information.
+- This release has no breaking changes. Review the [v19 Changelog](/docs/releases/enterprise/changelog#0190) for more information.
 
 ## 0.18.0
 

--- a/content/docs/releases/upgrading.mdx
+++ b/content/docs/releases/upgrading.mdx
@@ -86,6 +86,18 @@ Pomerium Core would only perform user authentication and session refresh with th
 
 ![idp_enterprise](./img/upgrading/idp_enterprise.png)
 
+## 0.19.0
+
+### No changes required to upgrade
+
+- This release has no breaking changes. Review the [v19 Changelog](/docs/deploy/core/changelog#v0190-2022-09-01) for more information.
+
+## 0.18.0
+
+### No changes required to upgrade
+
+- This release has no breaking changes. Review the [v18 Changelog](/docs/deploy/core/changelog#v0180-2022-07-27) for more information.
+
 ## 0.17.0
 
 ### New

--- a/content/docs/releases/upgrading.mdx
+++ b/content/docs/releases/upgrading.mdx
@@ -90,13 +90,13 @@ Pomerium Core would only perform user authentication and session refresh with th
 
 ### No changes required to upgrade
 
-- This release has no breaking changes. Review the [v19 Changelog](/docs/deploy/core/changelog#v0190-2022-09-01) for more information.
+- This release has no breaking changes. Review the [v19 Changelog](/docs/releases/changelog#v0190-2022-09-01) for more information.
 
 ## 0.18.0
 
 ### No changes required to upgrade
 
-- This release has no breaking changes. Review the [v18 Changelog](/docs/deploy/core/changelog#v0180-2022-07-27) for more information.
+- This release has no breaking changes. Review the [v18 Changelog](/docs/releases/changelog#v0180-2022-07-27) for more information.
 
 ## 0.17.0
 


### PR DESCRIPTION
Fixes broken backport to v21. The issue is the directory changes in v22-23 broke links in v20 and v21. So the links to v18 and v19 changelogs had different paths in v20 and v21, which breaks the build. 