### PR TITLE
Updates Docker pull URLs

### DIFF
--- a/content/docs/capabilities/high-availability.mdx
+++ b/content/docs/capabilities/high-availability.mdx
@@ -178,7 +178,7 @@ networks:
 services:
   pomerium-proxy:
     hostname: pomerium-proxy
-    image: pomerium/pomerium:latest
+    image: cr.pomerium.com/pomerium/pomerium:latest
     networks:
       main: {}
     volumes:
@@ -196,7 +196,7 @@ services:
       - CERTIFICATE_AUTHORITY_FILE=/run/secrets/ca.pem
   pomerium-authorize:
     hostname: pomerium-authorize
-    image: pomerium/pomerium:latest
+    image: cr.pomerium.com/pomerium/pomerium:latest
     networks:
       main: {}
     volumes:
@@ -208,7 +208,7 @@ services:
       - CERTIFICATE_AUTHORITY_FILE=/run/secrets/ca.pem
   pomerium-authenticate:
     hostname: pomerium-authenticate
-    image: pomerium/pomerium:latest
+    image: cr.pomerium.com/pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml
     secrets:
@@ -227,7 +227,7 @@ services:
           - authenticate.localhost.pomerium.io
   pomerium-databroker:
     hostname: pomerium-databroker
-    image: pomerium/pomerium:latest
+    image: cr.pomerium.com/pomerium/pomerium:latest
     networks:
       main: {}
     volumes:

--- a/content/docs/courses/fundamentals/advanced-policies.md
+++ b/content/docs/courses/fundamentals/advanced-policies.md
@@ -168,13 +168,13 @@ Docker Compose:
 version: '3'
 services:
   pomerium:
-    image: pomerium/pomerium:latest
+    image: cr.pomerium.com/pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:
       - 443:443
   verify:
-    image: pomerium/verify:latest
+    image: cr.pomerium.com/pomerium/verify:latest
     expose:
       - 8000
     environment:

--- a/content/docs/courses/fundamentals/advanced-routes.md
+++ b/content/docs/courses/fundamentals/advanced-routes.md
@@ -443,13 +443,13 @@ Docker Compose
 version: '3'
 services:
   pomerium:
-    image: pomerium/pomerium:latest
+    image: cr.pomerium.com/pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:
       - 443:443
   verify:
-    image: pomerium/verify:latest
+    image: cr.pomerium.com/pomerium/verify:latest
     expose:
       - 8000
     environment:

--- a/content/docs/courses/fundamentals/build-policies.md
+++ b/content/docs/courses/fundamentals/build-policies.md
@@ -247,13 +247,13 @@ Docker Compose:
 version: '3'
 services:
   pomerium:
-    image: pomerium/pomerium:latest
+    image: cr.pomerium.com/pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:
       - 443:443
   verify:
-    image: pomerium/verify:latest
+    image: cr.pomerium.com/pomerium/verify:latest
     expose:
       - 8000
   grafana:

--- a/content/docs/courses/fundamentals/build-routes.md
+++ b/content/docs/courses/fundamentals/build-routes.md
@@ -71,13 +71,13 @@ In your `docker-compose.yaml` file, add Grafana as a service:
 version: '3'
 services:
   pomerium:
-    image: pomerium/pomerium:latest
+    image: cr.pomerium.com/pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:
       - 443:443
   verify:
-    image: pomerium/verify:latest
+    image: cr.pomerium.com/pomerium/verify:latest
     expose:
       - 8000
   grafana:
@@ -185,13 +185,13 @@ Docker Compose:
 version: '3'
 services:
   pomerium:
-    image: pomerium/pomerium:latest
+    image: cr.pomerium.com/pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:
       - 443:443
   verify:
-    image: pomerium/verify:latest
+    image: cr.pomerium.com/pomerium/verify:latest
     expose:
       - 8000
   grafana:

--- a/content/docs/courses/fundamentals/get-started.md
+++ b/content/docs/courses/fundamentals/get-started.md
@@ -110,13 +110,13 @@ Add the following configuration settings to `docker-compose.yaml`:
 version: '3'
 services:
   pomerium:
-    image: pomerium/pomerium:latest
+    image: cr.pomerium.com/pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:
       - 443:443
   verify:
-    image: pomerium/verify:latest
+    image: cr.pomerium.com/pomerium/verify:latest
     expose:
       - 8000
 ```
@@ -184,13 +184,13 @@ Docker Compose:
 version: '3'
 services:
   pomerium:
-    image: pomerium/pomerium:latest
+    image: cr.pomerium.com/pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:
       - 443:443
   verify:
-    image: pomerium/verify:latest
+    image: cr.pomerium.com/pomerium/verify:latest
     expose:
       - 8000
 ```

