### PR TITLE
Docs: fixes timeouts formatting

### DIFF
--- a/content/docs/reference/global-timeouts.mdx
+++ b/content/docs/reference/global-timeouts.mdx
@@ -34,7 +34,7 @@ You can set also set [route-level timeouts](/docs/reference/routes/timeouts).
 
 | **Config file keys** | **Environment variables** | **Type** | **Default** |
 | :-- | :-- | :-- | :-- |
-| `timeout_read` | `TIMEOUT_READ` | `string` ([Go Duration](https://golang.org/pkg/time/#Duration.String) formatting) | `30s` | The amount of time for the entire request stream to be received from the client. |
+| `timeout_read` | `TIMEOUT_READ` | `string` ([Go Duration](https://golang.org/pkg/time/#Duration.String) formatting) | `30s` |
 
 ### Examples
 
@@ -124,7 +124,7 @@ timeouts:
 
 | **Config file keys** | **Environment variables** | **Type** | **Default** |
 | :-- | :-- | :-- | :-- |
-| `timeout_idle` | `TIMEOUT_IDLE` | `string` ([Go Duration](https://golang.org/pkg/time/#Duration.String) formatting) | `5m` | The idle timeout is the time at which a downstream or upstream connection will be terminated if there are no active streams. |
+| `timeout_idle` | `TIMEOUT_IDLE` | `string` ([Go Duration](https://golang.org/pkg/time/#Duration.String) formatting) | `5m` |
 
 ### Examples
 

--- a/content/docs/reference/global-timeouts.mdx
+++ b/content/docs/reference/global-timeouts.mdx
@@ -33,7 +33,7 @@ You can set also set [route-level timeouts](/docs/reference/routes/timeouts).
 <TabItem value="Core" label="Core">
 
 | **Config file keys** | **Environment variables** | **Type** | **Default** |
-| :-- | :-- | :-- | :-- | --- |
+| :-- | :-- | :-- | :-- |
 | `timeout_read` | `TIMEOUT_READ` | `string` ([Go Duration](https://golang.org/pkg/time/#Duration.String) formatting) | `30s` | The amount of time for the entire request stream to be received from the client. |
 
 ### Examples
@@ -123,7 +123,7 @@ timeouts:
 <TabItem value="Core" label="Core">
 
 | **Config file keys** | **Environment variables** | **Type** | **Default** |
-| :-- | :-- | :-- | :-- | --- |
+| :-- | :-- | :-- | :-- |
 | `timeout_idle` | `TIMEOUT_IDLE` | `string` ([Go Duration](https://golang.org/pkg/time/#Duration.String) formatting) | `5m` | The idle timeout is the time at which a downstream or upstream connection will be terminated if there are no active streams. |
 
 ### Examples


### PR DESCRIPTION
Fixes broken table formatting in `/docs/reference/global-timeouts`