### PR TITLE
Removes client ca reference page settings

### DIFF
--- a/content/docs/reference/certificates.mdx
+++ b/content/docs/reference/certificates.mdx
@@ -150,11 +150,3 @@ Kubernetes does not support `certificate_authority`
 
 </TabItem>
 </Tabs>
-
-:::caution
-
-We've removed support for the `client_ca` and `client_ca_file` settings. To configure client certificates for downstream connections, see the **Downstream mTLS Settings** group (see the [**Certificate Authority**](/docs/reference/downstream-mtls-settings#ca) setting there).
-
-If you need the older `client_ca` and `client_ca_file` settings, please see the [**v0.25.0 Client Certificate Authority**](https://0-25-0.docs.pomerium.com/docs/reference/certificates#client-certificate-authority) documentation, or an earlier Pomerium version.
-
-:::

--- a/content/docs/reference/certificates.mdx
+++ b/content/docs/reference/certificates.mdx
@@ -18,7 +18,6 @@ This reference covers all of Pomerium's **Certificates Settings**:
 
 - [Certificates](#certificates)
 - [Certificate Authority](#certificate-authority)
-- [Client Certificate Authority](#client-certificate-authority)
 
 :::tip **Note**
 
@@ -152,52 +151,10 @@ Kubernetes does not support `certificate_authority`
 </TabItem>
 </Tabs>
 
-## Client Certificate Authority {#client-certificate-authority}
-
 :::caution
 
-This setting is deprecated; it has been moved to a new **Downstream mTLS Settings** group (see the [**Certificate Authority**](/docs/reference/downstream-mtls-settings#ca) setting there).
+We've removed support for the `client_ca` and `client_ca_file` settings. To configure client certificates for downstream connections, see the **Downstream mTLS Settings** group (see the [**Certificate Authority**](/docs/reference/downstream-mtls-settings#ca) setting there).
 
-This setting will be treated as an alias for the new setting, but will be removed in a future Pomerium release.
+If you need the older `client_ca` and `client_ca_file` settings, please see the [**v0.25.0 Client Certificate Authority**](https://0-25-0.docs.pomerium.com/docs/reference/certificates#client-certificate-authority) documentation, or an earlier Pomerium version.
 
 :::
-
-**Client Certificate Authority** is the X.509 _public-key_ used to validate [mTLS client certificates](/docs/capabilities/mtls-clients).
-
-If not set, no client certificate will be required.
-
-### How to configure {#client-certificate-authority-how-to-configure}
-
-<Tabs>
-<TabItem value="Core" label="Core">
-
-| **Config file keys** | **Environment variables** | **Type** | **Usage**    |
-| :------------------- | :------------------------ | :------- | :----------- |
-| `client_ca`          | `CLIENT_CA`               | `string` | **optional** |
-| `client_ca_file`     | `CLIENT_CA_FILE`          | `string` | **optional** |
-
-### Examples {#client-certificate-authority-examples}
-
-```yaml
-client_ca: base64-encoded-string
-client_ca_file: base64-encoded-string
-```
-
-```bash
-CLIENT_CA=/relative/file/location
-
-CLIENT_CA_FILE=/relative/file/location
-```
-
-</TabItem>
-<TabItem value="Enterprise" label="Enterprise">
-
-`client_ca` and `client_ca_file` are bootstrap configuration settings and are not configurable in the Console.
-
-</TabItem>
-<TabItem value="Kubernetes" label="Kubernetes">
-
-Kubernetes does not support `client_certificate_ca`
-
-</TabItem>
-</Tabs>

--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -654,15 +654,6 @@
     "services": [],
     "type": "URL"
   },
-  "certificate-authority": {
-    "id": "certificate-authority",
-    "title": "Certificate Authority",
-    "path": "/certificates#certificate-authority",
-    "description": "Certificate Authority is set when behind-the-ingress service communication uses self-signed certificates.",
-    "services": [],
-    "type": "string",
-    "short_description": "Certificate authority relative file location string"
-  },
   "default-upstream-timeout": {
     "id": "default-upstream-timeout",
     "title": "Default Upstream Timeout",

--- a/static/_redirects
+++ b/static/_redirects
@@ -376,7 +376,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 # Certificates
 /docs/reference/certificate-authority /docs/reference/certificates#certificate-authority
 /docs/reference/certificates /docs/reference/certificates#certificates
-/docs/reference/client-certificate-authority /docs/reference/certificates#client-certificate-authority
+/docs/reference/client-certificate-authority /docs/reference/downstream-mtls-settings#ca
 /docs/reference/client-crl /docs/reference/downstream-mtls-settings#crl
 
 # Branding


### PR DESCRIPTION
This PR removes the Client Certificate Authority setting from `/docs/reference/certificates`. It also removes the entry in `reference.json` and adds a `caution` admonition with a hard-coded link to the last supported version. 

Resolves https://github.com/pomerium/internal/issues/1704