### PR TITLE
fix helm guide formatting

### DIFF
--- a/content/docs/guides/helm.mdx
+++ b/content/docs/guides/helm.mdx
@@ -174,7 +174,7 @@ If you haven't already, install cert-manager and create a CA issuer. You can fol
     :::
 
     <details>
-    <summary>Default Certificate</summary>
+<summary>Default Certificate</summary>
 
     If you're using a single wildcard certificate for all routes managed by Pomerium, you can set it in an annotation for the ingress controller.
 

--- a/content/docs/guides/helm.mdx
+++ b/content/docs/guides/helm.mdx
@@ -163,36 +163,32 @@ If you haven't already, install cert-manager and create a CA issuer. You can fol
 
 1.  Create a values file for Helm to use when installing Pomerium. Our example is named `pomerium-values.yaml`.
 
-            {' '}
+    <PomeriumValues />
 
-            {' '}
-            <PomeriumValues />
+    :::tip
 
-            :::tip The options required in the `authenticate.idp` block will vary depending on your [identity provider].
+    The options required in the `authenticate.idp` block will vary depending on your [identity provider].
 
-            If you changed the `*.localhost.pomerium.io` value in `pomerium-certificates.yaml` update `config.rootDomain` to match, omitting the `*`. :::
+    If you changed the `*.localhost.pomerium.io` value in `pomerium-certificates.yaml` update `config.rootDomain` to match, omitting the `*`.
 
-                <details>
+    :::
 
-            <summary>Default Certificate</summary>
-
-        <div>
+    <details>
+    <summary>Default Certificate</summary>
 
     If you're using a single wildcard certificate for all routes managed by Pomerium, you can set it in an annotation for the ingress controller.
 
-            Add a block defining the default certificate to `pomerium-values.yaml`:
+    Add a block defining the default certificate to `pomerium-values.yaml`:
 
-            ```yaml
-            ingressController:
-            ingressClassResource:
-              defaultCertSecret: 'namespace/certSecretName'
-            ```
+    ```yaml
+    ingressController:
+    ingressClassResource:
+      defaultCertSecret: 'namespace/certSecretName'
+    ```
 
-            Now when defining ingresses you need not specify individual certificates, as documented in our example service below.
+    Now when defining ingresses you need not specify individual certificates, as documented in our example service below.
 
-                   </div>
-
-             </details>
+    </details>
 
 1.  Add Pomerium's Helm repo:
 

--- a/content/docs/guides/helm.mdx
+++ b/content/docs/guides/helm.mdx
@@ -173,8 +173,7 @@ If you haven't already, install cert-manager and create a CA issuer. You can fol
 
     :::
 
-    <details>
-<summary>Default Certificate</summary>
+    <details><summary>Default Certificate</summary>
 
     If you're using a single wildcard certificate for all routes managed by Pomerium, you can set it in an annotation for the ingress controller.
 


### PR DESCRIPTION
Some of the Helm guide Markdown was indented too far, causing it to be rendered as a code block. Update the formatting to restore this guide content.

Fixes #996.