### PR TITLE
Docs: removes cookie secure setting

### DIFF
--- a/content/docs/reference/cookies.mdx
+++ b/content/docs/reference/cookies.mdx
@@ -17,7 +17,6 @@ This reference covers all of Pomerium's **Cookies Settings**:
 - [Cookie Name](#cookie-name)
 - [Cookie Secret](#cookie-secret)
 - [Cookie Domain](#cookie-domain)
-- [Cookie Secure](#cookie-secure)
 - [Cookie HTTP Only](#cookie-http-only)
 - [Cookie Expiration](#cookie-expiration)
 - [Cookie SameSite](#cookie-samesite)

--- a/content/docs/reference/cookies.mdx
+++ b/content/docs/reference/cookies.mdx
@@ -159,63 +159,6 @@ cookie:
 </TabItem>
 </Tabs>
 
-## Cookie Secure {#cookie-secure}
-
-If true, **Cookie Secure** instructs browsers to only send user session cookies over HTTPS.
-
-:::warning
-
-Setting this to `false` may result in session cookies being sent in clear text.
-
-:::
-
-:::note
-
-This setting cannot be set to `false` if [**Cookie SameSite**](#cookie-samesite) is set to `None`.
-
-:::
-
-### How to configure {#cookie-secure-how-to-configure}
-
-<Tabs>
-<TabItem value="Core" label="Core">
-
-| **Config file keys** | **Environment variables** | **Type**  | **Default** |
-| :------------------- | :------------------------ | :-------- | :---------- |
-| `cookie_secure`      | `COOKIE_SECURE`           | `boolean` | `true`      |
-
-#### Examples {#cookie-secure-examples}
-
-```yaml
-cookie_secure: false
-```
-
-```bash
-COOKIE_SECURE=false
-```
-
-</TabItem>
-<TabItem value="Enterprise" label="Enterprise">
-
-As of v0.25, we've removed the **Cookie Secure** setting from the Enterprise Console (in the Console, this setting was called **HTTPS only**).
-
-</TabItem>
-<TabItem value="Kubernetes" label="Kubernetes">
-
-| **[Parameter name](/docs/deploy/k8s/reference#cookie)** | **Type** | **Default** |
-| :-- | :-- | :-- |
-| `cookie.secure` | `boolean` | `true` |
-
-#### Examples {#cookie-secure-examples}
-
-```yaml
-cookie:
-  secure: false
-```
-
-</TabItem>
-</Tabs>
-
 ## Cookie HTTP Only {#cookie-http-only}
 
 If true, **Cookie HTTP Only** forbids JavaScript from accessing the cookie.

--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -191,28 +191,11 @@
     "description": "Configure and self-host your own Identity Provider with Pomerium's Identity Provider settings.",
     "type": "string"
   },
-  "cookie-secure": {
-    "id": "cookie-secure",
-    "title": "Secure Cookie",
-    "path": "/cookies#cookie-secure",
-    "description": "If true, instructs browsers to only send user session cookies over HTTPS.",
-    "services": [],
-    "type": "bool"
-  },
   "downstream-mtls-settings": {
     "id": "downstream-mtls-settings",
     "title": "Downstream mTLS Settings",
     "path": "/downstream-mtls-settings",
     "description": "Manage client certificate requirements for end users connecting to Pomerium-managed routes with downstream mTLS settings."
-  },
-  "https-only": {
-    "id": "https-only",
-    "title": "HTTPS only",
-    "path": "/cookies#cookie-secure",
-    "description": "If true, instructs browsers to only send user session cookies over HTTPS.",
-    "short_description": "Instruct browsers to only send user session cookies over HTTPS",
-    "services": [],
-    "type": "bool"
   },
   "identity-provider": {
     "id": "identity-provider",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@docusaurus/core": "^3.0.1",
     "@docusaurus/preset-classic": "^3.0.1",
     "@docusaurus/theme-common": "^3.0.1",
-    "@docusaurus/theme-mermaid": "3.0.1",
     "@docusaurus/types": "^3.0.1",
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2414,19 +2414,6 @@
     tslib "^2.6.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-mermaid@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-mermaid/-/theme-mermaid-3.0.1.tgz#a8e3db9f8ccb680f0a4359e2b0f6427f52223c15"
-  integrity sha512-jquSDnZfazABnC5i+02GzRIvufXKruKgvbYkQjKbI7/LWo0XvBs0uKAcCDGgHhth0t/ON5+Sn27joRfpeSk3Lw==
-  dependencies:
-    "@docusaurus/core" "3.0.1"
-    "@docusaurus/module-type-aliases" "3.0.1"
-    "@docusaurus/theme-common" "3.0.1"
-    "@docusaurus/types" "3.0.1"
-    "@docusaurus/utils-validation" "3.0.1"
-    mermaid "^10.4.0"
-    tslib "^2.6.0"
-
 "@docusaurus/theme-search-algolia@3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.0.1.tgz#d8fb6bddca8d8355e4706c4c7d30d3b800217cf4"
@@ -5433,11 +5420,6 @@ elkjs@^0.8.2:
   resolved "https://registry.yarnpkg.com/elkjs/-/elkjs-0.8.2.tgz#c37763c5a3e24e042e318455e0147c912a7c248e"
   integrity sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ==
 
-elkjs@^0.9.0:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/elkjs/-/elkjs-0.9.1.tgz#fd1524b3f0bed72dc65ba107ae91bcf04b5582bd"
-  integrity sha512-JWKDyqAdltuUcyxaECtYG6H4sqysXSLeoXuGUBfRNESMTkj+w+qdb0jya8Z/WI0jVd03WQtCGhS6FOFtlhD5FQ==
-
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -7559,32 +7541,6 @@ merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
-
-mermaid@^10.4.0:
-  version "10.7.0"
-  resolved "https://registry.yarnpkg.com/mermaid/-/mermaid-10.7.0.tgz#4fd5bfd60c0c5e5c42016a82905f06c4684ec53b"
-  integrity sha512-PsvGupPCkN1vemAAjScyw4pw34p4/0dZkSrqvAB26hUvJulOWGIwt35FZWmT9wPIi4r0QLa5X0PB4YLIGn0/YQ==
-  dependencies:
-    "@braintree/sanitize-url" "^6.0.1"
-    "@types/d3-scale" "^4.0.3"
-    "@types/d3-scale-chromatic" "^3.0.0"
-    cytoscape "^3.23.0"
-    cytoscape-cose-bilkent "^4.1.0"
-    cytoscape-fcose "^2.1.0"
-    d3 "^7.4.0"
-    d3-sankey "^0.12.3"
-    dagre-d3-es "7.0.10"
-    dayjs "^1.11.7"
-    dompurify "^3.0.5"
-    elkjs "^0.9.0"
-    khroma "^2.0.0"
-    lodash-es "^4.17.21"
-    mdast-util-from-markdown "^1.3.0"
-    non-layered-tidy-tree-layout "^2.0.2"
-    stylis "^4.1.3"
-    ts-dedent "^2.2.0"
-    uuid "^9.0.0"
-    web-worker "^1.2.0"
 
 mermaid@^10.6.1:
   version "10.6.1"


### PR DESCRIPTION
Removes the `cookie_secure` setting reference page entry and `reference.json` entries. 