### PR TITLE
Docs: updates duplicate/missing references

### DIFF
--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -129,14 +129,6 @@
     "short_description": "Certificate relative file location string",
     "services": []
   },
-  "client-certificate-authority": {
-    "id": "client-certificate-authority",
-    "title": "Client Certificate Authority",
-    "path": "/certificates",
-    "services": [],
-    "short_description": "Client certificate authority relative file location string",
-    "type": "string"
-  },
   "downstream-mtls-client-certificate-authority": {
     "id": "downstream-mtls-client-certificate-authority",
     "title": "Downstream mTLS Certificate Authority",
@@ -280,7 +272,7 @@
     "id": "polling-max-delay",
     "title": "Max Polling Delay",
     "path": "/identity-provider-settings#identity-provider-polling-minmax-delay",
-    "description": "Minimum delay between requests to the IdP Directory.",
+    "description": "Maximum delay between requests to the IdP Directory.",
     "type": "string"
   },
   "javascript-security": {
@@ -585,7 +577,7 @@
   "identity-provider-client-id": {
     "id": "identity-provider-client-id",
     "title": "Identity Provider Client ID",
-    "path": "/identity-provider-settings",
+    "path": "/identity-provider-settings#identity-provider-client-id",
     "description": "Client ID is the OAuth 2.0 Client Identifier retrieved from your identity provider.",
     "services": [],
     "type": "string"
@@ -593,7 +585,7 @@
   "identity-provider-client-secret-file": {
     "id": "identity-provider-client-secret-file",
     "title": "Identity Provider Client Secret File",
-    "path": "/identity-provider-settings",
+    "path": "/identity-provider-settings#identity-provider-client-secret-file",
     "description": "File path containing the client secret, the OAuth 2.0 Secret Identifier retrieved from your identity provider.",
     "services": [],
     "type": "string"
@@ -601,7 +593,7 @@
   "identity-provider-client-secret": {
     "id": "identity-provider-client-secret",
     "title": "Identity Provider Client Secret",
-    "path": "/identity-provider-settings",
+    "path": "/identity-provider-settings#identity-provider-client-secret",
     "description": "Client Secret is the OAuth 2.0 Secret Identifier retrieved from your identity provider.",
     "services": [],
     "type": "string"
@@ -609,7 +601,7 @@
   "identity-provider-name": {
     "id": "identity-provider-name",
     "title": "Identity Provider Name",
-    "path": "/identity-provider-settings",
+    "path": "/identity-provider-settings#identity-provider-name",
     "description": "Provider is the short-hand name of a built-in OpenID Connect (oidc) identity provider to be used for authentication.",
     "services": [],
     "type": "string"
@@ -626,7 +618,7 @@
   "identity-provider-url": {
     "id": "identity-provider-url",
     "title": "Identity Provider URL",
-    "path": "/identity-provider-settings",
+    "path": "/identity-provider-settings#identity-provider-url",
     "description": "Provider URL is the base path to an identity provider's OpenID connect discovery document.",
     "services": [],
     "type": "string"
@@ -642,7 +634,7 @@
   "identity-provider-polling-min-max-delay": {
     "id": "identity-provider-min-max-delay",
     "title": "Identity Provider Min/Max Delay",
-    "path": "/identity-provider-settings",
+    "path": "/identity-provider-settings#identity-provider-polling-minmax-delay",
     "description": "Sets the minimum and maximum delay times between requests to the identity provider directory.",
     "services": [],
     "type": "string"


### PR DESCRIPTION
This PR:
- Adds fragments to all `identity-provider-settings` paths
- Removes the `client-certificate-authority` entry
- Updates `polling-max-delay` description to use `maximum`  instead of `minimum`

**Note**: One discrepancy is the `identity-provider-polling-min-max-delay` ID in `reference.json`, which isn't consistent with the anchor link:  The anchor link is `#identity-provider-minmax-delay`, so the `path` uses this fragment instead of the key/id found in the reference file.

Resolves https://github.com/pomerium/internal/issues/1701