### PR TITLE
Adds ip range lookup support

### DIFF
--- a/content/docs/integrations.mdx
+++ b/content/docs/integrations.mdx
@@ -121,7 +121,7 @@ CIDR indexing follows this format:
 
 ```json
 {
-  "$index": {"cidr":"1.2.3.4/5"}
+  "$index": {"cidr": "1.2.3.4/5"}
 }
 ```
 

--- a/content/docs/integrations.mdx
+++ b/content/docs/integrations.mdx
@@ -93,7 +93,7 @@ Unless defined by the directory structure of a supplied archive file, the Record
 
 #### IP range lookup support
 
-Pomerium supports Classless Inter-Domain Routing (CIDR) indexing when filtering a list of records with the `request.ip` foreign key. This allows you to match against IP address ranges instead of manually importing records for individual IP addresses.
+For the `request.ip` foreign key, Pomerium also supports matching against a range of IP addresses (expressed in [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation)). This can reduce the number of data records you need.
 
 To match against an IP address range, add a special `$index` key to your external data source records. For example:
 

--- a/content/docs/integrations.mdx
+++ b/content/docs/integrations.mdx
@@ -115,7 +115,7 @@ For data sources using mTLS, you can select a [client certificate](/docs/concept
 
 ## IP range lookup support
 
-Pomerium supports Classless Inter-Domain Routing (CIDR) indexing to improve database performance. This is useful if you're importing a list of records containing IP ranges.
+Pomerium supports Classless Inter-Domain Routing (CIDR) indexing to improve database querying performance. This is useful if you're importing a list of records containing IP ranges.
 
 CIDR indexing follows this format:
 

--- a/content/docs/integrations.mdx
+++ b/content/docs/integrations.mdx
@@ -86,10 +86,24 @@ Unless defined by the directory structure of a supplied archive file, the Record
 
 **Foreign Key** is used to map an authorization evaluation to the corresponding record. The supported values are:
 
-- `user.id` (Also the default if no value is provided),
-- `user.email`,
-- `request.ip`,
-- `device.id`.
+- `user.id` (Also the default if no value is provided)
+- `user.email`
+- `request.ip`
+- `device.id`
+
+#### IP range lookup support
+
+Pomerium supports Classless Inter-Domain Routing (CIDR) indexing when filtering a list of records with the `request.ip` foreign key. This allows you to match against IP address ranges instead of manually importing records for individual IP addresses.
+
+To filter with CIDR indexing, add a special `$index` key to your external data source records. For example:
+
+```json
+{
+  "$index": {"cidr": "1.2.3.4/5"}
+}
+```
+
+See the [GeoIP Ranges](/docs/integrations/geoip) and [Well-Known IP Ranges](/docs/integrations/ip-ranges) guides for specific examples.
 
 ### Headers
 
@@ -112,17 +126,3 @@ If a job may not complete within the `min delay` period, it would be interrupted
 ### Client TLS Key
 
 For data sources using mTLS, you can select a [client certificate](/docs/concepts/certificates) (added under **Manage** → **Certificates**) to provide to the data source.
-
-## IP range lookup support
-
-Pomerium supports Classless Inter-Domain Routing (CIDR) indexing to improve database querying performance. This is useful if you're importing a list of records containing IP ranges.
-
-CIDR indexing follows this format:
-
-```json
-{
-  "$index": {"cidr": "1.2.3.4/5"}
-}
-```
-
-See the [GeoIP Ranges](/docs/integrations/geoip) and [Well-Known IP Ranges](/docs/integrations/ip-ranges) guides for specific examples.

--- a/content/docs/integrations.mdx
+++ b/content/docs/integrations.mdx
@@ -95,7 +95,7 @@ Unless defined by the directory structure of a supplied archive file, the Record
 
 Pomerium supports Classless Inter-Domain Routing (CIDR) indexing when filtering a list of records with the `request.ip` foreign key. This allows you to match against IP address ranges instead of manually importing records for individual IP addresses.
 
-To filter with CIDR indexing, add a special `$index` key to your external data source records. For example:
+To match against an IP address range, add a special `$index` key to your external data source records. For example:
 
 ```json
 {

--- a/content/docs/integrations.mdx
+++ b/content/docs/integrations.mdx
@@ -33,7 +33,7 @@ See the pages in this section for more information on our example data sources, 
 
 Any external data source integration requires the following settings:
 
-### **URL**
+### URL
 
 The path to the external data.
 
@@ -78,11 +78,11 @@ The Pomerium Databroker would be updated with types `example.com/geoip`, `device
 
 Compressed versions are supported using `gz` format.
 
-### **Record Type**
+### Record Type
 
 Unless defined by the directory structure of a supplied archive file, the Record Type field defines how the records will be stored and accessed in the Databroker.
 
-### **Foreign Key**
+### Foreign Key
 
 **Foreign Key** is used to map an authorization evaluation to the corresponding record. The supported values are:
 
@@ -91,15 +91,15 @@ Unless defined by the directory structure of a supplied archive file, the Record
 - `request.ip`,
 - `device.id`.
 
-### **Headers**
+### Headers
 
 Headers defined here will be used when connecting to the external data source.
 
-### **Allow Insecure TLS**
+### Allow Insecure TLS
 
 If set, allows the import of external data from sources using untrusted TLS certificates.
 
-### **Polling Min/Max Delay**
+### Polling Min/Max Delay
 
 Defines the minimum and maximum delay times between requests to the external data source. The job would be scheduled to run within `min delay` intervals.
 
@@ -109,6 +109,20 @@ If a job may not complete within the `min delay` period, it would be interrupted
 
 :::
 
-### **Client TLS Key**
+### Client TLS Key
 
 For data sources using mTLS, you can select a [client certificate](/docs/concepts/certificates) (added under **Manage** → **Certificates**) to provide to the data source.
+
+## IP range lookup support
+
+Pomerium supports Classless Inter-Domain Routing (CIDR) indexing to improve database performance. This is useful if you're importing a list of records containing IP ranges.
+
+CIDR indexing follows this format:
+
+```json
+{
+  "$index": {"cidr":"1.2.3.4/5"}
+}
+```
+
+See the [GeoIP Ranges](/docs/integrations/geoip) and [Well-Known IP Ranges](/docs/integrations/ip-ranges) guides for specific examples.

--- a/content/docs/integrations.mdx
+++ b/content/docs/integrations.mdx
@@ -99,7 +99,7 @@ To filter with CIDR indexing, add a special `$index` key to your external data s
 
 ```json
 {
-  "$index": {"cidr": "1.2.3.4/5"}
+  "$index": {"cidr": "10.1.2.3/24"}
 }
 ```
 

--- a/content/docs/integrations/ip-ranges.mdx
+++ b/content/docs/integrations/ip-ranges.mdx
@@ -13,21 +13,21 @@ The Well Known IP Ranges integration provides a list of IP address ranges for va
 ```json title="Example"
 [
   {
-    "index": {"cidr": "1.0.0.0/24"},
+    "$index": {"cidr": "1.0.0.0/24"},
     "id": "1.0.0.0/24",
     "as_number": "13335",
     "country_code": "US",
     "as_name": "CLOUDFLARENET"
   },
   {
-    "index": {"cidr": "1.0.4.0/23"},
+    "$index": {"cidr": "1.0.4.0/23"},
     "id": "1.0.4.0/23",
     "as_number": "38803",
     "country_code": "AU",
     "as_name": "WPL-AS-AP"
   },
   {
-    "index": {"cidr": "1.0.6.0/23"},
+    "$index": {"cidr": "1.0.6.0/23"},
     "id": "1.0.6.0/23",
     "as_number": "38803",
     "country_code": "AU",


### PR DESCRIPTION
This PR adds a section to our Integrations page explaining the CIDR indexing support for external data sources.

Resolves https://github.com/pomerium/internal/issues/1737