### PR TITLE
document client cert as external data key

### DIFF
--- a/content/docs/integrations.mdx
+++ b/content/docs/integrations.mdx
@@ -89,6 +89,7 @@ Unless defined by the directory structure of a supplied archive file, the Record
 - `user.id` (Also the default if no value is provided)
 - `user.email`
 - `request.ip`
+- `request.client_certificate.fingerprint` (if [mTLS](/docs/reference/downstream-mtls-settings) is enabled)
 
 #### IP range lookup support
 


### PR DESCRIPTION
Add client certificate fingerprint to the list of supported keys for use with external data sources.

Related issue: https://github.com/pomerium/internal/issues/1719