### PR TITLE
Removes outdated version element from docker files

### DIFF
--- a/content/docs/capabilities/high-availability.mdx
+++ b/content/docs/capabilities/high-availability.mdx
@@ -172,7 +172,6 @@ routes:
 Create docker compose configuration
 
 ```yaml title="docker-compose.yaml"
-version: '3.8'
 networks:
   main: {}
 services:

--- a/content/docs/courses/fundamentals/advanced-policies.md
+++ b/content/docs/courses/fundamentals/advanced-policies.md
@@ -165,7 +165,6 @@ routes:
 Docker Compose:
 
 ```yaml
-version: '3'
 services:
   pomerium:
     image: cr.pomerium.com/pomerium/pomerium:latest

--- a/content/docs/courses/fundamentals/advanced-routes.md
+++ b/content/docs/courses/fundamentals/advanced-routes.md
@@ -440,7 +440,6 @@ routes:
 Docker Compose
 
 ```yaml
-version: '3'
 services:
   pomerium:
     image: cr.pomerium.com/pomerium/pomerium:latest

--- a/content/docs/courses/fundamentals/build-policies.md
+++ b/content/docs/courses/fundamentals/build-policies.md
@@ -244,7 +244,6 @@ routes:
 Docker Compose:
 
 ```yaml
-version: '3'
 services:
   pomerium:
     image: cr.pomerium.com/pomerium/pomerium:latest

--- a/content/docs/courses/fundamentals/build-routes.md
+++ b/content/docs/courses/fundamentals/build-routes.md
@@ -68,7 +68,6 @@ routes:
 In your `docker-compose.yaml` file, add Grafana as a service:
 
 ```yaml title="docker-compose.yaml"
-version: '3'
 services:
   pomerium:
     image: cr.pomerium.com/pomerium/pomerium:latest
@@ -182,7 +181,6 @@ routes:
 Docker Compose:
 
 ```yaml
-version: '3'
 services:
   pomerium:
     image: cr.pomerium.com/pomerium/pomerium:latest

--- a/content/docs/courses/fundamentals/get-started.md
+++ b/content/docs/courses/fundamentals/get-started.md
@@ -107,7 +107,6 @@ Create a YAML file called `docker-compose.yaml`.
 Add the following configuration settings to `docker-compose.yaml`:
 
 ```yaml title="docker-compose.yaml"
-version: '3'
 services:
   pomerium:
     image: cr.pomerium.com/pomerium/pomerium:latest
@@ -181,7 +180,6 @@ routes:
 Docker Compose:
 
 ```yaml
-version: '3'
 services:
   pomerium:
     image: cr.pomerium.com/pomerium/pomerium:latest

--- a/content/docs/courses/fundamentals/jwt-verification.md
+++ b/content/docs/courses/fundamentals/jwt-verification.md
@@ -336,7 +336,6 @@ routes:
 Docker Compose
 
 ```yaml
-version: '3'
 services:
   pomerium:
     image: cr.pomerium.com/pomerium/pomerium:latest

--- a/content/docs/courses/fundamentals/tcp-routes.md
+++ b/content/docs/courses/fundamentals/tcp-routes.md
@@ -114,7 +114,6 @@ certificates:
 In your Docker Compose file, bind mount your wildcard certificates as a volume in the Pomerium service:
 
 ```yaml title="docker-compose.yaml"
-version: '3'
 services:
   pomerium:
     image: cr.pomerium.com/pomerium/pomerium:latest

--- a/content/docs/guides/code-server.mdx
+++ b/content/docs/guides/code-server.mdx
@@ -98,7 +98,6 @@ In this example route, `code.localhost.pomerium.io` is the publicly accessible r
 In your `docker-compose.yaml` file, add the code-server and Pomerium services:
 
 ```yaml
-version: '3'
 services:
   pomerium:
     image: cr.pomerium.com/pomerium/pomerium:latest

--- a/content/docs/guides/hedgedoc.md
+++ b/content/docs/guides/hedgedoc.md
@@ -95,7 +95,6 @@ In the next section, you'll bind mount these certificates in a Docker Compose fi
 In your `docker-compose.yaml` file, add the following services:
 
 ```yaml
-version: '3'
 services:
   pomerium:
     image: cr.pomerium.com/pomerium/pomerium:latest

--- a/content/docs/guides/jwt-verification.md
+++ b/content/docs/guides/jwt-verification.md
@@ -51,7 +51,6 @@ Mac and Linux users can use DNSMasq to map the `*.localhost.pomerium.io` domain 
 1. Create a `docker-compose.yaml` file containing:
 
    ```yaml title="docker-compose.yaml"
-   version: '3.9'
    networks:
      frontend:
        driver: 'bridge'

--- a/content/docs/guides/local-oidc.md
+++ b/content/docs/guides/local-oidc.md
@@ -14,7 +14,6 @@ You can use the same configuration examples below for other supported [identity 
 1. When using Docker-compose:
 
 ```yaml title="docker-compose.yaml"
