### PR TITLE
Removes protocol from jaeger agents endpoint example

### DIFF
--- a/content/docs/reference/tracing.mdx
+++ b/content/docs/reference/tracing.mdx
@@ -84,7 +84,7 @@ Pomerium settings
 ```yaml
 tracing_provider: jaeger
 tracing_jaeger_collector_endpoint: http://localhost:14268/api/traces
-tracing_jaeger_agent_endpoint: http://localhost:6831
+tracing_jaeger_agent_endpoint: localhost:6831
 ```
 
 Open Jaeger UI at `http://localhost:16686` in the browser to view Pomerium traces.


### PR DESCRIPTION
This PR removes the HTTP protocol from the `tracing_jaeger_agent_endpoint` example in our Tracing Docs. 

Resolves https://github.com/pomerium/pomerium-zero/issues/1761