### PR TITLE
Docs: updates route-level idle timeout ID

### DIFF
--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -868,7 +868,7 @@
     "path": "/routes/timeouts"
   },
   "route-idle-timeout": {
-    "id": "idle-timeout",
+    "id": "route-idle-timeout",
     "title": "Idle Timeout",
     "path": "/routes/timeouts#idle-timeout",
     "services": ["proxy"],


### PR DESCRIPTION
I know we've documented internally how we document our route- and global-level conventions, but this setting predates those decisions. For now, I've updated the route-level idle timeout setting ID to `route-idle-timeout`, as that was the original name given to the route-level setting. The Console and Zero repos' help docs also label this setting "route-idle-timeout."

I've filed issues on both repos to update the ID:
- https://github.com/pomerium/pomerium-zero/issues/1564
- https://github.com/pomerium/pomerium-console/issues/3998

Fixes https://github.com/pomerium/documentation/issues/1205