--- a/content/docs/courses/fundamentals/jwt-verification.md
+++ b/content/docs/courses/fundamentals/jwt-verification.md
@@ -208,7 +208,7 @@ In your Docker Compose file, add the following environment variable to your Veri
 
 ```yaml title="docker-compose"
 verify:
-  image: pomerium/verify:latest
+  image: cr.pomerium.com/pomerium/verify:latest
   expose:
     - 8000
   environment:
@@ -339,13 +339,13 @@ Docker Compose
 version: '3'
 services:
   pomerium:
-    image: pomerium/pomerium:latest
+    image: cr.pomerium.com/pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:
       - 443:443
   verify:
-    image: pomerium/verify:latest
+    image: cr.pomerium.com/pomerium/verify:latest
     expose:
       - 8000
     environment:

--- a/content/docs/courses/fundamentals/tcp-routes.md
+++ b/content/docs/courses/fundamentals/tcp-routes.md
@@ -117,7 +117,7 @@ In your Docker Compose file, bind mount your wildcard certificates as a volume i
 version: '3'
 services:
   pomerium:
-    image: pomerium/pomerium:latest
+    image: cr.pomerium.com/pomerium/pomerium:latest
     volumes:
       # Mount your wildcard certificates:
       - ./_wildcard.localhost.pomerium.io-key.pem:/pomerium/key.pem:ro

--- a/content/docs/deploy/clients/pomerium-cli.mdx
+++ b/content/docs/deploy/clients/pomerium-cli.mdx
@@ -92,21 +92,21 @@ The CLI utilizes a [minimal](https://github.com/GoogleContainerTools/distroless)
 - `:vX.Y.Z`: which will pull the a [specific tagged release](https://github.com/pomerium/cli/tags).
 
   ```bash {2}
-  docker run pomerium/cli:v0.1.0 --version
+  docker run cr.pomerium.com/pomerium/cli:v0.1.0 --version
   v0.1.0+53bfa4e
   ```
 
 - `:latest`: which will pull the [most recent tagged release](https://github.com/pomerium/cli/releases).
 
   ```bash {2}
-  docker run pomerium/cli:latest --version
+  docker run cr.pomerium.com/pomerium/cli:latest --version
   v0.2.0+87e214b
   ```
 
 - `:main` : which will pull an image in sync with git's [main](https://github.com/pomerium/pomerium/tree/main) branch.
 
   ```bash
-  docker pull pomerium/cli:main
+  docker pull cr.pomerium.com/pomerium/cli:main
   ```
 
 ### Source

--- a/content/docs/deploy/core.mdx
+++ b/content/docs/deploy/core.mdx
@@ -95,19 +95,19 @@ Pomerium also provides [Docker container images](https://www.docker.com/resource
 - `:vX.Y` corresponds to the latest patch release for a specific minor version (starting with v0.25).
 
   ```shell-session
-  $ docker pull pomerium/pomerium:v0.25
+  $ docker pull cr.pomerium.com/pomerium/pomerium:v0.25
   ```
 
 - `:latest` corresponds to the [most recent tagged release](https://github.com/pomerium/pomerium/releases/latest).
 
   ```shell-session
-  $ docker pull pomerium/pomerium:latest
+  $ docker pull cr.pomerium.com/pomerium/pomerium:latest
   ```
 
 - `:main` corresponds to the most recent development build from the [main](https://github.com/pomerium/pomerium/tree/main) git branch.
 
   ```shell-session
