### PR TITLE
build(deps): update @babel/types and @mui/x-data-grid

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "@mdx-js/react": "^1.6.22",
     "@mui/icons-material": "^5.6.2",
     "@mui/material": "^5.6.4",
-    "@mui/x-data-grid": "^5.10.0",
-    "@mui/x-data-grid-pro": "^5.10.0",
+    "@mui/x-data-grid": "5.11.0",
+    "@mui/x-data-grid-pro": "5.11.0",
     "clsx": "^1.1.1",
     "docusaurus-gtm-plugin": "^0.0.2",
     "dotenv": "^16.0.1",
@@ -55,5 +55,8 @@
   "devDependencies": {
     "js-yaml": "^4.1.0",
     "prettier": "^2.7.1"
+  },
+  "resolutions": {
+    "@babel/types": "7.20.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -689,10 +689,10 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
-"@babel/helper-string-parser@^7.18.10":
-  version "7.18.10"
-  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.18.10.tgz#181f22d28ebe1b3857fa575f5c290b1aaf659b56"
-  integrity sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==
+"@babel/helper-string-parser@^7.19.4":
+  version "7.24.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz#f99c36d3593db9540705d0739a1f10b5e20c696e"
+  integrity sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==
 
 "@babel/helper-validator-identifier@^7.16.7":
   version "7.16.7"
@@ -703,6 +703,11 @@
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
   integrity sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
+
+"@babel/helper-validator-identifier@^7.19.1":
+  version "7.24.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz#918b1a7fa23056603506370089bd990d8720db62"
+  integrity sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==
 
 "@babel/helper-validator-option@^7.16.7":
   version "7.16.7"
@@ -2109,21 +2114,13 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.12.7", "@babel/types@^7.15.6", "@babel/types@^7.16.0", "@babel/types@^7.16.7", "@babel/types@^7.16.8", "@babel/types@^7.17.0", "@babel/types@^7.4.4":
-  version "7.17.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.17.0.tgz#a826e368bccb6b3d84acd76acad5c0d87342390b"
-  integrity sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
+"@babel/types@7.20.0", "@babel/types@^7.12.7", "@babel/types@^7.15.6", "@babel/types@^7.16.0", "@babel/types@^7.16.7", "@babel/types@^7.16.8", "@babel/types@^7.17.0", "@babel/types@^7.18.10", "@babel/types@^7.18.13", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.4.4":
+  version "7.20.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.20.0.tgz#52c94cf8a7e24e89d2a194c25c35b17a64871479"
+  integrity sha512-Jlgt3H0TajCW164wkTOTzHkZb075tMQMULzrLUoUeKmO7eFL96GgDxf7/Axhc5CAuKE3KFyVW1p6ysKsi2oXAg==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.16.7"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.18.10", "@babel/types@^7.18.13", "@babel/types@^7.18.6", "@babel/types@^7.18.9":
-  version "7.18.13"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.13.tgz#30aeb9e514f4100f7c1cb6e5ba472b30e48f519a"
-  integrity sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==
-  dependencies:
-    "@babel/helper-string-parser" "^7.18.10"
-    "@babel/helper-validator-identifier" "^7.18.6"
+    "@babel/helper-string-parser" "^7.19.4"
+    "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
 "@braintree/sanitize-url@^6.0.0":
@@ -2406,7 +2403,7 @@
     "@docusaurus/theme-search-algolia" "2.2.0"
     "@docusaurus/types" "2.2.0"
 
-"@docusaurus/react-loadable@5.5.2", "react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+"@docusaurus/react-loadable@5.5.2":
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
   integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
@@ -2858,33 +2855,33 @@
     prop-types "^15.7.2"
     react-is "^17.0.2"
 
-"@mui/x-data-grid-pro@^5.10.0":
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/@mui/x-data-grid-pro/-/x-data-grid-pro-5.10.0.tgz#2b82649a0891cb0c0582afd730df2fa4f36bb084"
-  integrity sha512-eq9Lx6udftnW5O7D7xtecI9BljDRRuOijymKk6/pZDiS3tfbES8dK6p1v4Dd8yvqpORoIDG4eprU9kBaI4a9XA==
+"@mui/x-data-grid-pro@5.11.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-data-grid-pro/-/x-data-grid-pro-5.11.0.tgz#bd399c50ed56c566c0a887f8e5b65f7a157d8b63"
+  integrity sha512-whjv1tag+o5eQlvDYvaZXesJMb3ilEi3j8Gfh3K8E29RhcMGFJf1pfIhvAEw2vkS6B8XKDwpBidyPQwNmgmxfg==
   dependencies:
     "@mui/utils" "^5.6.1"
-    "@mui/x-data-grid" "5.10.0"
-    "@mui/x-license-pro" "5.10.0"
+    "@mui/x-data-grid" "5.11.0"
+    "@mui/x-license-pro" "5.11.0"
     "@types/format-util" "^1.0.2"
     clsx "^1.0.4"
     prop-types "^15.8.1"
     reselect "^4.1.5"
 
-"@mui/x-data-grid@5.10.0", "@mui/x-data-grid@^5.10.0":
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/@mui/x-data-grid/-/x-data-grid-5.10.0.tgz#22917a8c1a6e95a2d3cde691f53071a838cba0e2"
-  integrity sha512-+NELUtA+6RAVFHR8sGrSxtJC8+3NQMLflYBm816DXjQvPA8vvCPI50SPKCUYUpBuepQtTBQWcty0Tdm9tjzInA==
+"@mui/x-data-grid@5.11.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-data-grid/-/x-data-grid-5.11.0.tgz#436a2e95fef231dfe895ea72de95ec3411c84342"
+  integrity sha512-hVGzzmtAUjTvsOKo26gWbmNQhApfelUh1SSA8BLQhMDYwaOHVrC6hBlIOJV/Qlw3sAIAdq60iAg+G9NeHEib4w==
   dependencies:
     "@mui/utils" "^5.6.1"
     clsx "^1.1.1"
     prop-types "^15.8.1"
     reselect "^4.1.5"
 
-"@mui/x-license-pro@5.10.0":
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/@mui/x-license-pro/-/x-license-pro-5.10.0.tgz#a34599b2a97be3fb903c70b1c847a7b788bd8de2"
-  integrity sha512-F+jKunpdvL8eRjcK3kKnTJKdmIVvAL2+Y6OSv4nT/PHnc7ILe1SIYESqERqNI/fvlNh4fh320xTablf1p3556g==
+"@mui/x-license-pro@5.11.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-license-pro/-/x-license-pro-5.11.0.tgz#80ba9210c73c9a7e8170f93ed225bc50db39e801"
+  integrity sha512-dVgcbOUNG1jgc80vqiJzrs0Fz+YxG12uKkl8MNFQY2mMIRg8z0t1kDkzSZ14YTKYXEB72GEo7r4yLO/J13wagQ==
   dependencies:
     "@mui/utils" "^5.6.1"
     esm "^3.2.25"
@@ -7820,6 +7817,14 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   integrity sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==
   dependencies:
     "@babel/runtime" "^7.10.3"
+
+"react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
+  integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
+  dependencies:
+    "@types/react" "*"
+    prop-types "^15.6.2"
 
 react-mailchimp-subscribe@^2.1.3:
   version "2.1.3"


### PR DESCRIPTION
Address some deployment build errors:

 - TypeError: /opt/build/repo/static/img/logo.svg: isTSSatisfiesExpression is not a function
 - Error extracting license expiry timestamp. TypeError: Cannot read properties of null

(The fix for the license error is described at https://mui.com/x/introduction/licensing/#6-invalid-license-key-typeerror-extracting-license-expiry-timestamp.)