### PR TITLE
Adds Databroker storage connection string description

### DIFF
--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -739,6 +739,7 @@
   "data-broker-storage-connection-string": {
     "id": "data-broker-storage-connection-string",
     "title": "Databroker Storage Connection String",
+    "description": "Sets Postgres connection string to connect Databroker service to storage backend",
     "path": "/databroker#databroker-storage-connection-string",
     "services": [],
     "type": "string"


### PR DESCRIPTION
Adds a `description` in the `reference.json` file for the Databroker Storage Connection String setting. This is intended to be pulled for the Zero  Console UI.

Resolves https://github.com/pomerium/pomerium-zero/issues/1727 and https://github.com/pomerium/internal/issues/1729