### PR TITLE
ppl: update invalid_client_certificate description

### DIFF
--- a/content/docs/capabilities/ppl.mdx
+++ b/content/docs/capabilities/ppl.mdx
@@ -320,7 +320,7 @@ allow:
 [`allow_public_unauthenticated_access`]: /docs/reference/routes/public-access
 [`allow_any_authenticated_user`]: /docs/reference/routes/allow-any-authenticated-user
 [cors pre-flight requests]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#preflighted_requests
-[downstream mTLS]: /docs/reference/downstream-mtls-settings
+[downstream mtls]: /docs/reference/downstream-mtls-settings
 [pomerium enterprise]: /docs/deploy/enterprise/install
 [yaml]: https://en.wikipedia.org/wiki/YAML
 [string matcher]: #string-matcher

--- a/content/docs/capabilities/ppl.mdx
+++ b/content/docs/capabilities/ppl.mdx
@@ -137,7 +137,7 @@ PPL supports many different criteria:
 | `email` | [String Matcher] | Returns true if the logged-in user's email address matches the given value. |
 | `http_method` | [String Matcher] | Returns true if the HTTP method matches the given value. |
 | `http_path` | [String Matcher] | Returns true if the HTTP path matches the given value. |
-| `invalid_client_certificate` | Anything. Typically `true`. | Returns true if the incoming request has an invalid client certificate. A default `deny` rule using this criterion is added to all Pomerium policies when an mTLS [client certificate authority] is set. |
+| `invalid_client_certificate` | Anything. Typically `true`. | Returns true if the incoming request does not have a trusted client certificate. By default, a `deny` rule using this criterion is added to all Pomerium policies when [downstream mTLS] is configured (but this default can be changed using the [Enforcement Mode](/docs/reference/downstream-mtls-settings#enforcement-mode) setting.) |
 | `pomerium_routes` | Anything. Typically `true`. | Returns true if the incoming request is for the special `.pomerium` routes. A default `allow` rule using this criterion is added to all Pomerium policies. |
 | `reject` | Anything. Typically `true`. | Always returns false. The opposite of `accept`. |
 | `user` | [String Matcher] | Returns true if the logged-in user's id matches the given value. |
@@ -320,7 +320,7 @@ allow:
 [`allow_public_unauthenticated_access`]: /docs/reference/routes/public-access
 [`allow_any_authenticated_user`]: /docs/reference/routes/allow-any-authenticated-user
 [cors pre-flight requests]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#preflighted_requests
-[client certificate authority]: /docs/reference/certificates
+[downstream mTLS]: /docs/reference/downstream-mtls-settings
 [pomerium enterprise]: /docs/deploy/enterprise/install
 [yaml]: https://en.wikipedia.org/wiki/YAML
 [string matcher]: #string-matcher


### PR DESCRIPTION
Note that the default deny rule behavior is subject to the downstream mTLS "Enforcement Mode" setting. Update the existing reference link target to the newer "Downstream mTLS Settings" page.