### PR TITLE
start using 'shell-session' code blocks

### DIFF
--- a/content/_install-mkcert.md
+++ b/content/_install-mkcert.md
@@ -6,12 +6,12 @@ If you haven't, install `mkcert` following these [GitHub instructions](https://g
 
 Create a trusted **root CA** and confirm the presence and names of your local CA files:
 
-```bash
-mkcert -install
+```shell-session
+$ mkcert -install
 The local CA is already installed in the system trust store! 👍
 The local CA is already installed in the Firefox and/or Chrome/Chromium trust store! 👍
 
-ls "$(mkcert -CAROOT)"
+$ ls "$(mkcert -CAROOT)"
 rootCA-key.pem  rootCA.pem
 ```
 

--- a/content/docs/capabilities/mtls-services.mdx
+++ b/content/docs/capabilities/mtls-services.mdx
@@ -61,8 +61,8 @@ This guide uses the `localhost.pomerium.io` domain as the root domain (all subdo
 
 1. Create a certificate and key for your example upstream service, OpenSSL:
 
-   ```bash {1}
-   mkcert openssl.localhost
+   ```shell-session
+   $ mkcert openssl.localhost
 
    Created a new certificate valid for the following names 📜
    - "openssl.localhost"
@@ -74,8 +74,8 @@ This guide uses the `localhost.pomerium.io` domain as the root domain (all subdo
 
 1. Create a client certificate and key for Pomerium to use:
 
-   ```bash {1}
-   mkcert -client 'pomerium@localhost'
+   ```shell-session
+   $ mkcert -client 'pomerium@localhost'
 
    Created a new certificate valid for the following names 📜
    - "pomerium@localhost"
@@ -87,9 +87,9 @@ This guide uses the `localhost.pomerium.io` domain as the root domain (all subdo
 
 1. Change ownership of the client certificate files and move them to Pomerium's configuration directory:
 
-   ```bash
-   sudo chown pomerium:pomerium pomerium@localhost-client*pem /etc/pomerium
-   sudo mv pomerium@localhost-client*pem /etc/pomerium/
+   ```shell-session
+   $ sudo chown pomerium:pomerium pomerium@localhost-client*pem /etc/pomerium
+   $ sudo mv pomerium@localhost-client*pem /etc/pomerium/
    ```
 
 ## Configure OpenSSL server
@@ -98,14 +98,14 @@ OpenSSL is installed or easily available for most 'nix-based operating systems l
 
 1. In a terminal environment and the same directory where you created the certificate files, start an OpenSSL server process. Note that it will run in the foreground until stopped, so you will need another terminal environment to run additional commands:
 
-   ```bash
-   openssl s_server -key ./openssl.localhost-key.pem -cert ./openssl.localhost.pem -accept 44330 -www
+   ```shell-session
+   $ openssl s_server -key ./openssl.localhost-key.pem -cert ./openssl.localhost.pem -accept 44330 -www
    ```
 
    You can confirm that the server is responding using `curl`:
 
-   ```bash {1}
-   curl -k https://localhost:44330
+   ```shell-session
+   $ curl -k https://localhost:44330
    <HTML><BODY BGCOLOR="#ffffff">
    <pre>
 
@@ -152,8 +152,8 @@ OpenSSL is installed or easily available for most 'nix-based operating systems l
 
 1. Stop the OpenSSL server process (**Ctrl+C**) and start a new one with the additional flag `-Verify 1`:
 
-   ```bash
-   openssl s_server -Verify 1 -key ./openssl.localhost-key.pem -cert ./openssl.localhost.pem -accept 44330 -www
+   ```shell-session
+   $ openssl s_server -Verify 1 -key ./openssl.localhost-key.pem -cert ./openssl.localhost.pem -accept 44330 -www
    ```
 
 1. When you refresh <https://openssl.localhost.pomium.io> in your browser, the connection will fail. Back in the terminal, the OpenSSL server should output errors containing:

--- a/content/docs/capabilities/tcp.mdx
+++ b/content/docs/capabilities/tcp.mdx
@@ -67,8 +67,8 @@ While HTTP routes can be consumed with just a normal browser, `pomerium-cli` or 
 
 To connect, you normally need just the external hostname and port of your TCP route:
 
