### PR TITLE
Docs: adds core v0.25 changelog

### DIFF
--- a/content/docs/deploy/core/changelog.mdx
+++ b/content/docs/deploy/core/changelog.mdx
@@ -8,6 +8,143 @@ lang: en-US
 
 Please refer to the [upgrade guide](/docs/deploy/core/upgrading) before upgrading.
 
+## [v0.25.0](https://github.com/pomerium/pomerium/tree/v0.25.0) (2024-01-10)
+
+[Full Changelog](https://github.com/pomerium/pomerium/compare/v0.24.0...v0.25.0)
+
+### Breaking
+
+- **config**: remove support for base64 encoded certificates in the [`certificates`](https://www.pomerium.com/docs/reference/certificates#certificates) field. It may only contain file locations. See https://github.com/pomerium/pomerium/pull/4718 by @calebdoxsey for details.
+- **config**: remove [`debug`](https://www.pomerium.com/docs/reference/debug#summary) option, always use json logs by @calebdoxsey in https://github.com/pomerium/pomerium/pull/4857
+
+### New
+
+- **authenticate**: Refactoring identity authenticators to initiate redirect. For AWS Cognito, please allow the following sign out `https://{AUTHENTICATE_DOMAIN}/.pomerium/signed_out` URL. See more details in https://github.com/pomerium/pomerium/pull/4858 by @calebdoxsey.
+- Initial support for the [Pomerium Zero](https://www.pomerium.com/pomerium-zero/) closed beta is included in this release.
+
+### Fixed
+
+- **config**: add support for maps in environments, i.e. `env IDP_REQUEST_PARAMS='{"x":"y"}' ...` by @calebdoxsey in https://github.com/pomerium/pomerium/pull/4717
+- **core**: fix graceful stop by @calebdoxsey in https://github.com/pomerium/pomerium/pull/4865
+- **databroker**: fix nil data unmarshal by @calebdoxsey in https://github.com/pomerium/pomerium/pull/4734
+- **databroker**: fix Patch() error handling for in-memory databroker backend by @kenjenkins in https://github.com/pomerium/pomerium/pull/4838
+- **databroker**: hijack connections for notification listeners by @calebdoxsey in https://github.com/pomerium/pomerium/pull/4806
+- **databroker**: prevent `nil` data in the databroker deleted records by @wasaga in https://github.com/pomerium/pomerium/pull/4736
+- **databroker**: REDIS backend has been removed in the previous release, https://github.com/pomerium/pomerium/pull/4768 by @calebdoxsey cleans up some remaining references.
+- **envoy**: Rewrite the remove_pomerium_cookie lua function to handle `=` inside of cookie values. by @calebdoxsey in https://github.com/pomerium/pomerium/pull/4641
+- **metrics**: enforce `text/plain` metric format by @kenjenkins in https://github.com/pomerium/pomerium/pull/4774
+- **zero**: group funcs that need run within a lease by @wasaga in https://github.com/pomerium/pomerium/pull/4862
+
+### Changed
+
+- **authenticate**: add stateful flow by @kenjenkins in https://github.com/pomerium/pomerium/pull/4822
+- **authenticate**: change how sessions are deleted by @kenjenkins in https://github.com/pomerium/pomerium/pull/4893
+- **authenticate**: getUserInfoData() cleanup by @kenjenkins in https://github.com/pomerium/pomerium/pull/4818
+- **authenticate**: move events.go out of internal/authenticateflow by @kenjenkins in https://github.com/pomerium/pomerium/pull/4852
+- **authenticate**: move stateless flow logic by @kenjenkins in https://github.com/pomerium/pomerium/pull/4820
+- **authenticate**: move logAuthenticateEvent by @kenjenkins in https://github.com/pomerium/pomerium/pull/4821
+- **authenticate**: remove extra UpdateUserInfo() call by @kenjenkins in https://github.com/pomerium/pomerium/pull/4813
+- **authenticate**: Update the initialization logic for the authenticate, authorize, and proxy services to automatically select between the stateful authentication flow and the stateless authentication flow, depending on whether Pomerium is configured to use the hosted authenticate service. This change ensures a single IdP session is maintained for all user visits, enabling a single sign out behaviour for installations with IdP configured. @kenjenkins in https://github.com/pomerium/pomerium/pull/4765
+- **authenticate**: verify redirect in Callback test by @kenjenkins in https://github.com/pomerium/pomerium/pull/4894
+- **config**: Add a global config option for pass_identity_headers, in addition to existing per-route option by @calebdoxsey in https://github.com/pomerium/pomerium/pull/4720
+- **config**: disable strict-transport-security header with staging autocert by @calebdoxsey in https://github.com/pomerium/pomerium/pull/4741
+- **config**: no longer stub out HPKE public key fetch by @kenjenkins in https://github.com/pomerium/pomerium/pull/4853
+- **config**: remove unnecessary authenticate route when using hosted authenticate (authenticate.pomerium.app) by @calebdoxsey in https://github.com/pomerium/pomerium/pull/4719
+- **runtime**: automatically determine goroutine max cap by @calebdoxsey in https://github.com/pomerium/pomerium/pull/4766
+- **runtime**: update to Go 1.21.4 by @kenjenkins in https://github.com/pomerium/pomerium/pull/4770
+- **session**: add unit tests for gRPC wrapper methods by @kenjenkins in https://github.com/pomerium/pomerium/pull/4713
+- **tests**: add tool for renewing test certs by @kenjenkins in https://github.com/pomerium/pomerium/pull/4742
+- **tests**: check for profile cookies by @kenjenkins in https://github.com/pomerium/pomerium/pull/4847
+- **tests**: renew test certs by @kenjenkins in https://github.com/pomerium/pomerium/pull/4738
+- **tests**: re-generate test configurations by @kenjenkins in https://github.com/pomerium/pomerium/pull/4816
+- **zero**: add linear probabilistic counter for MAU estimation by @wasaga in https://github.com/pomerium/pomerium/pull/4776
+- **zero**: add more verbose logging about background control loops by @wasaga in https://github.com/pomerium/pomerium/pull/4815
+- **zero**: add reporter by @wasaga in https://github.com/pomerium/pomerium/pull/4855
+- **zero**: add support for managed mode from config file by @calebdoxsey in https://github.com/pomerium/pomerium/pull/4756
+- **zero**: better code reuse by @wasaga in https://github.com/pomerium/pomerium/pull/4758
+- **zero**: calculate DAU and MAU by @wasaga in https://github.com/pomerium/pomerium/pull/4810
+- **zero**: fix restart behavior by @kenjenkins in https://github.com/pomerium/pomerium/pull/4753
+- **zero**: rebase and merge feature/zero branch by @kenjenkins in https://github.com/pomerium/pomerium/pull/4745
+- **zero**: set drwx------ for cache dir by @wasaga in https://github.com/pomerium/pomerium/pull/4764
+- **zero**: support gzipped blobs by @wasaga in https://github.com/pomerium/pomerium/pull/4767
+- **zero**: use os.UserCacheDir for boostrap config path by @kenjenkins in https://github.com/pomerium/pomerium/pull/4744
+- **zero**: use production urls by default by @wasaga in https://github.com/pomerium/pomerium/pull/4814
+
+### Dependency
+
+- bump actions/checkout from 4.1.0 to 4.1.1 by @dependabot in https://github.com/pomerium/pomerium/pull/4692
+- bump actions/setup-go from 4.1.0 to 5.0.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4830
+- bump actions/setup-node from 3.8.1 to 4.0.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4694
+- bump actions/setup-node from 4.0.0 to 4.0.1 by @dependabot in https://github.com/pomerium/pomerium/pull/4888
+- bump actions/setup-python from 4.7.0 to 5.0.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4827
+- bump actions/stale from 8.0.0 to 9.0.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4825
+- bump actions/upload-artifact from 3.1.3 to 4.0.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4889
+- bump busybox from `3fbc632` to `1ceb872` in /.github by @dependabot in https://github.com/pomerium/pomerium/pull/4824
+- bump busybox from `1ceb872` to `ba76950` in /.github by @dependabot in https://github.com/pomerium/pomerium/pull/4884
+- bump cloud.google.com/go/storage from 1.33.0 to 1.35.1 by @dependabot in https://github.com/pomerium/pomerium/pull/4750
+- bump cloud.google.com/go/storage from 1.35.1 to 1.36.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4873
+- bump distroless/base from `46c5b9b` to `b31a6e0` in /.github by @dependabot in https://github.com/pomerium/pomerium/pull/4670
+- bump distroless/base from `b31a6e0` to `6c1e34e` in /.github by @dependabot in https://github.com/pomerium/pomerium/pull/4885
+- bump distroless/base-debian12 from `5e24c7a` to `996c583` by @dependabot in https://github.com/pomerium/pomerium/pull/4882
+- bump distroless/base-debian12 from `d2890b2` to `5e24c7a` by @dependabot in https://github.com/pomerium/pomerium/pull/4658
+- bump distroless/base-debian12 from `d64f548` to `1dfdb5e` in /.github by @dependabot in https://github.com/pomerium/pomerium/pull/4671
+- bump distroless/base-debian12 from `1dfdb5e` to `0a93daa` in /.github by @dependabot in https://github.com/pomerium/pomerium/pull/4886
+- bump docker/build-push-action from 5.0.0 to 5.1.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4777
+- bump docker/metadata-action from 5.0.0 to 5.3.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4826
+- bump docker/metadata-action from 5.3.0 to 5.4.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4891
+- bump github.com/aws/aws-sdk-go-v2 from 1.22.2 to 1.24.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4840
+- bump github.com/aws/aws-sdk-go-v2/service/s3 from 1.40.0 to 1.42.1 by @dependabot in https://github.com/pomerium/pomerium/pull/4751
+- bump github.com/bits-and-blooms/bitset from 1.11.0 to 1.13.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4876
+- bump github.com/caddyserver/certmagic from 0.19.2 to 0.20.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4836
+- bump github.com/cloudflare/circl from 1.3.3 to 1.3.6 by @dependabot in https://github.com/pomerium/pomerium/pull/4674
+- bump github.com/coreos/go-oidc/v3 from 3.6.0 to 3.8.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4791
+- bump github.com/coreos/go-oidc/v3 from 3.8.0 to 3.9.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4880
+- bump github.com/fsnotify/fsnotify from 1.6.0 to 1.7.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4680
+- bump github.com/google/go-cmp from 0.5.9 to 0.6.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4685
+- bump github.com/google/uuid from 1.3.1 to 1.4.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4677
+- bump github.com/google/uuid from 1.4.0 to 1.5.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4878
+- bump github.com/gorilla/mux from 1.8.0 to 1.8.1 by @dependabot in https://github.com/pomerium/pomerium/pull/4790
+- bump github.com/gorilla/websocket from 1.5.0 to 1.5.1 by @dependabot in https://github.com/pomerium/pomerium/pull/4793
+- bump github.com/go-chi/chi/v5 from 5.0.10 to 5.0.11 by @dependabot in https://github.com/pomerium/pomerium/pull/4875
+- bump github.com/go-jose/go-jose/v3 from 3.0.0 to 3.0.1 by @dependabot in https://github.com/pomerium/pomerium/pull/4760
+- bump github.com/jackc/pgx/v5 from 5.4.3 to 5.5.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4803
+- bump github.com/jackc/pgx/v5 from 5.5.0 to 5.5.1 by @dependabot in https://github.com/pomerium/pomerium/pull/4871
+- bump github.com/klauspost/compress from 1.17.0 to 1.17.4 by @dependabot in https://github.com/pomerium/pomerium/pull/4798
+- bump github.com/mattn/go-isatty from 0.0.19 to 0.0.20 by @dependabot in https://github.com/pomerium/pomerium/pull/4801
+- bump github.com/minio/minio-go/v7 from 7.0.63 to 7.0.65 by @dependabot in https://github.com/pomerium/pomerium/pull/4812
+- bump github.com/minio/minio-go/v7 from 7.0.65 to 7.0.66 by @dependabot in https://github.com/pomerium/pomerium/pull/4868
+- bump github.com/oapi-codegen/runtime from 1.0.0 to 1.1.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4870
+- bump github.com/open-policy-agent/opa from 0.57.0 to 0.59.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4799
+- bump github.com/open-policy-agent/opa from 0.59.0 to 0.60.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4879
+- bump github.com/prometheus/client_golang from 1.17.0 to 1.18.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4872
+- bump github.com/prometheus/client_model from 0.4.1-0.20230718164431-9a2bf3000d16 to 0.5.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4672
+- bump github.com/prometheus/common from 0.44.0 to 0.45.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4686
+- bump github.com/shirou/gopsutil/v3 from 3.23.9 to 3.23.11 by @dependabot in https://github.com/pomerium/pomerium/pull/4794
+- bump github.com/shirou/gopsutil/v3 from 3.23.11 to 3.23.12 by @dependabot in https://github.com/pomerium/pomerium/pull/4874
+- bump github.com/spf13/viper from 1.16.0 to 1.18.2 by @dependabot in https://github.com/pomerium/pomerium/pull/4861
+- bump github.com/VictoriaMetrics/fastcache from 1.12.1 to 1.12.2 by @dependabot in https://github.com/pomerium/pomerium/pull/4802
+- bump github.com/yuin/gopher-lua from 1.1.0 to 1.1.1 by @dependabot in https://github.com/pomerium/pomerium/pull/4832
+- bump golang from 1.21.4-bookworm to 1.21.5-bookworm by @dependabot in https://github.com/pomerium/pomerium/pull/4828
+- bump golang from `a6b787c` to `1415bb0` by @dependabot in https://github.com/pomerium/pomerium/pull/4883
+- bump golang.org/x/crypto from 0.16.0 to 0.17.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4860. This includes a patch for [GO-2023-2402](https://pkg.go.dev/vuln/GO-2023-2402) / [CVE-2023-48795](https://github.com/advisories/GHSA-45x7-px36-x8w8) (Terrapin). Note that Pomerium does not use the affected [golang.org/x/crypto/ssh](https://pkg.go.dev/golang.org/x/crypto/ssh) package from this module.
+- bump golang.org/x/net from 0.17.0 to 0.19.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4792
+- bump golang.org/x/oauth2 from 0.12.0 to 0.15.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4797
+- bump golang.org/x/sync from 0.3.0 to 0.5.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4748
+- bump golang.org/x/time from 0.3.0 to 0.5.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4796
+- bump google-github-actions/auth from 1.1.1 to 2.0.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4778
+- bump google-github-actions/setup-gcloud from 1.1.1 to 2.0.1 by @dependabot in https://github.com/pomerium/pomerium/pull/4890
+- bump google.golang.org/api from 0.143.0 to 0.153.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4835
+- bump google.golang.org/api from 0.153.0 to 0.154.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4867
+- bump google.golang.org/protobuf from 1.31.1-0.20231027082548-f4a6c1f6e5c1 to 1.32.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4877
+- bump mikefarah/yq from 4.35.2 to 4.40.3 by @dependabot in https://github.com/pomerium/pomerium/pull/4780
+- bump mikefarah/yq from 4.40.3 to 4.40.4 by @dependabot in https://github.com/pomerium/pomerium/pull/4829
+- bump mikefarah/yq from 4.40.4 to 4.40.5 by @dependabot in https://github.com/pomerium/pomerium/pull/4887
+- bump node from `42a4d97` to `5f21943` by @dependabot in https://github.com/pomerium/pomerium/pull/4659
+- bump node from `445acd9` to `8d0f16f` by @dependabot in https://github.com/pomerium/pomerium/pull/4881
+- bump sigs.k8s.io/yaml from 1.3.0 to 1.4.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4688
+- bump stefanzweifel/git-auto-commit-action from 4.16.0 to 5.0.0 by @dependabot in https://github.com/pomerium/pomerium/pull/4693
+- zero/openapi: pin v1.0.0 of a runtime by @wasaga in https://github.com/pomerium/pomerium/pull/4851
+
 ## [v0.24.0](https://github.com/pomerium/pomerium/tree/v0.24.0) (2023-11-16)
 
 [Full Changelog](https://github.com/pomerium/pomerium/compare/v0.23.0...v0.24.0)


### PR DESCRIPTION
This PR adds the v0.25 Core Changelog. Based on our release process steps, @desimone is to draft an upgrade guide. I have no problem drafting one, though. 