### PR TITLE
adds query strings to IdP guides

### DIFF
--- a/content/docs/identity-providers/auth0.mdx
+++ b/content/docs/identity-providers/auth0.mdx
@@ -46,8 +46,8 @@ While we do our best to keep our documentation up to date, changes to third-part
 
 You can now configure Pomerium with the identity provider settings retrieved in the previous steps. Your `config.yaml` keys or [environmental variables] should look something like this.
 
-<Tabs>
-<TabItem value="config.yaml" label="config.yaml">
+<Tabs queryString="configuration-settings">
+<TabItem value="config-file-keys" label="Config file keys">
 
 ```yaml
 idp_provider: 'auth0'
@@ -57,7 +57,7 @@ idp_client_secret: 'REPLACE_ME' # from the web application
 ```
 
 </TabItem>
-<TabItem value="Environment Variables" label="Environment Variables">
+<TabItem value="environment-variables" label="Environment Variables">
 
 ```bash
 IDP_PROVIDER="auth0"
@@ -77,8 +77,8 @@ Remember to prepend the provider URL from Auth0 with `https://`.
 
 ## Groups
 
-<Tabs>
-<TabItem value="Custom Claim (Open Source)" label="Custom Claim (Open Source)">
+<Tabs queryString="get-groups">
+<TabItem value="custom-claim" label="Custom Claim (Open Source)">
 
 ### Custom Claim
 
@@ -118,7 +118,7 @@ routes:
 ```
 
 </TabItem>
-<TabItem value="Directory Sync (Enterprise)" label="Directory Sync (Enterprise)">
+<TabItem value="directory-sync" label="Directory Sync (Enterprise)">
 
 ### Setting Up Directory Sync
 

--- a/content/docs/identity-providers/azure.mdx
+++ b/content/docs/identity-providers/azure.mdx
@@ -124,8 +124,8 @@ https://login.microsoftonline.com/0303f438-3c5c-4190-9854-08d3eb31bd9f/v2.0
 
 Configure Pomerium with the identity provider settings you saved in the previous steps:
 
-<Tabs>
-<TabItem value="Config file keys" label="Config file keys">
+<Tabs queryString="configuration-settings">
+<TabItem value="config-file-keys" label="Config file keys">
 
 ```yaml
 idp_provider: 'azure'
@@ -135,7 +135,7 @@ idp_client_secret: 'REPLACE-WITH-CLIENT-SECRET'
 ```
 
 </TabItem>
-<TabItem value="Environment variables" label="Environment variables">
+<TabItem value="environment-variables" label="Environment variables">
 
 ```bash
 IDP_PROVIDER="azure"
@@ -155,8 +155,8 @@ Pomerium currently uses **`azure`** as the **`idp_provider`** name to refer to M
 
 ## Getting Groups
 
-<Tabs>
-<TabItem value="Custom Claim (Open Source)" label="Custom Claim (Open Source)">
+<Tabs queryString="get-groups">
+<TabItem value="custom-claim" label="Custom Claim (Open Source)">
 
 ### Custom Claim (Open Source)
 
@@ -188,7 +188,7 @@ The **`groups`** claim contains group IDs, not group names.
 :::
 
 </TabItem>
-<TabItem value="Directory Sync (Enterprise)" label="Directory Sync (Enterprise)">
+<TabItem value="directory-sync" label="Directory Sync (Enterprise)">
 
 ### Directory Sync (Enterprise)
 

--- a/content/docs/identity-providers/cognito.mdx
+++ b/content/docs/identity-providers/cognito.mdx
@@ -90,8 +90,8 @@ You can choose whether to use your own **Domain Name**, or use an AWS-provided o
 
 Once you have configured AWS Cognito, configure Pomerium to connext to it:
 
-<Tabs>
-<TabItem value="config.yaml" label="config.yaml">
+<Tabs queryString="configuration-settings">
+<TabItem value="config-file-keys" label="Config file keys">
 
 ```yaml
 idp_provider: 'oidc'
@@ -102,7 +102,7 @@ idp_scopes: 'openid,profile,email'
 ```
 
 </TabItem>
-<TabItem value="Environment Variables" label="Environment Variables">
+<TabItem value="environment-variables" label="Environment Variables">
 
 ```bash
 IDP_PROVIDER="oidc"
@@ -113,7 +113,7 @@ IDP_SCOPES="openid,profile,email"
 ```
 
 </TabItem>
