### PR TITLE
Docs: adds console changelog

### DIFF
--- a/content/docs/deploy/enterprise/changelog.mdx
+++ b/content/docs/deploy/enterprise/changelog.mdx
@@ -7,6 +7,12 @@ toc_max_heading_level: 5
 
 # Changelog
 
+## 0.25.1
+
+### Fixes
+
+- Removes the **cookie secure** backend logic from the Enterprise Console.
+
 ## 0.25.0
 
 ### Breaking


### PR DESCRIPTION
Adds the Enterprise Console `v0.25.1` patch release changelog. 

Related to https://github.com/pomerium/pomerium-console/pull/3999#event-11634180409