### PR TITLE
Updates robots txt behavior notice

### DIFF
--- a/content/docs/capabilities/authorization.mdx
+++ b/content/docs/capabilities/authorization.mdx
@@ -200,6 +200,19 @@ Pomerium Core and Enterprise offer the following options for overriding your aut
 - **CORS Preflight**: Allows unauthenticated HTTP OPTIONS requests as per the CORS spec
 - **Public Access**: Allows complete, unrestricted access to an associated route (use this setting with caution)
 
+:::note robots.txt behavior
+
+By default, Pomerium serves a **robots.txt** response directly, instructing search engines _not_ to crawl the route domain:
+
+```txt
+User-agent: *
+Disallow: /
+```
+
+For routes with policies that allow public, unauthenticated access, Pomerium _will not_ serve **robots.txt** directly. Instead, Pomerium will proxy requests for `/robots.txt` to the upstream service.
+
+:::
+
 ## Manage devices
 
 :::enterprise

--- a/content/docs/reference/routes/public-access.mdx
+++ b/content/docs/reference/routes/public-access.mdx
@@ -24,7 +24,7 @@ Because the **Public Access** setting bypasses authentication and authorization 
 
 The **Public Access** setting instructs Pomerium to grant unauthorized and unauthenticated access to all requests to the upstream service. If you enable this setting, no other policy should be provided for the route.
 
-### Robots.txt behavior
+:::note robots.txt behavior
 
 By default, Pomerium serves a **robots.txt** response directly, instructing search engines _not_ to crawl the route domain:
 
@@ -33,7 +33,9 @@ User-agent: *
 Disallow: /
 ```
 
-For routes with `allow_public_unauthenticated_access` enabled, Pomerium will not serve **robots.txt** directly. Instead, requests for `/robots.txt` will be proxied to the upstream service.
+For routes with policies that allow public, unauthenticated access, Pomerium _will not_ serve **robots.txt** directly. Instead, Pomerium will proxy requests for `/robots.txt` to the upstream service.
+
+:::
 
 ## How to configure
 


### PR DESCRIPTION
This PR updates the robots.txt behavior notice. Now, the notice is in an admonition and the text has been updated to reflect the code changes mentioned in https://github.com/pomerium/pomerium/issues/4912#issuecomment-1927795854. 

I had to close the last PR, as it included Quickstart changes from another branch (forgot to switch branches). 

Resolves https://github.com/pomerium/internal/issues/1716