-<TabItem value="Kubernetes ConfigMap" label="Kubernetes ConfigMap">
+<TabItem value="kubernetes-config-map" label="Kubernetes ConfigMap">
 
 ```yaml
 apiVersion: v1
@@ -142,8 +142,8 @@ To retrieve the **User Pool ID**, go to **General Settings** in the Cognito Side
 
 Cognito embeds group membership into the access token. To create policies based on group membership, use the `allowed_idp_claims` key. Replace `admins` in the examples below with your group:
 
-<Tabs>
-<TabItem value="Custom Claim (Open Source)" label="Custom Claim (Open Source)">
+<Tabs queryString="get-groups">
+<TabItem value="custom-claim" label="Custom Claim (Open Source)">
 
 ### Custom Claim (Open Source)
 
@@ -156,7 +156,7 @@ Cognito embeds group membership into the access token. To create policies based 
 ```
 
 </TabItem>
-<TabItem value="Directory Sync (Enterprise)" label="Directory Sync (Enterprise)">
+<TabItem value="directory-sync" label="Directory Sync (Enterprise)">
 
 ### Directory Sync (Enterprise)
 

--- a/content/docs/identity-providers/github.mdx
+++ b/content/docs/identity-providers/github.mdx
@@ -43,8 +43,8 @@ The [GitHub API] does not support [OpenID Connect], just [OAuth 2.0]. For this r
 
 After creating your GitHub OAuth application, update the **Pomerium** configuration:
 
-<Tabs>
-<TabItem value="config.yaml" label="config.yaml">
+<Tabs queryString="configuration-settings">
+<TabItem value="config-file-keys" label="Config file keys">
 
 ```bash
 idp_provider: "github"
@@ -53,7 +53,7 @@ idp_client_secret: "REDACTED"   // github application secret
 ```
 
 </TabItem>
-<TabItem value="Environment Variables" label="Environment Variables">
+<TabItem value="environment-variables" label="Environment Variables">
 
 ```bash
 IDP_PROVIDER="github"
@@ -70,15 +70,15 @@ Whenever a user tries to access your application integrated with Pomerium, they 
 
 ### Getting groups
 
-<Tabs>
-<TabItem value="Custom Claim (Open Source)" label="Custom Claim (Open Source)">
+<Tabs queryString="get-groups">
+<TabItem value="custom-claim" label="Custom Claim (Open Source)">
 
 ### Custom Claim (Open Source)
 
 The [GitHub API] does not support [OpenID Connect], just [OAuth 2.0] and it is not possible to get groups using a custom identity (`id_token`) claim. A full directory sync is required.
 
 </TabItem>
-<TabItem value="Directory Sync (Enterprise)" label="Directory Sync (Enterprise)">
+<TabItem value="directory-sync" label="Directory Sync (Enterprise)">
 
 ### Directory Sync (Enterprise)
 

--- a/content/docs/identity-providers/gitlab.mdx
+++ b/content/docs/identity-providers/gitlab.mdx
@@ -47,8 +47,8 @@ Edit your Pomerium configuration to provide the Client ID, secret, and domain (f
 
 ### GitLab.com
 
-<Tabs>
-<TabItem value="config.yaml-" label="config.yaml">
+<Tabs queryString="configuration-settings">
+<TabItem value="config-file-keys" label="Config file keys">
 
 ```yaml
 idp_provider: 'gitlab'
@@ -57,7 +57,7 @@ idp_client_secret: 'REDACTED' # gitlab application secret
 ```
 
 </TabItem>
-<TabItem value="Environment Variables" label="Environment Variables">
+<TabItem value="environment-variables" label="Environment Variables">
 
 ```bash
 IDP_PROVIDER="gitlab"
@@ -72,8 +72,8 @@ IDP_CLIENT_SECRET="REDACTED" # gitlab application secret
 
 Self-hosted CE/EE instances should be configured as a generic OpenID Connect provider:
 
-<Tabs>
-<TabItem value="config.yaml" label="config.yaml">
+<Tabs queryString="configuration-settings">
+<TabItem value="config-file-keys" label="config.yaml">
 
 ```yaml
 idp_provider: oidc
@@ -84,7 +84,7 @@ idp_provider_url: https://gitlab.example.com # Base URL of GitLab instance
 ```
 
 </TabItem>
