### PR TITLE
FIX: use correct config key for cookie expiration

### DIFF
--- a/content/docs/reference/cookies.mdx
+++ b/content/docs/reference/cookies.mdx
@@ -220,16 +220,16 @@ cookie:
 
 | **Config file keys** | **Environment variables** | **Type** | **Default** |
 | :-- | :-- | :-- | :-- |
-| `cookie_expiration` | `COOKIE_EXPIRATION` | `string` ([Go Duration](https://golang.org/pkg/time/#Duration.String) formatting) | `14h` |
+| `cookie_expire` | `COOKIE_EXPIRE` | `string` ([Go Duration](https://golang.org/pkg/time/#Duration.String) formatting) | `14h` |
 
 #### Examples {#cookie-expiration-examples}
 
 ```yaml
-cookie_expiration: 13h15m0.5s
+cookie_expire: 13h15m0.5s
 ```
 
 ```bash
-COOKIE_EXPIRATION=13h15m0.5s
+COOKIE_EXPIRE=13h15m0.5s
 ```
 
 </TabItem>


### PR DESCRIPTION
The here documented key cookie_expiration does not work (tested using 0.25.2), cookie_expire does work, which was documented in an older version of the docs. If the docs are meant to be correct, then maybe pomerium itself should be changed to use the updated syntax