### PR TITLE
Updates route-level pass id headers setting

### DIFF
--- a/content/docs/reference/pass-identity-headers.mdx
+++ b/content/docs/reference/pass-identity-headers.mdx
@@ -18,7 +18,7 @@ import TabItem from '@theme/TabItem';
 
 When set to true, the **Pass Identity Headers** setting sends identity headers to all upstream applications.
 
-If you enable the [route-level Pass Identity Headers](/docs/reference/routes/pass-identity-headers-per-route) setting for a route, the route setting will take precedence over the global setting.
+To change this behavior for a specific route, use the [route-level Pass Identity Headers](/docs/reference/routes/pass-identity-headers-per-route).
 
 Identity headers include:
 

--- a/content/docs/reference/pass-identity-headers.mdx
+++ b/content/docs/reference/pass-identity-headers.mdx
@@ -18,7 +18,7 @@ import TabItem from '@theme/TabItem';
 
 When set to true, the **Pass Identity Headers** setting sends identity headers to all upstream applications.
 
-If a route already has the [route-level Pass Identity Headers](/docs/reference/routes/pass-identity-headers-per-route) setting set, the route setting will take precedence over the global setting.
+If you enable the [route-level Pass Identity Headers](/docs/reference/routes/pass-identity-headers-per-route) setting for a route, the route setting will take precedence over the global setting.
 
 Identity headers include:
 

--- a/content/docs/reference/pass-identity-headers.mdx
+++ b/content/docs/reference/pass-identity-headers.mdx
@@ -18,7 +18,7 @@ import TabItem from '@theme/TabItem';
 
 When set to true, the **Pass Identity Headers** setting sends identity headers to all upstream applications.
 
-To change this behavior for a specific route, use the [route-level Pass Identity Headers](/docs/reference/routes/pass-identity-headers-per-route).
+To change this behavior for a specific route, use the [route-level Pass Identity Headers](/docs/reference/routes/pass-identity-headers-per-route) setting.
 
 Identity headers include:
 

--- a/content/docs/reference/routes/pass-identity-headers.mdx
+++ b/content/docs/reference/routes/pass-identity-headers.mdx
@@ -18,7 +18,7 @@ import TabItem from '@theme/TabItem';
 
 When set to true, the **Pass Identity Headers (per route)** setting will pass identity headers to the upstream application.
 
-If you enable the [global-level Pass Identity Headers](/docs/reference/pass-identity-headers) setting, the route-level setting will still take precedence.
+The default value for this setting is controlled by the [global-level Pass Identity Headers](/docs/reference/pass-identity-headers) setting.
 
 Identity headers include:
 

--- a/content/docs/reference/routes/pass-identity-headers.mdx
+++ b/content/docs/reference/routes/pass-identity-headers.mdx
@@ -16,9 +16,11 @@ import TabItem from '@theme/TabItem';
 
 ## Summary
 
-When set, **Pass Identity Headers** will pass identity headers to the upstream application.
+When set to true, the **Pass Identity Headers (per route)** setting will pass identity headers to the upstream application.
 
-These headers include:
+If you enable the [global-level Pass Identity Headers](/docs/reference/pass-identity-headers) setting, the route-level setting will still take precedence.
+
+Identity headers include:
 
 - `X-Pomerium-Jwt-Assertion`
 - `X-Pomerium-Claim-*` (see [JWT Claim Headers](/docs/reference/jwt-claim-headers) for more information)
@@ -28,9 +30,9 @@ These headers include:
 <Tabs>
 <TabItem value="Core" label="Core">
 
-| **YAML**/**JSON** setting | **Type**  | **Usage**    | **Default** |
-| :------------------------ | :-------- | :----------- | :---------- |
-| `pass_identity_headers`   | `boolean` | **optional** | `false`     |
+| **YAML**/**JSON** setting | **Type**  | **Usage**    |
+| :------------------------ | :-------- | :----------- |
+| `pass_identity_headers`   | `boolean` | **optional** |
 
 ### Examples
 


### PR DESCRIPTION
This PR adds a link from the route-level pass identity headers setting to the global-level setting. It also removes the `default` column from the configuration table.

Fixes #1224 