-version: '3'
 services:
   pomerium:
     image: cr.pomerium.com/pomerium/pomerium:latest

--- a/content/docs/guides/tiddlywiki.mdx
+++ b/content/docs/guides/tiddlywiki.mdx
@@ -84,7 +84,6 @@ Let's review the configuration file:
 Add the following code in your `docker-compose.yaml` file:
 
 ```yaml title="docker-compose.yaml"
-version: '3'
 services:
   pomerium:
     image: cr.pomerium.com/pomerium/pomerium:latest

--- a/content/docs/identity-providers/oidc.mdx
+++ b/content/docs/identity-providers/oidc.mdx
@@ -33,7 +33,6 @@ To complete this guide, you need:
 Create a `docker-compose.yaml` file and add the following configuration:
 
 ```yaml title="docker-compose.yaml"
-version: '3'
 services:
   mykeycloak:
     image: quay.io/keycloak/keycloak:22.0.1

--- a/content/docs/integrations/bamboohr.mdx
+++ b/content/docs/integrations/bamboohr.mdx
@@ -30,7 +30,6 @@ These instructions assume a local testing environment using [Docker Compose]. Ad
 1. Add the datasource docker image to Docker Compose:
 
 ```yaml showLineNumbers
-version: '3'
 services:
   bamboohr:
     image: docker.cloudsmith.io/pomerium/datasource/datasource:main

--- a/content/docs/integrations/zenefits.mdx
+++ b/content/docs/integrations/zenefits.mdx
@@ -33,7 +33,6 @@ These instructions assume a local testing environment using [Docker Compose]. Ad
 1. Add the datasource docker image to Docker Compose:
 
 ```yaml showLineNumbers
-version: '3'
 services:
   zenefits:
     image: docker.cloudsmith.io/pomerium/datasource/datasource:main

--- a/content/examples/docker/autocert.docker-compose.yml
+++ b/content/examples/docker/autocert.docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   pomerium:
     image: cr.pomerium.com/pomerium/pomerium:latest

--- a/content/examples/docker/basic.docker-compose.yml.md
+++ b/content/examples/docker/basic.docker-compose.yml.md
@@ -1,5 +1,4 @@
 ```yaml
-version: "3"
 services:
   pomerium:
     image: cr.pomerium.com/pomerium/pomerium:latest

--- a/content/examples/docker/nginx.docker-compose.yml
+++ b/content/examples/docker/nginx.docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   nginx:
     image: pomerium/nginx-proxy:latest

--- a/content/examples/enterprise/hosted-auth-docker.yaml.md
+++ b/content/examples/enterprise/hosted-auth-docker.yaml.md
@@ -1,5 +1,4 @@
 ```yaml title="docker-compose.yaml"
-version: '3'
 services:
   pomerium:
     image: cr.pomerium.com/pomerium/pomerium:latest

--- a/content/examples/jenkins/jenkins-docker-compose.md
+++ b/content/examples/jenkins/jenkins-docker-compose.md
@@ -1,5 +1,4 @@
 ```yaml
-version: '3'
 networks:
  main: {}
 services:

--- a/content/examples/nginx/docker-compose.yaml.md
+++ b/content/examples/nginx/docker-compose.yaml.md
@@ -1,5 +1,4 @@
 ```yaml title="docker-compose.yaml"
-version: "3"
 services:
   nginx:
     # to emulate nginx-ingress behavior, use openresty which comes with 'escaped_request_uri'

--- a/content/examples/tcp/docker-compose.yaml.md
+++ b/content/examples/tcp/docker-compose.yaml.md
@@ -1,5 +1,4 @@
 ```yaml title="docker-compose.md"
-version: "3"
 services:
   pomerium:
     image: cr.pomerium.com/pomerium/pomerium:latest

--- a/content/examples/tiddlywiki/docker-compose.yaml.md
+++ b/content/examples/tiddlywiki/docker-compose.yaml.md
@@ -1,6 +1,4 @@
 ```yaml title="docker-compose.yaml"
-version: "3"
-
 services:
   pomerium:
     image: cr.pomerium.com/pomerium/pomerium:latest

--- a/content/examples/tooljet/console-compose.yaml.md
+++ b/content/examples/tooljet/console-compose.yaml.md
@@ -1,5 +1,4 @@
 ```yaml title=docker-compose.yaml
-version: '3'
 networks:
   main: {}
 services:

--- a/content/examples/tooljet/docker-compose.yaml.md
+++ b/content/examples/tooljet/docker-compose.yaml.md
@@ -1,5 +1,4 @@
 ```yaml title=docker-compose.yaml
-version: "3"
 networks:
   main: {}
 services:


### PR DESCRIPTION
This PR removes outdated `version: X` elements from all of our Docker Compose examples (related to https://github.com/lablup/backend.ai/issues/2034 and some internal discussion).

@ssveta7ak  This should be all of them, but please let me know if there are other Docker instances I missed! 