-  $ docker pull pomerium/pomerium:main
+  $ docker pull cr.pomerium.com/pomerium/pomerium:main
   ```
 
 Rootless images for official releases are also published to provide additional security. In these images, Pomerium runs as the `nonroot` user. Depending on your deployment environment, you may need to grant the container additional [capabilities](https://linux-audit.com/linux-capabilities-hardening-linux-binaries-by-removing-setuid/) or change the [listen address](/docs/reference/address) to use a port number other than 443.

--- a/content/docs/guides/code-server.mdx
+++ b/content/docs/guides/code-server.mdx
@@ -101,7 +101,7 @@ In your `docker-compose.yaml` file, add the code-server and Pomerium services:
 version: '3'
 services:
   pomerium:
-    image: pomerium/pomerium:latest
+    image: cr.pomerium.com/pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:

--- a/content/docs/guides/gitlab.mdx
+++ b/content/docs/guides/gitlab.mdx
@@ -212,7 +212,7 @@ Integrations that use unique subdomains will require their own certificates and 
     ...
 
       pomerium:
-        image: pomerium/pomerium:latest
+        image: cr.pomerium.com/pomerium/pomerium:latest
         container_name: pomerium
         volumes:
           - ./srv/pomerium/config.yaml:/pomerium/config.yaml:ro

--- a/content/docs/guides/jwt-verification.md
+++ b/content/docs/guides/jwt-verification.md
@@ -59,7 +59,7 @@ Mac and Linux users can use DNSMasq to map the `*.localhost.pomerium.io` domain 
        driver: 'bridge'
    services:
      pomerium:
-       image: pomerium/pomerium:latest
+       image: cr.pomerium.com/pomerium/pomerium:latest
        ports:
          - '443:443'
        volumes:

--- a/content/docs/guides/local-oidc.md
+++ b/content/docs/guides/local-oidc.md
@@ -17,7 +17,7 @@ You can use the same configuration examples below for other supported [identity 
 version: '3'
 services:
   pomerium:
-    image: pomerium/pomerium:latest
+    image: cr.pomerium.com/pomerium/pomerium:latest
     environment:
       # Generate new secret keys. e.g. `head -c32 /dev/urandom | base64`
       - COOKIE_SECRET=<redacted>
@@ -36,7 +36,7 @@ services:
       - identityprovider
 
   verify:
-    image: pomerium/verify
+    image: cr.pomerium.com/pomerium/verify:latest
     expose:
       - 8000
 

--- a/content/docs/identity-providers/oidc.mdx
+++ b/content/docs/identity-providers/oidc.mdx
@@ -49,13 +49,13 @@ services:
         aliases:
           - keycloak.localhost.pomerium.io
   pomerium:
-    image: pomerium/pomerium:v0.23.0
+    image: cr.pomerium.com/pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:
       - 443:443
   verify:
-    image: pomerium/verify:latest
+    image: cr.pomerium.com/pomerium/verify:latest
     environment:
       JWKS_ENDPOINT: https://pomerium/.well-known/pomerium/jwks.json
 ```

--- a/content/examples/docker/autocert.docker-compose.yml
+++ b/content/examples/docker/autocert.docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   pomerium:
-    image: pomerium/pomerium:latest
+    image: cr.pomerium.com/pomerium/pomerium:latest
     environment:
       # Generate new secret keys. e.g. `head -c32 /dev/urandom | base64`
       - COOKIE_SECRET=V2JBZk0zWGtsL29UcFUvWjVDWWQ2UHExNXJ0b2VhcDI=
@@ -13,6 +13,6 @@ services:
 
   # https://verify.corp.beyondperimeter.com --> Pomerium --> http://verify
   verify:
-    image: pomerium/verify:latest
+    image: cr.pomerium.com/pomerium/verify:latest
     expose:
       - 80

--- a/content/examples/docker/basic.docker-compose.yml.md
+++ b/content/examples/docker/basic.docker-compose.yml.md
@@ -2,7 +2,7 @@
 version: "3"
 services:
   pomerium:
-    image: pomerium/pomerium:latest
+    image: cr.pomerium.com/pomerium/pomerium:latest
     volumes:
       ## Mount your config file: https://www.pomerium.com/docs/reference/
       - ./config.yaml:/pomerium/config.yaml:ro
@@ -10,7 +10,7 @@ services:
       - 443:443
   ## https://verify.localhost.pomerium.io --> Pomerium --> http://verify
   verify:
