### PR TITLE
Update Enterprise admonitions

### DIFF
--- a/content/docs/capabilities/authentication.mdx
+++ b/content/docs/capabilities/authentication.mdx
@@ -54,6 +54,10 @@ By configuring your applications to route requests to Pomerium’s Proxy service
 
 ## External data sources (Enterprise)
 
+:::enterprise Pomerium Enterprise
+
 [Enterprise customers](https://www.pomerium.com/enterprise-sales/) can enforce context-aware access with Pomerium’s [external data sources](/docs/integrations) feature (directory sync).
+
+:::
 
 From the Enterprise Console, you can import external data from sources other than your IdP. User identity context such as users, groups, roles, language, time zones, location, and more can be included into your authorization policy so you can make granular access control decisions.

--- a/content/docs/capabilities/authorization.mdx
+++ b/content/docs/capabilities/authorization.mdx
@@ -106,7 +106,11 @@ In this example, Pomerium will grant a user access if their email address ends i
 
 ### Enterprise Console GUI
 
-The Enterprise Console provides a policy builder GUI so you can build policies and reapply them to multiple routes and namespaces.
+:::enterprise Pomerium Enterprise
+
+The Enterprise Console provides a policy builder GUI so you can build policies and reapply them to multiple routes and namespaces. See our [**Enterprise**](/docs/deploy/enterprise) page to learn more.
+
+:::
 
 Use the **BUILDER** tab to build your policy:
 
@@ -198,6 +202,12 @@ Pomerium Core and Enterprise offer the following options for overriding your aut
 
 ## Manage devices
 
+:::enterprise Pomerium Enterprise
+
+[Device identity](/docs/capabilities/device-identity) is an Enterprise feature. Check out our [Enterpise](/docs/deploy/enterprise) page to learn more.
+
+:::
+
 The **Manage Devices** feature in the Enterprise Console allows you to enroll and manage user devices for policy-based authorization.
 
 ![Enroll devices](./img/authorization/enroll-device.png)
@@ -205,5 +215,3 @@ The **Manage Devices** feature in the Enterprise Console allows you to enroll an
 The **Devices List** displays enrolled devices for each user and the approval status. Administrators can inspect, approve, or delete registered devices from this table.
 
 ![List of user devices](./img/authorization/console-devices.png)
-
-See [Device Identity](docs/capabilities/device-identity) for more information.

--- a/content/docs/capabilities/authorization.mdx
+++ b/content/docs/capabilities/authorization.mdx
@@ -34,9 +34,13 @@ You can apply policies in Pomerium to [Namespaces](/docs/capabilities/namespacin
 
 ### Namespaces
 
-Administrators can create a namespace, add users, groups, and routes to it, and configure a policy that applies to that specific namespace.
+:::enterprise Pomerium Enterprise
 
 Namespace support is only available for [Enterprise customers](https://www.pomerium.com/enterprise-sales/).
+
+:::
+
+Administrators can create a namespace, add users, groups, and routes to it, and configure a policy that applies to that specific namespace.
 
 ### Routes
 

--- a/content/docs/capabilities/authorization.mdx
+++ b/content/docs/capabilities/authorization.mdx
@@ -36,7 +36,7 @@ You can apply policies in Pomerium to [Namespaces](/docs/capabilities/namespacin
 
 :::enterprise Pomerium Enterprise
 
-Namespace support is only available for [Enterprise customers](https://www.pomerium.com/enterprise-sales/).
+Namespace support is available only for [Enterprise customers](https://www.pomerium.com/enterprise-sales/).
 
 :::
 

--- a/content/docs/capabilities/authorization.mdx
+++ b/content/docs/capabilities/authorization.mdx
@@ -204,7 +204,7 @@ Pomerium Core and Enterprise offer the following options for overriding your aut
 
 :::enterprise Pomerium Enterprise
 
-[Device identity](/docs/capabilities/device-identity) is an Enterprise feature. Check out our [Enterpise](/docs/deploy/enterprise) page to learn more.
+[Device identity](/docs/capabilities/device-identity) is an Enterprise feature. Check out our [Enterprise](/docs/deploy/enterprise) page to learn more.
 
 :::
 

--- a/content/docs/guides/jenkins.mdx
+++ b/content/docs/guides/jenkins.mdx
@@ -176,9 +176,9 @@ Sign in to continue to the Jenkins dashboard.
 </TabItem>
 <TabItem label="Enterprise" value="Enterprise">
 
-:::tip Note
+:::enterprise Pomerium Enterprise
 
-This guide assumes you can access the Enterprise Console.
+This guide assumes you can access the [Enterprise Console](/docs/deploy/enterprise).
 
 :::
 

--- a/content/docs/guides/tooljet.mdx
+++ b/content/docs/guides/tooljet.mdx
@@ -111,7 +111,7 @@ In your browser, go to the external ToolJet URL to set up your workspace.
 
 :::enterprise Pomerium Enterprise
 
-This guide assumes you can access the [Enterprise Console](/docs/deploy/install).
+This guide assumes you can access the [Enterprise Console](/docs/deploy/enterprise/install).
 
 The Docker Compose configuration in the Enterprise portion of this guide uses same implementation as the [Enterprise Quickstart](/docs/deploy/enterprise/quickstart).
 

--- a/content/docs/guides/tooljet.mdx
+++ b/content/docs/guides/tooljet.mdx
@@ -109,9 +109,9 @@ In your browser, go to the external ToolJet URL to set up your workspace.
 </TabItem>
 <TabItem value="Enterprise" label="Enterprise">
 
-:::tip **Note**
+:::enterprise Pomerium Enterprise
 
-This guide assumes you can access the Enterprise Console.
+This guide assumes you can access the [Enterprise Console](/docs/deploy/install).
 
 The Docker Compose configuration in the Enterprise portion of this guide uses same implementation as the [Enterprise Quickstart](/docs/deploy/enterprise/quickstart).
 

--- a/content/docs/integrations.mdx
+++ b/content/docs/integrations.mdx
@@ -4,6 +4,12 @@ sidebar_label: integrations
 description: Extend your authorization policies with data from external sources.
 ---
 
+:::enterprise Pomerium Enterprise
+
+This article describes a use case only available to [Pomerium Enterprise](/docs/deploy/enterprise) customers.
+
+:::
+
 <iframe
   width="100%"
   height="415"


### PR DESCRIPTION
This PR mainly updates old admonitions, but it also adds a few:
- Tooljet guide
- Jenkins guide
- Integrations page
- Authorization
- Authentication
- Device identity

I should add this is just the initial use case for the admonition. I'd like to strategically place it with more compelling text to help broadcast Enterprise features and use cases.

Resolves https://github.com/pomerium/internal/issues/1711

