### PR TITLE
adds v0.22 outdated docs notice

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -50,6 +50,13 @@ const config = {
 
   themeConfig: {
     image: 'docs/img/logo.svg',
+    announcementBar: {
+      id: 'old_version',
+      content: 'You\'re viewing the <b>Pomerium v0.22</b> docs website. This documentation is outdated. To view the latest documentation, go to <a href="https://pomerium.com/docs">https://pomerium.com/docs</a>.',
+      backgroundColor: '#fddda3',
+      textColor: '#000000',
+      isCloseable: false,
+    },
     algolia: {
       appId: process.env.ALGOLIA_APPID,
       apiKey: process.env.ALGOLIA_APIKEY, // cSpell:ignore APIKEY


### PR DESCRIPTION
Related to https://github.com/pomerium/documentation/issues/1389 and https://github.com/pomerium/internal/issues/1791