-    image: pomerium/verify:latest
+    image: cr.pomerium.com/pomerium/verify:latest
     expose:
       - 8000
 ```

--- a/content/examples/docker/nginx.docker-compose.yml
+++ b/content/examples/docker/nginx.docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - /var/run/docker.sock:/tmp/docker.sock:ro
 
   pomerium-authenticate:
-    image: pomerium/pomerium:latest # or `build: .` to build from source
+    image: cr.pomerium.com/pomerium/pomerium:latest # or `build: .` to build from source
     restart: always
     environment:
       - SERVICES=authenticate
@@ -60,7 +60,7 @@ services:
       - 443
 
   pomerium-authorize:
-    image: pomerium/pomerium:latest # or `build: .` to build from source
+    image: cr.pomerium.com/pomerium/pomerium:latest # or `build: .` to build from source
     restart: always
     environment:
       - SERVICES=authorize
@@ -77,7 +77,7 @@ services:
       - 443
 
   pomerium-databroker:
-    image: pomerium/pomerium:latest # or `build: .` to build from source
+    image: cr.pomerium.com/pomerium/pomerium:latest # or `build: .` to build from source
     restart: always
     environment:
       - SERVICES=databroker
@@ -94,7 +94,7 @@ services:
 
   # https://verify.corp.beyondperimeter.com
   verify:
-    image: pomerium/verify:latest
+    image: cr.pomerium.com/pomerium/verify:latest
     expose:
       - 80
   # https://hello.corp.beyondperimeter.com

--- a/content/examples/enterprise/hosted-auth-docker.yaml.md
+++ b/content/examples/enterprise/hosted-auth-docker.yaml.md
@@ -2,7 +2,7 @@
 version: '3'
 services:
   pomerium:
-    image: pomerium/pomerium:latest
+    image: cr.pomerium.com/pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:
@@ -58,7 +58,7 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
   verify:
-    image: pomerium/verify:latest
+    image: cr.pomerium.com/pomerium/verify:latest
     expose:
       - 8000
     restart: always

--- a/content/examples/jenkins/jenkins-docker-compose.md
+++ b/content/examples/jenkins/jenkins-docker-compose.md
@@ -4,7 +4,7 @@ networks:
  main: {}
 services:
  pomerium:
-   image: pomerium/pomerium:latest
+   image: cr.pomerium.com/pomerium/pomerium:latest
    volumes:
      - ./config.yaml:/pomerium/config.yaml:ro
    ports:
@@ -16,7 +16,7 @@ services:
  verify:
    networks:
      main: {}
-   image: pomerium/verify:latest
+   image: cr.pomerium.com/pomerium/verify:latest
    expose:
      - 8000
  jenkins:

--- a/content/examples/nginx/docker-compose.yaml.md
+++ b/content/examples/nginx/docker-compose.yaml.md
@@ -19,11 +19,11 @@ services:
       - ./proxy.conf:/etc/nginx/proxy.conf
 
   verify:
-    image: pomerium/verify
+    image: cr.pomerium.com/pomerium/verify:latest
     expose:
       - 80
   pomerium:
-    image: pomerium/pomerium:latest
+    image: cr.pomerium.com/pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     expose:

--- a/content/examples/tcp/docker-compose.yaml.md
+++ b/content/examples/tcp/docker-compose.yaml.md
@@ -2,7 +2,7 @@
 version: "3"
 services:
   pomerium:
-    image: pomerium/pomerium:latest
+    image: cr.pomerium.com/pomerium/pomerium:latest
     volumes:
       # Uncomment to mount certificates (optional)
       # - ./_wildcard.localhost.pomerium.io.pem:/pomerium/cert.pem:ro

--- a/content/examples/tiddlywiki/docker-compose.yaml.md
+++ b/content/examples/tiddlywiki/docker-compose.yaml.md
@@ -3,7 +3,7 @@ version: "3"
 
 services:
   pomerium:
-    image: pomerium/pomerium:latest
+    image: cr.pomerium.com/pomerium/pomerium:latest
     volumes:
       # Use a volume to store ACME certificates
       - ./config.yaml:/pomerium/config.yaml:ro

--- a/content/examples/tooljet/console-compose.yaml.md
+++ b/content/examples/tooljet/console-compose.yaml.md
@@ -4,7 +4,7 @@ networks:
   main: {}
 services:
   pomerium:
-    image: pomerium/pomerium:v0.21.1
+    image: cr.pomerium.com/pomerium/pomerium:v0.21.1
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:
@@ -69,7 +69,7 @@ services:
   verify:
     networks:
       main: {}
-    image: pomerium/verify:latest
+    image: cr.pomerium.com/pomerium/verify:latest
     expose:
       - 8000
     restart: always

--- a/content/examples/tooljet/docker-compose.yaml.md
+++ b/content/examples/tooljet/docker-compose.yaml.md
@@ -4,7 +4,7 @@ networks:
   main: {}
 services:
   pomerium:
-    image: pomerium/pomerium:latest
+    image: cr.pomerium.com/pomerium/pomerium:latest
     volumes:
       ## Mount your config file: https://www.pomerium.com/docs/reference/
       - ./config.yaml:/pomerium/config.yaml:ro
@@ -19,7 +19,7 @@ services:
   verify:
     networks:
       main: {}
-    image: pomerium/verify:latest
+    image: cr.pomerium.com/pomerium/verify:latest
     expose:
       - 8000
   tooljet:


### PR DESCRIPTION
This PR updates all instances of the Docker pull URL in our docs.  I may have missed  a few, so I'd appreciate a quick review from the team.

I backported to v0.25, but we could also backport to previous versions. Thoughts or opinions here?