### PR TITLE
Moves databroker service def to data-storage

### DIFF
--- a/content/docs/internals/data-storage.md
+++ b/content/docs/internals/data-storage.md
@@ -86,7 +86,7 @@ name=value[&...]
 
 When using multiple hosts make sure to specify `target_session_attrs=read-write` so that the Databroker does not attempt to write to a read-only replica.
 
-:::note 
+:::note
 
 Configuration options for each backend are detailed in the [**databroker configuration reference**](/docs/reference/databroker) page.
 

--- a/content/docs/internals/data-storage.md
+++ b/content/docs/internals/data-storage.md
@@ -31,9 +31,17 @@ To prevent early session loss in production deployments, persistent storage back
 
 ## Backends
 
-Configuration options for each backend are detailed in [databroker configuration reference](/docs/reference/databroker).
+The **Databroker Service** stores user session data, and uses an in-memory databroker by default.
 
 Pomerium encrypts record values only for the Redis storage backend (not for the in-memory or Postgres storage backends). When using the Postgres backend we recommend that users configure their own encryption at rest, for example by using full-disk encryption on the volume where Postgres data is stored.
+
+:::tip
+
+You can create your own databroker by implementing Pomerium's [**databroker gRPC interface**](https://github.com/pomerium/pomerium/blob/main/pkg/grpc/databroker/databroker.proto). For an example implementation, see the in-memory database used by the databroker service:
+
+- [pkg/storage](https://github.com/pomerium/pomerium/tree/main/pkg/storage/inmemory)
+
+:::
 
 ### In-Memory
 
@@ -77,6 +85,12 @@ name=value[&...]
 ```
 
 When using multiple hosts make sure to specify `target_session_attrs=read-write` so that the Databroker does not attempt to write to a read-only replica.
+
+:::note 
+
+Configuration options for each backend are detailed in the [**databroker configuration reference**](/docs/reference/databroker) page.
+
+:::
 
 ## Troubleshooting
 

--- a/content/docs/reference/databroker.mdx
+++ b/content/docs/reference/databroker.mdx
@@ -11,32 +11,6 @@ import TabItem from '@theme/TabItem';
 
 # Databroker Settings
 
-This reference covers all of Pomerium's **Databroker Settings**:
-
-- [Databroker Service](#databroker-service)
-- [Databroker Service URL](#databroker-service-url)
-- [Databroker Internal Service URL](#databroker-internal-service-url)
-- [Databroker Storage Certificate Authority](#databroker-storage-certificate-authority)
-- [Databroker Storage Certificate File](#databroker-storage-certificate-file)
-- [Databroker Storage Certificate Key File](#databroker-storage-certificate-key-file)
-- [Databroker Storage Connection String](#databroker-storage-connection-string)
-- [Databroker Storage TLS Skip Verify](#databroker-storage-tls-skip-verify)
-- [Databroker Storage Type](#databroker-storage-type)
-
-## Databroker Service {#databroker-service}
-
-The **Databroker Service** stores user session data.
-
-### How to configure {#databroker-service-how-to-configure}
-
-By default, the `databroker` service uses an in-memory databroker.
-
-To create your own databroker, implement Pomerium's [databroker gRPC interface](https://github.com/pomerium/pomerium/blob/main/pkg/grpc/databroker/databroker.proto).
-
-For an example implementation, see the in-memory database used by the databroker service here:
-
-- [pkg/storage](https://github.com/pomerium/pomerium/tree/main/pkg/storage/inmemory)
-
 ## Databroker Service URL {#databroker-service-url}
 
 **Databroker Service URL** points to a data broker which is responsible for storing associated authorization context (for example, sessions, users, and user groups).


### PR DESCRIPTION
This PR removes the **Databroker Service** entry from the databroker reference page, modifies the text, and moves the text to the internals persistence page. 

Resolves https://github.com/pomerium/internal/issues/1748.