### PR TITLE
Docs: runs prettier to cleanup unrelated code and text

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,12 +1,12 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "monthly"
+      interval: 'monthly'
     open-pull-requests-limit: 50
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "monthly"
+      interval: 'monthly'
     open-pull-requests-limit: 50

--- a/content/docs/deploy/k8s/reference.md
+++ b/content/docs/deploy/k8s/reference.md
@@ -4,10 +4,10 @@ sidebar_label: Reference
 description: Reference for Pomerium settings in Kubernetes deployments.
 ---
 
-Pomerium-specific parameters should be configured via the `ingress.pomerium.io/Pomerium` CRD.
-The default Pomerium deployment is listening to the CRD `global`, that may be customized via command line parameters.
+Pomerium-specific parameters should be configured via the `ingress.pomerium.io/Pomerium` CRD. The default Pomerium deployment is listening to the CRD `global`, that may be customized via command line parameters.
 
 Pomerium posts updates to the CRD <a href="#status">`/status`</a>:
+
 ```shell
 kubectl describe pomerium
 ```
@@ -262,8 +262,6 @@ PomeriumSpec defines Pomerium-specific configuration parameters.
     </tbody>
 </table>
 
-
-
 ### `authenticate`
 
 Authenticate sets authenticate service parameters. If not specified, a Pomerium-hosted authenticate service would be used.
@@ -312,8 +310,6 @@ Authenticate sets authenticate service parameters. If not specified, a Pomerium-
     
     </tbody>
 </table>
-
-
 
 ### `cookie`
 
@@ -425,8 +421,6 @@ Cookie defines Pomerium session cookie options.
     
     </tbody>
 </table>
-
-
 
 ### `identityProvider`
 
@@ -578,8 +572,6 @@ IdentityProvider configure single-sign-on authentication and user identity detai
     </tbody>
 </table>
 
-
-
 ### `postgres`
 
 Postgres specifies PostgreSQL database connection parameters
@@ -648,8 +640,6 @@ Postgres specifies PostgreSQL database connection parameters
     
     </tbody>
 </table>
-
-
 
 ### `redis`
 
@@ -736,8 +726,6 @@ Redis defines REDIS connection parameters
     </tbody>
 </table>
 
-
-
 ### `refreshDirectory`
 
 RefreshDirectory is no longer supported, please see <a href="https://docs.pomerium.com/docs/overview/upgrading#idp-directory-sync">Upgrade Guide</a>.
@@ -788,8 +776,6 @@ RefreshDirectory is no longer supported, please see <a href="https://docs.pomeri
     </tbody>
 </table>
 
-
-
 ### `storage`
 
 Storage defines persistent storage for sessions and other data. See <a href="https://www.pomerium.com/docs/topics/data-storage">Storage</a> for details. If no storage is specified, Pomerium would use a transient in-memory storage (not recommended for production).
@@ -835,8 +821,6 @@ Storage defines persistent storage for sessions and other data. See <a href="htt
     
     </tbody>
 </table>
-
-
 
 ### `timeouts`
 
@@ -907,8 +891,6 @@ Timeout specifies the <a href="https://www.pomerium.com/docs/reference/global-ti
     </tbody>
 </table>
 
-
-
 ## Status
 
 PomeriumStatus represents configuration and Ingress status.
@@ -954,8 +936,6 @@ PomeriumStatus represents configuration and Ingress status.
     
     </tbody>
 </table>
-
-
 
 ### `ingress`
 
@@ -1052,8 +1032,6 @@ ResourceStatus represents the outcome of the latest attempt to reconcile relevan
     </tbody>
 </table>
 
-
-
 ### `settingsStatus`
 
 SettingsStatus represent most recent main configuration reconciliation status.
@@ -1148,6 +1126,3 @@ SettingsStatus represent most recent main configuration reconciliation status.
     
     </tbody>
 </table>
