### PR TITLE
Updates service account admonition

### DIFF
--- a/content/docs/capabilities/enterprise-api.mdx
+++ b/content/docs/capabilities/enterprise-api.mdx
@@ -56,9 +56,9 @@ This doc assumes:
 
 :::tip
 
-[**Service Accounts**](/docs/capabilities/service-accounts) created in any Namespace other than **Global** will include a reference to that Namespace ID. A service account created in a non-global Namespace will follow this format:
+[**Service Accounts**](/docs/capabilities/service-accounts) created in any Namespace other than **Global** will include a reference to that Namespace ID. A service account created in a non-global Namespace will generate a **User ID** that follows this format:
 
-`[user-id]@[namespace-reference]`
+`{user-id}@{namespace-reference}.pomerium`
 
 You must specify the entire **User ID** when using the service account. For example:
 

--- a/content/docs/capabilities/enterprise-api.mdx
+++ b/content/docs/capabilities/enterprise-api.mdx
@@ -58,7 +58,7 @@ This doc assumes:
 
 [**Service Accounts**](/docs/capabilities/service-accounts) created in any Namespace other than **Global** will include a reference to that Namespace ID. A service account created in a non-global Namespace will generate a **User ID** that follows this format:
 
-`{user-id}@{namespace-reference}.pomerium`
+`{user-id}@{namespace-id}.pomerium`
 
 You must specify the entire **User ID** when using the service account. For example:
 


### PR DESCRIPTION
After reading @wasaga's Service Accounts RFC, I realized the format of a SA created in a non-global Namespace included in an admonition in `/docs/capabilities/enterprise-api` was incorrect. This PR updates the format.