-<TabItem value="Environment Variables" label="Environment Variables">
+<TabItem value="environment-variables" label="Environment Variables">
 
 ```bash
 IDP_PROVIDER="oidc"
@@ -103,15 +103,15 @@ When a user first uses Pomerium to login, they are presented with an authorizati
 
 ![gitlab access authorization screen](img/gitlab/gitlab-verify-access.png)
 
-<Tabs>
-<TabItem value="Custom Claim (Open Source)" label="Custom Claim (Open Source)">
+<Tabs queryString="get-groups">
+<TabItem value="custom-claim" label="Custom Claim (Open Source)">
 
 ### Custom Claim (Open Source)
 
 Unfortunately, Gitlab does not support OpenID Connect, and does not support custom identity (`id_token`) group claims.
 
 </TabItem>
-<TabItem value="Directory Sync (Enterprise)" label="Directory Sync (Enterprise)">
+<TabItem value="directory-sync" label="Directory Sync (Enterprise)">
 
 ### Directory Sync (Enterprise)
 

--- a/content/docs/identity-providers/google.mdx
+++ b/content/docs/identity-providers/google.mdx
@@ -67,7 +67,7 @@ Click **Create** once complete.
 
 Edit `config.yaml` or set your [environment variables] to connect Pomerium to Google:
 
-<Tabs queryString="configuration-settings">
+<Tabs>
 <TabItem value="config-file-keys" label="config.yaml">
 
 ```yaml title=/etc/pomerium/config.yaml
@@ -90,38 +90,40 @@ IDP_CLIENT_SECRET="xxxxxx"
 
 ## Getting Groups
 
-<Tabs queryString="get-groups">
-<TabItem value="custom-claim" label="Custom Claim (Open Source)">
+### Custom claims
 
