### PR TITLE
docs(data-storage): remove mention of encryption with deprecated Redis backend

### DIFF
--- a/content/docs/internals/data-storage.md
+++ b/content/docs/internals/data-storage.md
@@ -33,7 +33,7 @@ To prevent early session loss in production deployments, persistent storage back
 
 The **Databroker Service** stores user session data, and uses an in-memory databroker by default.
 
-Pomerium encrypts record values only for the Redis storage backend (not for the in-memory or Postgres storage backends). When using the Postgres backend we recommend that users configure their own encryption at rest, for example by using full-disk encryption on the volume where Postgres data is stored.
+Pomerium does not encrypt record values for either the in-memory or Postgres storage backends. When using the Postgres backend we recommend that users configure their own encryption at rest, for example by using full-disk encryption on the volume where Postgres data is stored.
 
 :::tip
 


### PR DESCRIPTION
This PR removes a last remaining mention of the deprecated Redis storage backend on the "Persistence" page.

Closes #1390. 