### PR TITLE
update TCP Redis example

### DIFF
--- a/content/docs/capabilities/tcp.mdx
+++ b/content/docs/capabilities/tcp.mdx
@@ -69,7 +69,7 @@ To connect, you normally need just the external hostname and port of your TCP ro
 
 ```shell-session
 $ pomerium-cli tcp redis.localhost.pomerium.io:6739
-2023/10/02 11:19:59 listening on 127.0.0.1:53479
+2023/10/02 11:19:59 listening on 127.0.0.1:52046
 ```
 
 By default, `pomerium-cli` will start a listener on loopback on a random port.


### PR DESCRIPTION
In the 'Connect to TCP Routes' example, make sure the port number chosen by pomerium-cli matches the port number in the redis-cli command.