### PR TITLE
Adds prompt to change email in config.yaml like enterprise quickstart

### DIFF
--- a/content/docs/quickstart.mdx
+++ b/content/docs/quickstart.mdx
@@ -43,6 +43,8 @@ Add the configuration below to `config.yaml`:
 
 <ConfigDocker />
 
+Replace `user@example.com` with your email address.
+
 ## Configure Docker
 
 Create a `docker-compose.yaml` file in the root of your project.


### PR DESCRIPTION
I noticed the note for updated the email in config.yaml was omitted from the non-enterprise quickstart, which would land a user at 403 forbidden instead of the desired page. 