### PR TITLE
reference.json: update Autocert link paths

### DIFF
--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -37,7 +37,7 @@
   },
   "autocert": {
     "id": "autocert",
-    "path": "/autocert",
+    "path": "/autocert#autocert",
     "title": "Autocert",
     "description": "Turning on autocert allows Pomerium to automatically retrieve, manage, and renew public facing TLS certificates from Lets Encrypt.",
     "short_description": "Retrieve, manage, and renew public-facing TLS certificates from Let's Encrypt.",
@@ -47,7 +47,7 @@
   "autocert-ca": {
     "id": "autocert-ca",
     "title": "Autocert CA",
-    "path": "/autocert",
+    "path": "/autocert#autocert-ca",
     "description": "Autocert CA is the directory URL of the ACME CA to use when requesting certificates.",
     "short_description": "The directory URL of the ACME CA to use when requesting certificates.",
     "type": "",
@@ -56,7 +56,7 @@
   "autocert-email": {
     "id": "autocert-email",
     "title": "Autocert Email",
-    "path": "/autocert",
+    "path": "/autocert#autocert-email",
     "description": "Autocert Email is the email address to use when requesting certificates from an ACME CA.",
     "short_description": "Use Autocert Email address when requesting certificates from an ACME CA.",
     "services": ["authenticate", "proxy"],
@@ -65,7 +65,7 @@
   "autocert-must-staple": {
     "id": "autocert-must-staple",
     "title": "Autocert Must-Staple",
-    "path": "/autocert",
+    "path": "/autocert#autocert-must-staple",
     "type": "bool",
     "short_description": "Force Autocert to request a certificate with the status_request extension",
     "services": ["authenticate", "proxy"]
@@ -73,7 +73,7 @@
   "autocert-directory": {
     "id": "autocert-directory",
     "title": "Autocert Directory",
-    "path": "/autocert",
+    "path": "/autocert#autocert-directory",
     "description": "Autocert directory is the path which Autocert will store x509 certificate data.",
     "services": ["authenticate", "proxy"],
     "short_description": "Path of Autocert directory storing certificate data",
@@ -82,7 +82,7 @@
   "autocert-use-staging": {
     "id": "autocert-use-staging",
     "title": "Autocert Use Staging",
-    "path": "/autocert",
+    "path": "/autocert#autocert-use-staging",
     "description": "Autocert Use Staging setting allows you to use Let's Encrypt's staging environment, which has more lenient usage limits than the production environment.",
     "short_description": "Use Let's Encrypt's staging environment.",
     "type": "bool",
@@ -91,7 +91,7 @@
   "autocert-eab-key-id": {
     "id": "autocert-eab-key-id",
     "title": "Autocert EAB Key ID",
-    "path": "/autocert",
+    "path": "/autocert#autocert-eab-key-id",
     "description": "Autocert EAB Key ID is the key identifier when requesting a certificate from a CA with External Account Binding enabled.",
     "short_description": "String containing the identifier for an ACME EAB key to use",
     "type": "string",
@@ -100,7 +100,7 @@
   "autocert-eab-mac-key": {
     "id": "autocert-eab-mac-key",
     "title": "Autocert EAB MAC Key",
-    "path": "/autocert",
+    "path": "/autocert#autocert-eab-mac-key",
     "description": "Autocert EAB MAC Key is the base64, url-encoded secret key corresponding to the Autocert EAB Key ID.",
     "short_description": "String containing secret key",
     "type": "string",
@@ -109,7 +109,7 @@
   "autocert-trusted-certificate-authority": {
     "id": "autocert-trusted-certificate-authority",
     "title": "Autocert Trusted Certificate Authority",
-    "path": "/autocert",
+    "path": "/autocert#autocert-trusted-certificate-authority",
     "services": ["authenticate", "proxy"],
     "type": "string",
     "short_description": "Certificate Authority relative file location string"


### PR DESCRIPTION
Update the Autocert settings entries in reference.json to link to specific section headings on the combined Autocert reference page.

Related: pomerium/pomerium-zero#1532