### PR TITLE
Fixes typos in lb entries

### DIFF
--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -909,18 +909,18 @@
     "description": "Checks a response with 'fuzzy' matching to the extent that each payload block must be found, and in the specified order, but not necessarily contiguous. Optional.",
     "type": "Payload"
   },
-  "grpc-health-check-receive": {
+  "grpc-health-check-authority": {
     "id": "grpc-health-check-authority",
-    "title": "gRPC Health Check Receive",
+    "title": "gRPC Health Check Authority",
     "path": "/routes/load-balancing#grpc-healthcheck-overview",
-    "description": "The ':authority' header value in a gRPC health check request. Optional.",
+    "description": "Specifies the ':authority' header value in a gRPC health check request. Optional.",
     "type": "string"
   },
   "grpc-health-check-service-name": {
     "id": "grpc-health-check-service-name",
     "title": "gRPC Health Check Service Name",
     "path": "/routes/load-balancing#grpc-healthcheck-overview",
-    "description": "An optional service name parameter sent to the gRPC service. Optional.",
+    "description": "Specifies the service name parameter sent to the gRPC service. Optional.",
     "type": "string"
   },
   "headers-settings": {


### PR DESCRIPTION
This PR fixes a few typos in the `reference.json` file for Load Balancing gRPC health checks settings.