### PR TITLE
minor updates to the 'From Source' page

### DIFF
--- a/content/docs/deploy/core/from-source.mdx
+++ b/content/docs/deploy/core/from-source.mdx
@@ -20,18 +20,17 @@ import ConfigMinimal from '@site/content/examples/config/config.minimal.yaml.md'
 
 # Building Pomerium From Source
 
-This document covers how to retrieve and build Pomerium from its source-code as well as how to run Pomerium using a minimal but complete configuration. One of the benefits of compiling from source is that Go supports building static binaries for a [wide array of architectures and operating systems](https://gist.github.com/asukakenji/f15ba7e588ac42795f421b48b8aede63).
+This document covers how to retrieve and build Pomerium from its source code as well as how to run Pomerium using a minimal but complete configuration.
 
 ## Prerequisites
 
 - [git](https://git-scm.com/)
 - [go](https://golang.org/doc/install) programming language
 - A configured [identity provider]
-- [golangci-lint](https://golangci-lint.run/usage/install/#local-installation)
 
 ## Download
 
-Retrieve the latest copy of pomerium's source code by cloning the repository.
+Retrieve the latest copy of Pomerium's source code by cloning the repository.
 
 ```bash
 git clone https://github.com/pomerium/pomerium.git $HOME/pomerium


### PR DESCRIPTION
The part about "a wide array of architectures and operating systems" predates the dependency on Envoy. Currently Pomerium is limited by the OSes/architectures supported by Envoy, which I believe includes only Linux and macOS, for amd64 and arm64. (According to an announcement at https://groups.google.com/g/envoy-announce/c/2e-mSnit_BQ/m/VvweUrdaAAAJ Windows is no longer supported after Envoy 1.27.)

As of pomerium/pomerium@faa2a8652b8f001f6777d017af8f5ea021f1dc4b golangci-lint is no longer required to be installed locally (it is instead invoked via `go run`).

Finally, make sure "Pomerium" is capitalized consistently.