### PR TITLE
Removes device.id foreign key option

### DIFF
--- a/content/docs/integrations.mdx
+++ b/content/docs/integrations.mdx
@@ -89,7 +89,6 @@ Unless defined by the directory structure of a supplied archive file, the Record
 - `user.id` (Also the default if no value is provided)
 - `user.email`
 - `request.ip`
-- `device.id`
 
 #### IP range lookup support
 


### PR DESCRIPTION
This PR removes the unsupported `device.id` option from the list of supported foreign keys on https://www.pomerium.com/docs/integrations#foreign-key. 

Fixes #1271 