### PR TITLE
Docs: fixes core service example

### DIFF
--- a/content/docs/reference/service-mode.mdx
+++ b/content/docs/reference/service-mode.mdx
@@ -40,11 +40,11 @@ import TabItem from '@theme/TabItem';
 ### Examples
 
 ```yaml
-service: authorize
+services: authorize
 ```
 
 ```bash
-SERVICE=databroker
+SERVICES=databroker
 ```
 
 </TabItem>


### PR DESCRIPTION
Fixes a Core example that was missed in https://github.com/pomerium/documentation/pull/1114