### PR TITLE
Docs: updates global and route pass id headers settings

### DIFF
--- a/content/docs/capabilities/getting-users-identity.md
+++ b/content/docs/capabilities/getting-users-identity.md
@@ -168,6 +168,6 @@ In an actual client, you'll want to ensure that all the other claims values are 
 [jwt.io]: https://jwt.io/
 [key management service]: https://en.wikipedia.org/wiki/Key_management
 [nist p-256]: https://csrc.nist.gov/csrc/media/events/workshop-on-elliptic-curve-cryptography-standards/documents/papers/session6-adalier-mehmet.pdf
-[pass identity headers]: /docs/reference/routes/pass-identity-headers
+[pass identity headers]: /docs/reference/routes/pass-identity-headers-per-route
 [signing key]: /docs/reference/signing-key
 [signing key file]: /docs/reference/signing-key-file

--- a/content/docs/capabilities/original-request-context.md
+++ b/content/docs/capabilities/original-request-context.md
@@ -57,7 +57,7 @@ routes:
 - **API** is also accessed through it's Pomerium Route, but is only accessible by the **App**, using a [service account](/docs/capabilities/service-accounts) to authenticate.
 - The **API** service needs to know the user making the request to **App** in order to formulate the correct response.
 
-Both Routes include [`pass_identity_headers`](/docs/reference/routes/pass-identity-headers), which provides (at minimum) the `X-Pomerium-Jwt-Assertion` header to the downstream application.
+Both Routes include [`pass_identity_headers`](/docs/reference/routes/pass-identity-headers-per-route), which provides (at minimum) the `X-Pomerium-Jwt-Assertion` header to the downstream application.
 
 When a user makes a request that requires data from the API service, the following happens:
 

--- a/content/docs/concepts/mutual-auth.md
+++ b/content/docs/concepts/mutual-auth.md
@@ -177,7 +177,7 @@ In this example:
 [grafana]: /docs/guides/grafana
 [jwt verification]: /docs/guides/jwt-verification.md
 [jwt-rfc]: https://datatracker.ietf.org/doc/html/rfc7519
-[`pass_identity_headers`]: /docs/reference/routes/pass-identity-headers
+[`pass_identity_headers`]: /docs/reference/routes/pass-identity-headers-per-route
 [quickstart]: /docs/quickstart
 [transport layer security]: https://en.wikipedia.org/wiki/Transport_Layer_Security
 [zero trust]: https://www.pomerium.com/docs/background.html

--- a/content/docs/deploy/k8s/ingress.md
+++ b/content/docs/deploy/k8s/ingress.md
@@ -659,7 +659,7 @@ For more information on the Pomerium Ingress Controller or the Kubernetes concep
 [`ingress.pomerium.io/idle_timeout`]: /docs/reference/routes/timeouts#idle-timeout
 [`ingress.pomerium.io/lb_config`]: /docs/reference/load-balancing-policy-config
 [`ingress.pomerium.io/outlier_detection`]: /docs/reference/routes/outlier-detection
-[`ingress.pomerium.io/pass_identity_headers`]: /docs/reference/routes/pass-identity-headers
+[`ingress.pomerium.io/pass_identity_headers`]: /docs/reference/routes/pass-identity-headers-per-route
 [`ingress.pomerium.io/policy`]: /docs/reference/routes/policy
 [`ingress.pomerium.io/prefix_rewrite`]: /docs/reference/routes/path-rewriting#prefix-rewrite
 [`ingress.pomerium.io/preserve_host_header`]: /docs/reference/routes/headers#host-rewrite

--- a/content/docs/deploy/k8s/reference.md
+++ b/content/docs/deploy/k8s/reference.md
@@ -167,7 +167,7 @@ PomeriumSpec defines Pomerium-specific configuration parameters.
                 </p>
                 <p>
                     
-                    PassIdentityHeaders sets the <a href="https://www.pomerium.com/docs/reference/routes/pass-identity-headers">pass identity headers</a> option.
+                    PassIdentityHeaders sets the <a href="https://www.pomerium.com/docs/reference/routes/pass-identity-headers-per-route">pass identity headers</a> option.
                 </p>
                 
             </td>

