### PR TITLE
Adds noindex to v0.18

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -18,6 +18,7 @@ const config = {
   organizationName: "pomerium",
   projectName: "documentation",
   trailingSlash: false,
+  noIndex: true,
 
   customFields: {
     xgridKey: process.env.XGRID_KEY,


### PR DESCRIPTION
Adds noIndex for v0.18 using the Docusaurus [noIndex](https://docusaurus.io/docs/next/api/docusaurus-config#noIndex) config option.

Related to https://github.com/pomerium/internal/issues/1798. 