-Unfortunately, Google does not yet support getting groups data using a custom claim. Groups must be loaded by using a plugin to fetch directory information (see Enterprise's Directory Sync).
+Unfortunately, Google doesn't support getting groups data with a custom claim. To get and use groups data from your Google directory, you must conduct a directory sync in the Enterprise Console.
 
-</TabItem>
+:::enterprise
 
-<TabItem value="directory-sync" label="Directory Sync (Enterprise)">
+See the [**Directory Sync**](/docs/capabilities/directory-sync) page for more information about syncing directory data in the Enterprise Console.
 
-## Setting Up Directory Sync
+Or, [contact sales](https://www.pomerium.com/enterprise-sales/) if you want to learn more about Pomerium Enterprise.
+
+:::
+
+## Set Up Directory Sync
 
 ### Create a service account
 
-In order for Pomerium to validate group membership, we'll also need to configure a [service account](https://console.cloud.google.com/iam-admin/serviceaccounts) with [G-suite domain-wide delegation](https://developers.google.com/admin-sdk/directory/v1/guides/delegation) enabled.
+In order for Pomerium to validate group membership, you must configure a [service account](https://console.cloud.google.com/iam-admin/serviceaccounts) with [G-suite domain-wide delegation](https://developers.google.com/admin-sdk/directory/v1/guides/delegation) enabled:
 
-1. Open the [**Service accounts** page](https://console.developers.google.com/iam-admin/serviceaccounts). If prompted, select a project.
+  1. Open the [**Service accounts** page](https://console.developers.google.com/iam-admin/serviceaccounts). If prompted, select a project.
 
-1. Click **+ Create Service Account**, enter a name and description for the service account. You can use the default service account ID, or choose a different, unique one. When done click **Create and continue**.
+  1. Click **+ Create Service Account**, enter a name and description for the service account. You can use the default service account ID, or choose a different, unique one. When done click **Create and continue**.
 
-1. The next sections, labeled **Grant this service account access to project** and **Grant users access to this service account**, are not required. Click **Continue** to both, and then **Create**.
+  1. The next sections, labeled **Grant this service account access to project** and **Grant users access to this service account**, are not required. Click **Continue** to both, and then **Create**.
 
-1. Select your new service account, and click on the **KEYS** tab. Select **Add key**, then **Create new key**:
+  1. Select your new service account, and click on the **KEYS** tab. Select **Add key**, then **Create new key**. In the side panel, select the **JSON** format for your key:
+    ![Creating a new key for a Google service account](./img/google/google-service-account-create-key.png)
 
-![Creating a new key for a Google service account](./img/google/google-service-account-create-key.png)
+  1. Click **Create**. Your new public/private key pair is generated and downloaded to your machine; it serves as the only copy of this key. For information on how to store it securely, see [Managing service account keys](https://cloud.google.com/iam/docs/understanding-service-accounts#managing_service_account_keys).
 
-In the side panel that appears, select the format for your key: **JSON**.
+  1. Click **Close** on the **Private key saved to your computer** dialog, then click **←** to return to the table of your service accounts.
 
-1. Click **Create**. Your new public/private key pair is generated and downloaded to your machine; it serves as the only copy of this key. For information on how to store it securely, see [Managing service account keys](https://cloud.google.com/iam/docs/understanding-service-accounts#managing_service_account_keys).
+### Enable domain-wide delegation
 
-1. Click **Close** on the **Private key saved to your computer** dialog, then click **←** to return to the table of your service accounts.
-
-Next, we need to enable enable G Suite domain-wide delegation:
+Next, we need to enable **domain-wide delegation**:
 
 1. Locate the newly-created service account in the table. Under **Actions**, click **Manage Details**.
 
@@ -139,7 +141,7 @@ Next, we need to enable enable G Suite domain-wide delegation:
 
 ### Set directory permissions for Workspaces
 
-Next, we need to give that service account permissions on the GSuite / Workspace side of the house.
+Next, we need to give that service account permissions on the G Suite / Workspace side of the house.
 
 1. From your Google Workspace domain's [Admin console](http://admin.google.com/) Main menu, go to **Security** > **Access and data control** > **API controls**.
 
@@ -149,12 +151,10 @@ Next, we need to give that service account permissions on the GSuite / Workspace
 
 1. In the **Client ID** field, enter the client ID obtained from the service account creation steps above.
 
-1. In the **OAuth Scopes** field, enter a comma-delimited list of the scopes required for your application (for a list of possible scopes, see [Authorize requests](https://developers.google.com/admin-sdk/directory/v1/guides/authorizing)).
+1. In the **OAuth Scopes** field, enter a comma-delimited list of the scopes required for your application (for a list of possible scopes, see [Authorize requests](https://developers.google.com/admin-sdk/directory/v1/guides/authorizing)). At a minimum, include the following scopes:
 
-Include at a minimum the following list of scopes:
-
-- `https://www.googleapis.com/auth/admin.directory.group.readonly`
-- `https://www.googleapis.com/auth/admin.directory.user.readonly`
+    - `https://www.googleapis.com/auth/admin.directory.group.readonly`
+    - `https://www.googleapis.com/auth/admin.directory.user.readonly`
 
 1. Click the **Authorize** button.
 
@@ -165,9 +165,6 @@ Include at a minimum the following list of scopes:
 Under **Settings → Identity Providers**, select "Google" as the identity provider and set the Impersonate User and JSON file.
 
 ![Google Settings](./img/google/google-idp.png)
-
-</TabItem>
-</Tabs>
 
 [client id]: /docs/reference/identity-provider-settings#identity-provider-client-id
 [client secret]: /docs/reference/identity-provider-settings#identity-provider-client-secret

--- a/content/docs/identity-providers/google.mdx
+++ b/content/docs/identity-providers/google.mdx
@@ -108,18 +108,17 @@ Or, [contact sales](https://www.pomerium.com/enterprise-sales/) if you want to l
 
 In order for Pomerium to validate group membership, you must configure a [service account](https://console.cloud.google.com/iam-admin/serviceaccounts) with [G-suite domain-wide delegation](https://developers.google.com/admin-sdk/directory/v1/guides/delegation) enabled:
 
-  1. Open the [**Service accounts** page](https://console.developers.google.com/iam-admin/serviceaccounts). If prompted, select a project.
+1. Open the [**Service accounts** page](https://console.developers.google.com/iam-admin/serviceaccounts). If prompted, select a project.
 
-  1. Click **+ Create Service Account**, enter a name and description for the service account. You can use the default service account ID, or choose a different, unique one. When done click **Create and continue**.
+1. Click **+ Create Service Account**, enter a name and description for the service account. You can use the default service account ID, or choose a different, unique one. When done click **Create and continue**.
 
-  1. The next sections, labeled **Grant this service account access to project** and **Grant users access to this service account**, are not required. Click **Continue** to both, and then **Create**.
+1. The next sections, labeled **Grant this service account access to project** and **Grant users access to this service account**, are not required. Click **Continue** to both, and then **Create**.
 
-  1. Select your new service account, and click on the **KEYS** tab. Select **Add key**, then **Create new key**. In the side panel, select the **JSON** format for your key:
-    ![Creating a new key for a Google service account](./img/google/google-service-account-create-key.png)
+1. Select your new service account, and click on the **KEYS** tab. Select **Add key**, then **Create new key**. In the side panel, select the **JSON** format for your key: ![Creating a new key for a Google service account](./img/google/google-service-account-create-key.png)
 
-  1. Click **Create**. Your new public/private key pair is generated and downloaded to your machine; it serves as the only copy of this key. For information on how to store it securely, see [Managing service account keys](https://cloud.google.com/iam/docs/understanding-service-accounts#managing_service_account_keys).
+1. Click **Create**. Your new public/private key pair is generated and downloaded to your machine; it serves as the only copy of this key. For information on how to store it securely, see [Managing service account keys](https://cloud.google.com/iam/docs/understanding-service-accounts#managing_service_account_keys).
 
-  1. Click **Close** on the **Private key saved to your computer** dialog, then click **←** to return to the table of your service accounts.
+1. Click **Close** on the **Private key saved to your computer** dialog, then click **←** to return to the table of your service accounts.
 
 ### Enable domain-wide delegation
 
@@ -153,8 +152,8 @@ Next, we need to give that service account permissions on the G Suite / Workspac
 
 1. In the **OAuth Scopes** field, enter a comma-delimited list of the scopes required for your application (for a list of possible scopes, see [Authorize requests](https://developers.google.com/admin-sdk/directory/v1/guides/authorizing)). At a minimum, include the following scopes:
 
-    - `https://www.googleapis.com/auth/admin.directory.group.readonly`
-    - `https://www.googleapis.com/auth/admin.directory.user.readonly`
+   - `https://www.googleapis.com/auth/admin.directory.group.readonly`
+   - `https://www.googleapis.com/auth/admin.directory.user.readonly`
 
 1. Click the **Authorize** button.
 

--- a/content/docs/identity-providers/google.mdx
+++ b/content/docs/identity-providers/google.mdx
@@ -67,8 +67,8 @@ Click **Create** once complete.
 
 Edit `config.yaml` or set your [environment variables] to connect Pomerium to Google:
 
-<Tabs>
-<TabItem value="config.yaml" label="config.yaml">
+<Tabs queryString="configuration-settings">
+<TabItem value="config-file-keys" label="config.yaml">
 
 ```yaml title=/etc/pomerium/config.yaml
 idp_provider: 'google'
@@ -77,7 +77,7 @@ idp_client_secret: 'xxxxxx'
 ```
 
 </TabItem>
-<TabItem value="Environment Variables" label="Environment Variables">
+<TabItem value="environment-variables" label="Environment Variables">
 
 ```bash
 IDP_PROVIDER="google"
@@ -90,14 +90,14 @@ IDP_CLIENT_SECRET="xxxxxx"
 
 ## Getting Groups
 
-<Tabs>
-<TabItem value="Custom Claim (Open Source)" label="Custom Claim (Open Source)">
+<Tabs queryString="get-groups">
+<TabItem value="custom-claim" label="Custom Claim (Open Source)">
 
 Unfortunately, Google does not yet support getting groups data using a custom claim. Groups must be loaded by using a plugin to fetch directory information (see Enterprise's Directory Sync).
 
 </TabItem>
 
-<TabItem value="Directory Sync (Enterprise)" label="Directory Sync (Enterprise)">
+<TabItem value="directory-sync" label="Directory Sync (Enterprise)">
 
 ## Setting Up Directory Sync
 

--- a/content/docs/identity-providers/google.mdx
+++ b/content/docs/identity-providers/google.mdx
@@ -114,7 +114,8 @@ In order for Pomerium to validate group membership, you must configure a [servic
 
 1. The next sections, labeled **Grant this service account access to project** and **Grant users access to this service account**, are not required. Click **Continue** to both, and then **Create**.
 
-1. Select your new service account, and click on the **KEYS** tab. Select **Add key**, then **Create new key**. In the side panel, select the **JSON** format for your key: ![Creating a new key for a Google service account](./img/google/google-service-account-create-key.png)
+1. Select your new service account, and click on the **KEYS** tab. Select **Add key**, then **Create new key**. In the side panel, select the **JSON** format for your key:
+  ![Creating a new key for a Google service account](./img/google/google-service-account-create-key.png)
 
 1. Click **Create**. Your new public/private key pair is generated and downloaded to your machine; it serves as the only copy of this key. For information on how to store it securely, see [Managing service account keys](https://cloud.google.com/iam/docs/understanding-service-accounts#managing_service_account_keys).
 

--- a/content/docs/identity-providers/google.mdx
+++ b/content/docs/identity-providers/google.mdx
@@ -92,7 +92,7 @@ IDP_CLIENT_SECRET="xxxxxx"
 
 ### Custom claims
 
-Unfortunately, Google doesn't support getting groups data with a custom claim. To get and use groups data from your Google directory, you must conduct a directory sync in the Enterprise Console.
+Unfortunately, Google doesn't support getting groups data with a custom claim. To get and use groups data from your Google directory, you must enable directory sync in the Enterprise Console.
 
 :::enterprise
 

--- a/content/docs/identity-providers/google.mdx
+++ b/content/docs/identity-providers/google.mdx
@@ -114,8 +114,7 @@ In order for Pomerium to validate group membership, you must configure a [servic
 
 1. The next sections, labeled **Grant this service account access to project** and **Grant users access to this service account**, are not required. Click **Continue** to both, and then **Create**.
 
-1. Select your new service account, and click on the **KEYS** tab. Select **Add key**, then **Create new key**. In the side panel, select the **JSON** format for your key:
-  ![Creating a new key for a Google service account](./img/google/google-service-account-create-key.png)
+1. Select your new service account, and click on the **KEYS** tab. Select **Add key**, then **Create new key**. In the side panel, select the **JSON** format for your key: ![Creating a new key for a Google service account](./img/google/google-service-account-create-key.png)
 
 1. Click **Create**. Your new public/private key pair is generated and downloaded to your machine; it serves as the only copy of this key. For information on how to store it securely, see [Managing service account keys](https://cloud.google.com/iam/docs/understanding-service-accounts#managing_service_account_keys).
 

--- a/content/docs/identity-providers/okta.mdx
+++ b/content/docs/identity-providers/okta.mdx
@@ -54,8 +54,8 @@ While we do our best to keep our documentation up to date, changes to third-part
 
 Finally, configure Pomerium with the identity provider settings retrieved in the previous steps. Your [environmental variables] should look something like this.
 
-<Tabs>
-<TabItem value="config.yaml" label="config.yaml">
+<Tabs queryString="configuration-settings">
+<TabItem value="config-file-keys" label="config.yaml">
 
 ```yaml
 idp_provider: 'okta'
@@ -65,7 +65,7 @@ idp_client_secret: 'REPLACE ME'
 ```
 
 </TabItem>
-<TabItem value="Environment Variables" label="Environment Variables">
+<TabItem value="environment-variables" label="Environment Variables">
 
 ```bash
 IDP_PROVIDER="okta"
@@ -77,8 +77,8 @@ IDP_CLIENT_SECRET="REPLACE_ME"
 </TabItem>
 </Tabs>
 
-<Tabs>
-<TabItem value="Custom Claim (Open Source)" label="Custom Claim (Open Source)">
+<Tabs queryString="get-groups">
+<TabItem value="custom-claim" label="Custom Claim (Open Source)">
 
 ### Custom Claim (Open Source)
 
@@ -99,7 +99,7 @@ routes:
 ```
 
 </TabItem>
-<TabItem value="Directory Sync (Enterprise)" label="Directory Sync (Enterprise)">
+<TabItem value="directory-sync" label="Directory Sync (Enterprise)">
 
 ### Directory Sync (Enterprise)
 

--- a/content/docs/identity-providers/one-login.mdx
+++ b/content/docs/identity-providers/one-login.mdx
@@ -59,8 +59,8 @@ OneLogin will not make your new application accessible to members of your organi
 
 Update your Pomerium configuration:
 
-<Tabs>
-<TabItem value="config.yaml" label="config.yaml">
+<Tabs queryString="configuration-settings">
+<TabItem value="config-file-keys" label="config.yaml">
 
 ```yaml
 idp_provider: 'onelogin'
@@ -70,7 +70,7 @@ idp_client_secret: 'REDACTED' # Your OneLogin application secret
 ```
 
 </TabItem>
-<TabItem value="Environment Variables" label="Environment Variables">
+<TabItem value="environment-variables" label="Environment Variables">
 
 ```bash
 IDP_PROVIDER="onelogin"
@@ -102,15 +102,15 @@ routes:
             - claim/groups: admin
 ```
 
-<Tabs>
-<TabItem value="Custom Claim (Open Source)" label="Custom Claim (Open Source)">
+<Tabs queryString="get-groups">
+<TabItem value="custom-claim" label="Custom Claim (Open Source)">
 
 ### Custom Claim (Open Source)
 
 Unfortunately, OneLogin does not yet support getting groups data using a custom claim. Groups must be loaded by using a plugin to fetch directory information (see Enterprise's Directory Sync).
 
 </TabItem>
-<TabItem value="Directory Sync (Enterprise)" label="Directory Sync (Enterprise)">
+<TabItem value="directory-sync" label="Directory Sync (Enterprise)">
 
 ### Directory Sync (Enterprise)
 

--- a/content/docs/identity-providers/ping.mdx
+++ b/content/docs/identity-providers/ping.mdx
@@ -57,8 +57,8 @@ While we do our best to keep our documentation up to date, changes to third-part
 
 Update your Pomerium configuration to use Ping as the IdP:
 
-<Tabs>
-<TabItem value="config.yaml" label="config.yaml">
+<Tabs queryString="configuration-settings">
+<TabItem value="config-file-keys" label="config.yaml">
 
 ```yaml
 idp_provider: 'ping'
@@ -68,7 +68,7 @@ idp_client_secret: 'CLIENT_SECRET'
 ```
 
 </TabItem>
-<TabItem value="Environment Variables" label="Environment Variables">
+<TabItem value="environment-variables" label="Environment Variables">
 
 ```bash
 IDP_PROVIDER="ping"
@@ -84,8 +84,8 @@ IDP_CLIENT_SECRET="CLIENT_SECRET"
 
 ![Ping Settings](./img/ping/ping-idp.png)
 
-<Tabs>
-<TabItem value="Custom Claim (Open Source)" label="Custom Claim (Open Source)">
+<Tabs queryString="get-groups">
+<TabItem value="custom-claim" label="Custom Claim (Open Source)">
 
 ### Custom Claim (Open Source)
 
@@ -112,7 +112,7 @@ The `groups` claim contains group IDs, not group names.
 :::
 
 </TabItem>
-<TabItem value="Directory Sync (Enterprise)" label="Directory Sync (Enterprise)">
+<TabItem value="directory-sync" label="Directory Sync (Enterprise)">
 
 ### Directory Sync (Enterprise)
 


### PR DESCRIPTION
This PR adds query strings to Tabs. Now, when you send a link that includes an anchor link within a Tab, the page will scroll to the correct location. 

Note: I did add `queryString` to the Config and Envar Tabs, too. If you click one of these tabs, and then click another Tab in a separate  block, with a query string, it will conjoin them. For example: 

```markdown
<Tabs queryString="foo-a">
<TabItem value="bar-a"></TabItem>
<TabItem value="baz-a"></TabItem>
</Tabs>
<Tabs queryString="foo-b">
<TabItem value="bar-b"></TabItem>
<TabItem value="baz-b"></TabItem>
</Tabs>
```
Selecting `baz-a` and then `bar-b` would result in a string like:

`?foo-a=baz-a&foo-b=bar-b`. A real life example:

`/docs/identity-providers/github?configuration-settings=environment-variables&get-groups=directory-sync`

It's entirely possible that user would unwittingly select both Tabs, which would break the functionality. I want the team's input, but maybe we should only add query strings to one tab block in a page going forward? Happy to document this internally. 

Resolves https://github.com/pomerium/documentation/issues/1288