### PR TITLE
reference.json: update Branding link paths

### DIFF
--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -793,7 +793,7 @@
   "error-message-header": {
     "id": "error-message-first-paragraph",
     "title": "Error Message Header",
-    "path": "/branding",
+    "path": "/branding#error-message-header",
     "description": "A paragraph that will appear on all Route Error Pages in the top section.",
     "short_description": "Can contain plain text or Markdown.",
     "services": [],
@@ -802,7 +802,7 @@
   "favicon-url": {
     "id": "favicon-url",
     "title": "Favicon Url",
-    "path": "/branding",
+    "path": "/branding#favicon-url",
     "description": "A Url pointing to your favicon. Defaults to Pomerium's Favicon.",
     "services": [],
     "type": "URL"
@@ -891,7 +891,7 @@
   "logo-url": {
     "id": "logo-url",
     "title": "Logo Url",
-    "path": "/branding",
+    "path": "/branding#logo-url",
     "description": "A Url pointing to your logo. Defaults to Pomerium's Logo.",
     "services": [],
     "type": "URL"
@@ -988,7 +988,7 @@
   "primary-color": {
     "id": "primary-color",
     "title": "Primary Color",
-    "path": "/branding",
+    "path": "/branding#primary-color",
     "description": "A hex code that determines the primary color for the Enterprise Console and Route Error Details pages.",
     "short_description": "Defaults to #6F43E7",
     "services": [],
@@ -997,7 +997,7 @@
   "primary-color-dark-mode": {
     "id": "darkmode-primary-color",
     "title": "Primary Color (Dark Mode)",
-    "path": "/branding",
+    "path": "/branding#primary-color-dark-mode",
     "description": "A hex code that determines the primary color for the Enterprise Console and Route Error Details pages when in Dark Mode.",
     "short_description": "Defaults to #6F43E7",
     "services": [],
@@ -1072,7 +1072,7 @@
     "id": "secondary-color",
     "title": "Secondary Color",
     "description": "A hex code that determines the secondary color for the Enterprise Console and Route Error Details pages.",
-    "path": "/branding",
+    "path": "/branding#secondary-color",
     "short_description": "Defaults to #49AAA1",
     "services": [],
     "type": "string"
@@ -1082,7 +1082,7 @@
     "title": "Secondary Color (Dark Mode)",
     "description": "A hex code that determines the secondary color for the Enterprise Console and Route Error Details pages when in Dark Mode.",
     "short_description": "Defaults to #49AAA1",
-    "path": "/branding",
+    "path": "/branding#secondary-color-dark-mode",
     "services": [],
     "type": "string"
   },


### PR DESCRIPTION
Update the Branding settings entries in reference.json to link to specific section headings on the combined Branding reference page.

Related issue: https://github.com/pomerium/pomerium-zero/issues/1546