### PR TITLE
tcp: correct pomerium-cli version number

### DIFF
--- a/content/docs/capabilities/tcp.mdx
+++ b/content/docs/capabilities/tcp.mdx
@@ -117,7 +117,7 @@ The command above connects to `https://pomerium.corp.example.com:8443` and then 
 
 If Pomerium is configured to require client certificates, you will also need to provide a client certificate and private key when invoking the `pomerium-cli` command.
 
-You can specify these either by using PEM files, or (starting in v0.25) by searching for a certificate in the system trust store (**macOS** and **Windows** only).
+You can specify these either by using PEM files, or (new in [v0.23.0](https://github.com/pomerium/cli/releases/tag/v0.23.0)) by searching for a certificate in the system trust store (on **macOS** and **Windows** only).
 
 To specify a client certificate and key using PEM files:
 


### PR DESCRIPTION
Fix an incorrect pomerium-cli version number and add a link to the GitHub release.