### PR TITLE
Adds response header descriptions

### DIFF
--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -666,6 +666,7 @@
     "id": "set-response-headers",
     "title": "Set Response Headers",
     "path": "/set-response-headers",
+    "description": "Set static HTTP Response Header values for all managed routes",
     "services": [],
     "type": "map of strings key value pairs"
   },
@@ -673,6 +674,7 @@
     "id": "set-response-headers-route",
     "title": "Set Response Headers (Per Route)",
     "path": "/routes/headers#set-response-headers",
+    "description": "Set static HTTP Response Header values for a route",
     "services": [],
     "type": "map of strings key value pairs"
   },


### PR DESCRIPTION
Adds a description for Global and Route Set Response Headers settings in `reference.json`

Fixes https://github.com/pomerium/pomerium-zero/issues/1740