-
-
-

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -38,10 +38,7 @@ const config = {
           customCss: require.resolve('./src/css/custom.css'),
         },
         gtag: {
-          trackingID: [
-            `${process.env.GA4}`,
-            `${process.env.GA}`,
-          ]
+          trackingID: [`${process.env.GA4}`, `${process.env.GA}`],
         },
         sitemap: {
           filename: 'docs/sitemap.xml',
@@ -171,7 +168,14 @@ const config = {
     prism: {
       theme: lightCodeTheme(),
       darkTheme: darkCodeTheme(),
-      additionalLanguages: ['actionscript', 'log', 'ini', 'nginx', 'rego', 'shell-session'],
+      additionalLanguages: [
+        'actionscript',
+        'log',
+        'ini',
+        'nginx',
+        'rego',
+        'shell-session',
+      ],
     },
   },
   stylesheets: [
@@ -191,17 +195,23 @@ const config = {
 // The prism-react-renderer themes do not define styles for the 'shell-session'
 // token types, so define our own styles for these types here.
 function lightCodeTheme() {
-  return {...githubCodeTheme, styles: githubCodeTheme.styles.concat([
-    {types: ['shell-symbol'], style: { color: '#5d36c6' }},
-    {types: ['command'], style: { color: '#1c1e21' }},
-    {types: ['output'], style: { color: '#133369' }}
-  ])};
+  return {
+    ...githubCodeTheme,
+    styles: githubCodeTheme.styles.concat([
+      {types: ['shell-symbol'], style: {color: '#5d36c6'}},
+      {types: ['command'], style: {color: '#1c1e21'}},
+      {types: ['output'], style: {color: '#133369'}},
+    ]),
+  };
 }
 function darkCodeTheme() {
-  return {...draculaCodeTheme, styles: draculaCodeTheme.styles.concat([
-    {types: ['shell-symbol'], style: { color: '#c0a9ff' }},
-    {types: ['output'], style: { color: '#e4e4c4' }}
-  ])};
+  return {
+    ...draculaCodeTheme,
+    styles: draculaCodeTheme.styles.concat([
+      {types: ['shell-symbol'], style: {color: '#c0a9ff'}},
+      {types: ['output'], style: {color: '#e4e4c4'}},
+    ]),
+  };
 }
 
 if (!process.env.ALGOLIA_APPID) {

--- a/src/components/HomepageLayout/VideoCards.js
+++ b/src/components/HomepageLayout/VideoCards.js
@@ -7,148 +7,139 @@ import Typography from '@mui/material/Typography';
 import Link from '@docusaurus/Link';
 import {useColorMode} from '@docusaurus/theme-common';
 
-
 export default function VideoMediaCard() {
-
   const {colorMode} = useColorMode();
 
   return (
     <div>
       <div>
-      <Card sx={{
-        maxWidth: 850,
-        mb: 7,
-        ml: 0
-        }}>
-        <CardMedia
-          component="iframe"
-          alt="2-minute explainer video of what Pomerium is."
-          height="350"
-          width="100%"
-          src="https://www.youtube.com/embed/WGwC9ULDnAY?rel=0"
-        />
-        <CardContent sx={{
-          bgcolor:
-          colorMode === 'dark'
-            ? '#121212'
-            : ""
-        }}>
-          <Typography gutterBottom variant="h5" component="div" sx={{
-              color:
-              colorMode === 'dark'
-                ? '#ebedf0;'
-                : ""
+        <Card
+          sx={{
+            maxWidth: 850,
+            mb: 7,
+            ml: 0,
           }}>
-            Pomerium Demo
-          </Typography>
-          <Typography variant="body1" sx={{
-              color:
-              colorMode === 'dark'
-                ? '#ebedf0;'
-                : ""
-          }}>
-            Learn how Pomerium secures your apps and services in this 2-minute demo.
-          </Typography>
-        </CardContent>
-        <CardActions sx={{
-          bgcolor:
-          colorMode === 'dark'
-            ? '#121212'
-            : ""
-        }}>
-          <Link to="/docs/quickstart">
-            Try Quickstart
-          </Link>
-        </CardActions>
-      </Card>
+          <CardMedia
+            component="iframe"
+            alt="2-minute explainer video of what Pomerium is."
+            height="350"
+            width="100%"
+            src="https://www.youtube.com/embed/WGwC9ULDnAY?rel=0"
+          />
+          <CardContent
+            sx={{
+              bgcolor: colorMode === 'dark' ? '#121212' : '',
+            }}>
+            <Typography
+              gutterBottom
+              variant="h5"
+              component="div"
+              sx={{
+                color: colorMode === 'dark' ? '#ebedf0;' : '',
+              }}>
+              Pomerium Demo
+            </Typography>
+            <Typography
+              variant="body1"
+              sx={{
+                color: colorMode === 'dark' ? '#ebedf0;' : '',
+              }}>
+              Learn how Pomerium secures your apps and services in this 2-minute
+              demo.
+            </Typography>
+          </CardContent>
+          <CardActions
+            sx={{
+              bgcolor: colorMode === 'dark' ? '#121212' : '',
+            }}>
+            <Link to="/docs/quickstart">Try Quickstart</Link>
+          </CardActions>
+        </Card>
       </div>
       <div>
-      <Card sx={{
-        maxWidth: 850,
-        mb: 7,
-        ml: 0
-        }}>
-        <CardMedia
-          component="iframe"
-          alt="something"
-          height="350"
-          width="100%"
-          src="https://www.youtube.com/embed/bUZUg0e3A1Y"
-        />
-        <CardContent sx={{
-          bgcolor:
-          colorMode === 'dark'
-            ? '#121212'
-            : ""
-        }}>
-          <Typography gutterBottom variant="h5" component="div" sx={{
-              color:
-              colorMode === 'dark'
-                ? '#ebedf0;'
-                : ""
+        <Card
+          sx={{
+            maxWidth: 850,
+            mb: 7,
+            ml: 0,
           }}>
-            Clientless Access
-          </Typography>
-          <Typography variant="body1" sx={{
-              color:
-              colorMode === 'dark'
-                ? '#ebedf0;'
-                : ""
-          }}>
-          Learn how Pomerium simplifies access control by providing clientless access to users within your organization.
-          </Typography>
-        </CardContent>
-      </Card>
+          <CardMedia
+            component="iframe"
+            alt="something"
+            height="350"
+            width="100%"
+            src="https://www.youtube.com/embed/bUZUg0e3A1Y"
+          />
+          <CardContent
+            sx={{
+              bgcolor: colorMode === 'dark' ? '#121212' : '',
+            }}>
+            <Typography
+              gutterBottom
+              variant="h5"
+              component="div"
+              sx={{
+                color: colorMode === 'dark' ? '#ebedf0;' : '',
+              }}>
+              Clientless Access
+            </Typography>
+            <Typography
+              variant="body1"
+              sx={{
+                color: colorMode === 'dark' ? '#ebedf0;' : '',
+              }}>
+              Learn how Pomerium simplifies access control by providing
+              clientless access to users within your organization.
+            </Typography>
+          </CardContent>
+        </Card>
       </div>
       <div>
-      <Card sx={{
-        maxWidth: 850,
-        mb: 7,
-        ml: 0
-        }}>
-        <CardMedia
-          component="iframe"
-          alt="something"
-          height="350"
-          width="100%"
-          src="https://www.youtube.com/embed/3MJrNvQ7aIE"
-        />
-        <CardContent sx={{
-          bgcolor:
-          colorMode === 'dark'
-            ? '#121212'
-            : ""
-        }}>
-          <Typography gutterBottom variant="h5" component="div" sx={{
-              color:
-              colorMode === 'dark'
-                ? '#ebedf0;'
-                : ""
+        <Card
+          sx={{
+            maxWidth: 850,
+            mb: 7,
+            ml: 0,
           }}>
-            Continuous Verification
-          </Typography>
-          <Typography variant="body1" sx={{
-              color:
-              colorMode === 'dark'
-                ? '#ebedf0;'
-                : ""
-          }}>
-            Learn what Continuous Verification is, how it works with Pomerium, and why it's important for building a Zero Trust Architecture.
-          </Typography>
-        </CardContent>
-        <CardActions sx={{
-          bgcolor:
-          colorMode === 'dark'
-            ? '#121212'
-            : ""
-        }}>
-        <Link to="/docs/capabilities/authorization">
-            Go to Authorization Docs
-          </Link>
-        </CardActions>
-      </Card>
+          <CardMedia
+            component="iframe"
+            alt="something"
+            height="350"
+            width="100%"
+            src="https://www.youtube.com/embed/3MJrNvQ7aIE"
+          />
+          <CardContent
+            sx={{
+              bgcolor: colorMode === 'dark' ? '#121212' : '',
+            }}>
+            <Typography
+              gutterBottom
+              variant="h5"
+              component="div"
+              sx={{
+                color: colorMode === 'dark' ? '#ebedf0;' : '',
+              }}>
+              Continuous Verification
+            </Typography>
+            <Typography
+              variant="body1"
+              sx={{
+                color: colorMode === 'dark' ? '#ebedf0;' : '',
+              }}>
+              Learn what Continuous Verification is, how it works with Pomerium,
+              and why it's important for building a Zero Trust Architecture.
+            </Typography>
+          </CardContent>
+          <CardActions
+            sx={{
+              bgcolor: colorMode === 'dark' ? '#121212' : '',
+            }}>
+            <Link to="/docs/capabilities/authorization">
+              Go to Authorization Docs
+            </Link>
+          </CardActions>
+        </Card>
       </div>
     </div>
-  )
+  );
 }
-


### PR DESCRIPTION
Just a quick cleanup PR to fix formatting on pages and code so that it prettier won't throw an error when running `yarn format`.