### PR TITLE
Updates idp min max delay enterprise admonition

### DIFF
--- a/content/docs/reference/identity-provider-settings.mdx
+++ b/content/docs/reference/identity-provider-settings.mdx
@@ -372,7 +372,7 @@ Identity provider **Polling Minimum Delay** and **Polling Maximum Delay** settin
 
 A job starts with the **minimum delay** intervals. If the job fails to complete within the minimum delay period, it will be interrupted and the job will restart. If the job is interrupted due to timeout or an error, it will restart with increasing intervals up to the **maximum delay** period.
 
-:::note
+:::enterprise
 
 The `minimum_delay` and `maximum_delay` settings are an [**Enterprise Console**](https://www.pomerium.com/enterprise-sales/) feature, and are not configurable in Pomerium Core.
 


### PR DESCRIPTION
Replacing current IdP min/max delay admonition with the Enterprise admonition.