--- a/content/docs/guides/code-server.mdx
+++ b/content/docs/guides/code-server.mdx
@@ -151,7 +151,7 @@ Allow your route to create [Websocket connections](/docs/reference/routes/timeou
 1. Select **Timeouts**
 2. Select **Allow Websockets**
 
-Add a policy and allow your route to [pass identity headers](/docs/reference/routes/pass-identity-headers):
+Add a policy and allow your route to [pass identity headers](/docs/reference/routes/pass-identity-headers-per-route):
 
 1. Under **General** > **Policies**, select **Allow anybody**
 2. Select **Pass identity headers to upstream applications**

--- a/content/docs/guides/gitlab.mdx
+++ b/content/docs/guides/gitlab.mdx
@@ -164,7 +164,7 @@ Now when you first initiate a `pull`, `push`, or `fetch` command your web browse
 
 ## Identity Management
 
-While GitLab has a [JWT OmniAuth provider], it only accepts a JSON web token (**JWT**) as a callback url parameter and not as an HTTP header [provided by Pomerium](/docs/reference/routes/pass-identity-headers). If your IdP is a [supported OmniAuth provider](https://docs.gitlab.com/ee/integration/omniauth.html#supported-providers), you can integrate it directly to GitLab to re-use your current session, but it will require signing in twice; once with Pomerium and again with GitLab:
+While GitLab has a [JWT OmniAuth provider], it only accepts a JSON web token (**JWT**) as a callback url parameter and not as an HTTP header [provided by Pomerium](/docs/reference/routes/pass-identity-headers-per-route). If your IdP is a [supported OmniAuth provider](https://docs.gitlab.com/ee/integration/omniauth.html#supported-providers), you can integrate it directly to GitLab to re-use your current session, but it will require signing in twice; once with Pomerium and again with GitLab:
 
 <video controls muted={true} width="100%">
   <source src="/gitlab-login.webm" type="video/webm" />

--- a/content/docs/identity-providers/oidc.mdx
+++ b/content/docs/identity-providers/oidc.mdx
@@ -176,7 +176,7 @@ Note the following points:
 
 - The `idp_provider_url` should match the Keycloak network alias in your Docker Compose file. So that it's valid, add the protocol (`http://`) and the correct path (`/realms/<your_realm>`) to the URL.
 - The `signing_key` is used by Pomerium to cryptographically sign the user's JWT, and is required for [identity verification](/docs/capabilities/getting-users-identity)
-- The [`pass_identity_headers`](/docs/reference/routes/pass-identity-headers) setting forwards the JWT Assertion Header to the upstream application
+- The [`pass_identity_headers`](/docs/reference/routes/pass-identity-headers-per-route) setting forwards the JWT Assertion Header to the upstream application
 
 :::caution
 

--- a/content/docs/reference/jwt-claim-headers.mdx
+++ b/content/docs/reference/jwt-claim-headers.mdx
@@ -20,7 +20,7 @@ import TabItem from '@theme/TabItem';
 
 The **JWT Claims Headers** setting allows you to pass specific user session data to upstream applications as HTTP request headers. Claims forwarded with JWT Claims Headers are not signed by the Authorization Service (unlike the ` X-Pomerium-Jwt-Assertion` header).
 
-Forwarding a claim with JWT Claims Headers adds the claim to the X-Pomerium-Jwt-Assertion header if the claim is not already included in the assertion header. Both JWT Claims Headers and the signed assertion header are forwarded with the [`pass_identity_headers`](/docs/reference/routes/pass-identity-headers) setting.
+Forwarding a claim with JWT Claims Headers adds the claim to the X-Pomerium-Jwt-Assertion header if the claim is not already included in the assertion header. Both JWT Claims Headers and the signed assertion header are forwarded with the [`pass_identity_headers`](/docs/reference/routes/pass-identity-headers-per-route) setting.
 
 ## How to configure
 

--- a/content/docs/reference/pass-identity-headers.mdx
+++ b/content/docs/reference/pass-identity-headers.mdx
@@ -1,32 +1,26 @@
 ---
-id: global-pass-identity-headers
-title: (Global) Pass Identity Headers
+id: pass-identity-headers
+title: Pass Identity Headers
 description: The global Pass Identity Headers setting passes identity headers to all routes by default.
 keywords: [identity headers, reverse proxy]
-sidebar_label: (Global) Pass Identity Headers
+sidebar_label: Pass Identity Headers
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# (Global) Pass Identity Headers
+# Pass Identity Headers
 
 ## Summary
 
-When set to true, the **Global Pass Identity Headers** setting sends identity headers to all upstream applications.
+When set to true, the **Pass Identity Headers** setting sends identity headers to all upstream applications.
 
-If a route already has the route-level `pass_identity_headers` setting configured, the route option will take precedence over the global setting.
+If a route already has the [route-level Pass Identity Headers](/docs/reference/routes/pass-identity-headers) setting set, the route setting will take precedence over the global setting.
 
 Identity headers include:
 
 - `X-Pomerium-Jwt-Assertion`
 - `X-Pomerium-Claim-*` (see [JWT Claim Headers](/docs/reference/jwt-claim-headers) for more information)
-
-:::info
-
-To only send identity headers to a specific upstream application, see the route-level [**Pass Identity Headers**](/docs/reference/routes/pass-identity-headers) setting.
-
-:::
 
 ## How to configure
 
@@ -40,7 +34,7 @@ To only send identity headers to a specific upstream application, see the route-
 </TabItem>
 <TabItem value="Enterprise" label="Enterprise">
 
-Configure **(Global) Pass Identity Headers** in the Console with the **Pass Identity Headers** toggle button.
+Configure **Pass Identity Headers** in the Console with the **Pass Identity Headers** toggle button.
 
 The button has three states:
 
@@ -65,7 +59,6 @@ The button has three states:
 ### Examples
 
 ```yaml
-# config file key
 pass_identity_headers: true
 
 routes:
@@ -74,6 +67,5 @@ routes:
 ```
 
 ```yaml
-# ingress controller
 passIdentityHeaders: 'true'
 ```

--- a/content/docs/reference/pass-identity-headers.mdx
+++ b/content/docs/reference/pass-identity-headers.mdx
@@ -15,7 +15,7 @@ import TabItem from '@theme/TabItem';
 
 When set to true, the **Pass Identity Headers** setting sends identity headers to all upstream applications.
 
-If a route already has the [route-level Pass Identity Headers](/docs/reference/routes/pass-identity-headers) setting set, the route setting will take precedence over the global setting.
+If a route already has the [route-level Pass Identity Headers](/docs/reference/routes/pass-identity-headers-per-route) setting set, the route setting will take precedence over the global setting.
 
 Identity headers include:
 

--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -925,21 +925,21 @@
     "services": ["proxy"],
     "type": "object"
   },
-  "pass-identity-headers": {
-    "id": "pass-identity-headers",
-    "title": "Pass Identity Headers",
+  "pass-identity-headers-per-route": {
+    "id": "pass-identity-headers-per-route",
+    "title": "Pass Identity Headers (per route)",
     "description": "When set, Pass Identity Headers passes identity headers to the upstream application.",
     "short_description": "Pass identity headers to the upstream application",
-    "path": "/routes/pass-identity-headers",
+    "path": "/routes/pass-identity-headers-per-route",
     "services": ["proxy"],
     "type": "boolean"
   },
-  "global-pass-identity-headers": {
-    "id": "global-pass-identity-headers",
-    "title": "(Global) Pass Identity Headers",
+  "pass-identity-headers": {
+    "id": "pass-identity-headers",
+    "title": "Pass Identity Headers",
     "description": "The global Pass Identity Headers setting passes identity headers to all upstream applications.",
     "short_description": "Pass identity headers to all upstream applications",
-    "path": "/global-pass-identity-headers",
+    "path": "/pass-identity-headers",
     "services": ["proxy"],
     "type": "boolean"
   },

--- a/content/docs/reference/routes/pass-identity-headers.mdx
+++ b/content/docs/reference/routes/pass-identity-headers.mdx
@@ -1,6 +1,6 @@
 ---
-id: pass-identity-headers
-title: Pass Identity Headers
+id: pass-identity-headers-per-route
+title: Pass Identity Headers (per route)
 keywords:
   - reference
   - Pass Identity Headers
@@ -11,7 +11,7 @@ pagination_next: null
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Pass Identity Headers
+# Pass Identity Headers (per route)
 
 ## Summary
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -445,6 +445,9 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/reference/routes/signout-redirect-url /docs/reference/signout-redirect-url
 /reference/* /docs/reference/:splat
 
+# Pass Identity Headers
+/docs/reference/routes/pass-identity-headers /docs/reference/routes/pass-identity-headers-per-route
+
 # Topics links - now concepts
 /docs/topics/auth-logs /docs/capabilities/audit-logs
 /docs/topics/single-sign-out.html /docs/capabilities/single-sign-out

--- a/static/_redirects
+++ b/static/_redirects
@@ -446,7 +446,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /reference/* /docs/reference/:splat
 
 # Pass Identity Headers
-/docs/reference/routes/pass-identity-headers /docs/reference/routes/pass-identity-headers-per-route
+/docs/reference/routes/pass-identity-headers-per-route /docs/reference/routes/pass-identity-headers-per-route-per-route
 
 # Topics links - now concepts
 /docs/topics/auth-logs /docs/capabilities/audit-logs


### PR DESCRIPTION
This PR updates the global- and route-level Pass ID Headers settings so they're consistent with other settings that share global and route entries. 

Here's the main change:
- route-level Pass ID Headers is now `/reference/routes/pass-identity-headers-per-route`  
- global-level is now `/reference/pass-identity-headers` 
- the `reference.json` file has been updated to reflect these changes

@calebdoxsey and @nhayfield once this is merged, can you two update Console so that the Help Docs links don't break? 