-```bash {1}
-pomerium-cli tcp redis.corp.example.com:6379
+```shell-session
+$ pomerium-cli tcp redis.corp.example.com:6379
 5:57PM INF tcptunnel: listening on 127.0.0.1:52046
 ```
 
@@ -76,8 +76,8 @@ By default, `pomerium-cli` will start a listener on loopback on a random port.
 
 On first connection, you will be sent through a standard Pomerium HTTP authentication flow. After completing this, your TCP connection should be established!
 
-```bash {1}
-% redis-cli -h localhost -p 52046
+```shell-session
+$ redis-cli -h localhost -p 52046
 localhost:52046> keys *
 (empty array)
 localhost:52046>

--- a/content/docs/deploy/core.mdx
+++ b/content/docs/deploy/core.mdx
@@ -83,22 +83,22 @@ Pomerium utilizes a [minimal](https://github.com/GoogleContainerTools/distroless
 
 - `:vX.Y.Z`: which will pull the a [specific tagged release](https://github.com/pomerium/pomerium/tags).
 
-  ```bash {1}
-  docker run pomerium/pomerium:v0.1.0 --version
+  ```shell-session
+  $ docker run pomerium/pomerium:v0.1.0 --version
   v0.1.0+53bfa4e
   ```
 
 - `:latest`: which will pull the [most recent tagged release](https://github.com/pomerium/pomerium/releases).
 
-  ```bash {1}
-  docker pull pomerium/pomerium:latest && docker run pomerium/pomerium:latest --version
+  ```shell-session
+  $ docker pull pomerium/pomerium:latest && docker run pomerium/pomerium:latest --version
   v0.2.0+87e214b
   ```
 
 - `:main` : which will pull an image in sync with git's [main](https://github.com/pomerium/pomerium/tree/main) branch.
 
-  ```bash {1}
-  docker pull pomerium/pomerium:main
+  ```shell-session
+  $ docker pull pomerium/pomerium:main
   ```
 
 Rootless images for official releases are also published to provide additional security. In these images, Pomerium runs as the `nonroot` user. Depending on your deployment environment, you may need to grant the container additional [capabilities](https://linux-audit.com/linux-capabilities-hardening-linux-binaries-by-removing-setuid/) or change the listening port from `443`.

--- a/content/docs/guides/helm.mdx
+++ b/content/docs/guides/helm.mdx
@@ -92,8 +92,8 @@ If you haven't already, install cert-manager and create a CA issuer. You can fol
 
 1. Confirm deployment with `kubectl get pods --namespace cert-manager`:
 
-   ```bash {1}
-   kubectl get pods --namespace cert-manager
+   ```shell-session
+   $ kubectl get pods --namespace cert-manager
    NAME                                       READY   STATUS    RESTARTS   AGE
    cert-manager-5d7f97b46d-8g942              1/1     Running   0          33s
    cert-manager-cainjector-69d885bf55-6x5v2   1/1     Running   0          33s
@@ -122,8 +122,8 @@ If you haven't already, install cert-manager and create a CA issuer. You can fol
 
 1. Apply and confirm:
 
-   ```bash {1}
-   kubectl apply -f issuer.yaml
+   ```shell-session
+   $ kubectl apply -f issuer.yaml
    issuer.cert-manager.io/pomerium-issuer created
 
    kubectl get issuers.cert-manager.io --namespace pomerium
@@ -155,8 +155,8 @@ If you haven't already, install cert-manager and create a CA issuer. You can fol
     kubectl apply -f pomerium-certificates.yaml
     ```
 
-    ```bash {1}
-    kubectl get certificate
+    ```shell-session
+    $ kubectl get certificate
     NAME                    READY   SECRET                 AGE
     pomerium-cert           True    pomerium-tls           10s
     ```

--- a/content/docs/guides/istio.mdx
+++ b/content/docs/guides/istio.mdx
@@ -114,8 +114,8 @@ Follow [Install Pomerium using Helm] to set up the Pomerium Ingress Controller a
 
 1. When [defining a test service](/docs/deploy/k8s/quickstart#test-service), you should now see two containers for the service pod:
 
-   ```bash {1}
-   kubectl get pods
+   ```shell-session
+   $ kubectl get pods
    NAME                                           READY   STATUS    RESTARTS   AGE
    ...
    nginx-6955473668-cxprp                         2/2     Running   0          19s

--- a/content/docs/guides/securing-tcp.mdx
+++ b/content/docs/guides/securing-tcp.mdx
@@ -105,13 +105,17 @@ pomerium-cli tcp [hostname]:[port]
 
 ## Redis
 
-````bash {2,6}
-# Start a proxy to redis in the background
-pomerium-cli tcp redis.localhost.pomerium.io:6379 --listen localhost:6379 &
-3:01PM INF tcptunnel: listening on 127.0.0.1:6379
+Start a proxy to redis in the background:
 
-# Start the redis client
-redis-cli
+```shell-session
+$ pomerium-cli tcp redis.localhost.pomerium.io:6379 --listen localhost:6379 &
+3:01PM INF tcptunnel: listening on 127.0.0.1:6379
+```
+
+Start the redis client:
+
+```shell-session
+$ redis-cli
 3:01PM INF tcptunnel: opening connection dst=redis.localhost.pomerium.io:6379 proxy=redis.localhost.pomerium.io:443 secure=true
 3:01PM INF tcptunnel: opening connection dst=redis.localhost.pomerium.io:6379 proxy=redis.localhost.pomerium.io:443 secure=true
 3:01PM INF tcptunnel: connection established
@@ -125,20 +129,24 @@ redis-cli
  7) "type.googleapis.com/session.Session_version_set"
  8) "server_version_version_set"
  9) "server_version"
-10) "type.googleapis.com/directory.User_last_version"```
-````
+10) "type.googleapis.com/directory.User_last_version"
+```
 
 ## Postgres
 
 In our example docker-compose, we have configured `supersecret` as the password for the `postgres` user.
 
-```bash {2,6}
-# Start a proxy to postgres in the background
-pomerium-cli tcp pgsql.localhost.pomerium.io:5432 --listen localhost:5432 &
-3:07PM INF tcptunnel: listening on 127.0.0.1:5432
+Start a proxy to postgres in the background:
 
-# Connect and list the schemas after password authentication
-psql -h localhost -W -U postgres -c '\dn'
+```shell-session
+$ pomerium-cli tcp pgsql.localhost.pomerium.io:5432 --listen localhost:5432 &
+3:07PM INF tcptunnel: listening on 127.0.0.1:5432
+```
+
+Connect and list the schemas after password authentication:
+
+```shell-session
+$ psql -h localhost -W -U postgres -c '\dn'
 Password:
 3:06PM INF tcptunnel: opening connection dst=pgsql.localhost.pomerium.io:5432 proxy=pgsql.localhost.pomerium.io:443 secure=true
 3:06PM INF tcptunnel: connection established
@@ -176,8 +184,8 @@ That's it! A Pomerium proxy will be started _automatically_ whenever you ssh to 
 
 In our example docker-compose, we have an SSH server configured with `supersecret` as the password for `myuser`.
 
-```bash {1}
-ssh myuser@ssh.localhost.pomerium.io
+```shell-session
+$ ssh myuser@ssh.localhost.pomerium.io
 3:19PM INF tcptunnel: opening connection dst=ssh.localhost.pomerium.io:22 proxy=ssh.localhost.pomerium.io:443 secure=true
 3:19PM INF tcptunnel: connection established
 myuser@ssh.localhost.pomerium.io's password:

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -167,7 +167,7 @@ const config = {
     prism: {
       theme: lightCodeTheme,
       darkTheme: darkCodeTheme,
-      additionalLanguages: ['actionscript', 'log', 'ini', 'nginx', 'rego'],
+      additionalLanguages: ['actionscript', 'log', 'ini', 'nginx', 'rego', 'shell-session'],
     },
   },
   stylesheets: [
@@ -183,6 +183,18 @@ const config = {
     ],
   ],
 };
+
+// The prism-react-renderer themes do not define styles for the 'shell-session'
+// token types, so define our own styles here.
+lightCodeTheme.styles.push(
+  {types: ['shell-symbol'], style: { color: '#5d36c6' }},
+  {types: ['command'], style: { color: '#1c1e21' }},
+  {types: ['output'], style: { color: '#133369' }}
+);
+darkCodeTheme.styles.push(
+  {types: ['shell-symbol'], style: { color: '#c0a9ff' }},
+  {types: ['output'], style: { color: '#e4e4c4' }}
+);
 
 if (!process.env.ALGOLIA_APPID) {
   delete config.themeConfig.algolia;

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,8 +1,8 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
-const lightCodeTheme = require('prism-react-renderer/themes/github');
-const darkCodeTheme = require('prism-react-renderer/themes/dracula');
+const githubCodeTheme = require('prism-react-renderer/themes/github');
+const draculaCodeTheme = require('prism-react-renderer/themes/dracula');
 const dotenv = require('dotenv');
 
 dotenv.config();
@@ -165,8 +165,8 @@ const config = {
       copyright: `Copyright © ${new Date().getFullYear()} Pomerium.`,
     },
     prism: {
-      theme: lightCodeTheme,
-      darkTheme: darkCodeTheme,
+      theme: lightCodeTheme(),
+      darkTheme: darkCodeTheme(),
       additionalLanguages: ['actionscript', 'log', 'ini', 'nginx', 'rego', 'shell-session'],
     },
   },
@@ -185,16 +185,24 @@ const config = {
 };
 
 // The prism-react-renderer themes do not define styles for the 'shell-session'
-// token types, so define our own styles here.
-lightCodeTheme.styles.push(
-  {types: ['shell-symbol'], style: { color: '#5d36c6' }},
-  {types: ['command'], style: { color: '#1c1e21' }},
-  {types: ['output'], style: { color: '#133369' }}
-);
-darkCodeTheme.styles.push(
-  {types: ['shell-symbol'], style: { color: '#c0a9ff' }},
-  {types: ['output'], style: { color: '#e4e4c4' }}
-);
+// token types, so define our own styles for these types here.
+function lightCodeTheme() {
+  const theme = githubCodeTheme;
+  theme.styles = theme.styles.concat([
+    {types: ['shell-symbol'], style: { color: '#5d36c6' }},
+    {types: ['command'], style: { color: '#1c1e21' }},
+    {types: ['output'], style: { color: '#133369' }}
+  ]);
+  return theme;
+}
+function darkCodeTheme() {
+  const theme = draculaCodeTheme;
+  theme.styles = theme.styles.concat([
+    {types: ['shell-symbol'], style: { color: '#c0a9ff' }},
+    {types: ['output'], style: { color: '#e4e4c4' }}
+  ]);
+  return theme;
+}
 
 if (!process.env.ALGOLIA_APPID) {
   delete config.themeConfig.algolia;

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -187,21 +187,17 @@ const config = {
 // The prism-react-renderer themes do not define styles for the 'shell-session'
 // token types, so define our own styles for these types here.
 function lightCodeTheme() {
-  const theme = githubCodeTheme;
-  theme.styles = theme.styles.concat([
+  return {...githubCodeTheme, styles: githubCodeTheme.styles.concat([
     {types: ['shell-symbol'], style: { color: '#5d36c6' }},
     {types: ['command'], style: { color: '#1c1e21' }},
     {types: ['output'], style: { color: '#133369' }}
-  ]);
-  return theme;
+  ])};
 }
 function darkCodeTheme() {
-  const theme = draculaCodeTheme;
-  theme.styles = theme.styles.concat([
+  return {...draculaCodeTheme, styles: draculaCodeTheme.styles.concat([
     {types: ['shell-symbol'], style: { color: '#c0a9ff' }},
     {types: ['output'], style: { color: '#e4e4c4' }}
-  ]);
-  return theme;
+  ])};
 }
 
 if (!process.env.ALGOLIA_APPID) {


### PR DESCRIPTION
Configure 'shell-session' as an additional language for syntax highlighting in code blocks. This differs from 'bash' highlighting in that lines not beginning with a shell symbol (e.g. '$') won't be treated as part of a shell command.

Some of our existing code blocks use 'bash' along with line highlights to present interactive shell sessions. Convert these to use 'shell-session', adding '$' to any input lines.

Note that the prism-react-renderer themes do not currently have styles for the 'shell-session' token types, so we need to define our own styles for these.

### Example comparison

Before:
![Screen Shot 2023-09-19 at 11 15 48 AM](https://github.com/pomerium/documentation/assets/51246568/933f5940-7c6c-4ad2-ad60-bcb01f77e24a)

After:
![Screen Shot 2023-09-19 at 11 16 04 AM](https://github.com/pomerium/documentation/assets/51246568/e4224311-3728-4390-8221-2569fe6ba9e6)
