### PR TITLE
Docs: removes cookie secure example from Enterprise tab

### DIFF
--- a/content/docs/reference/cookies.mdx
+++ b/content/docs/reference/cookies.mdx
@@ -197,7 +197,7 @@ COOKIE_SECURE=false
 </TabItem>
 <TabItem value="Enterprise" label="Enterprise">
 
-As of v0.25, we've removed support for the **Cookie Secure** setting in the Enterprise Console (in the Console, this setting was called **Javascript Security**). Now, this setting is always enabled by default.
+As of v0.25, we've removed the **Cookie Secure** setting from the Enterprise Console (in the Console, this setting was called **HTTPS only**).
 
 </TabItem>
 <TabItem value="Kubernetes" label="Kubernetes">

--- a/content/docs/reference/cookies.mdx
+++ b/content/docs/reference/cookies.mdx
@@ -169,7 +169,11 @@ Setting this to `false` may result in session cookies being sent in clear text.
 
 :::
 
-Note: this cannot be set to `false` if [**Cookie SameSite**](#cookie-samesite) is set to `None`.
+:::note
+
+This setting cannot be set to `false` if [**Cookie SameSite**](#cookie-samesite) is set to `None`.
+
+:::
 
 ### How to configure {#cookie-secure-how-to-configure}
 
@@ -193,13 +197,7 @@ COOKIE_SECURE=false
 </TabItem>
 <TabItem value="Enterprise" label="Enterprise">
 
-Configure **Cookie Secure** with the **HTTPS only** toggle button in the Console. The button has three states:
-
-- **Unset** ("-") uses the value in your configuration file
-- **Checkmark** sets `cookie_secure` to `true`
-- **Empty** sets `cookie_secure` to `false`
-
-![Configure Cookie Secure in the Console](./img/cookies/cookie-settings.png)
+As of v0.25, we've removed support for the **Cookie Secure** setting in the Enterprise Console (in the Console, this setting was called **Javascript Security**). Now, this setting is always enabled by default.
 
 </TabItem>
 <TabItem value="Kubernetes" label="Kubernetes">


### PR DESCRIPTION
Fixes #1170 