### PR TITLE
reference.json: update Databroker link paths

### DIFF
--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -359,13 +359,13 @@
   "data-broker-service": {
     "id": "data-broker-service",
     "title": "Databroker Service",
-    "path": "/databroker",
+    "path": "/databroker#databroker-service",
     "services": ["databroker"]
   },
   "data-broker-service-url": {
     "id": "data-broker-service-url",
     "title": "Databroker Service URL",
-    "path": "/databroker",
+    "path": "/databroker#databroker-service-url",
     "services": [],
     "type": "URL"
   },
@@ -715,49 +715,49 @@
   "data-broker-internal-service-url": {
     "id": "data-broker-internal-service-url",
     "title": "Databroker Internal Service URL",
-    "path": "/databroker",
+    "path": "/databroker#databroker-internal-service-url",
     "services": [],
     "type": "URL"
   },
   "data-broker-storage-type": {
     "id": "data-broker-storage-type",
     "title": "Databroker Storage Type",
-    "path": "/databroker",
+    "path": "/databroker#databroker-storage-type",
     "services": [],
     "type": "string"
   },
   "data-broker-storage-connection-string": {
     "id": "data-broker-storage-connection-string",
     "title": "Databroker Storage Connection String",
-    "path": "/databroker",
+    "path": "/databroker#databroker-storage-connection-string",
     "services": [],
     "type": "string"
   },
   "data-broker-storage-certificate-file": {
     "id": "data-broker-storage-certificate-file",
     "title": "Databroker Storage Certificate File",
-    "path": "/databroker",
+    "path": "/databroker#databroker-storage-certificate-file",
     "services": [],
     "type": "relative file location"
   },
   "data-broker-storage-certificate-key-file": {
     "id": "data-broker-storage-certificate-key-file",
     "title": "Databroker Storage Certificate Key File",
-    "path": "/databroker",
+    "path": "/databroker#databroker-storage-certificate-key-file",
     "services": [],
     "type": "relative file location"
   },
   "data-broker-storage-certificate-authority": {
     "id": "data-broker-storage-certificate-authority",
     "title": "Databroker Storage Certificate Authority",
-    "path": "/databroker",
+    "path": "/databroker#databroker-storage-certificate-authority",
     "services": [],
     "type": "relative file location"
   },
   "data-broker-storage-tls-skip-verify": {
     "id": "data-broker-storage-tls-skip-verify",
     "title": "Databroker Storage TLS Skip Verify",
-    "path": "/databroker",
+    "path": "/databroker#databroker-storage-tls-skip-verify",
     "services": [],
     "type": "bool"
   },


### PR DESCRIPTION
Update the Databroker settings entries in reference.json to link to specific section headings on the combined Databroker reference page.

Related issue: https://github.com/pomerium/pomerium-zero/issues/1548