### PR TITLE
Replaces loom iframes with  wistia inline iframes

### DIFF
--- a/content/docs/capabilities/custom-domains.mdx
+++ b/content/docs/capabilities/custom-domains.mdx
@@ -11,7 +11,7 @@ description: The Custom Domains page teaches you how to add your own domain in P
 <iframe
   width="100%"
   height="500"
-  src="https://www.youtube.com/embed/qj1D5Rgziz0?si=hXM8itfRJ_2lXztP"
+  src="https://fast.wistia.com/embed/iframe/twp82swgeo"
   title="YouTube video player"
   frameborder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"

--- a/content/docs/capabilities/ppl.mdx
+++ b/content/docs/capabilities/ppl.mdx
@@ -11,7 +11,7 @@ description: Learn how to use Pomerium Policy Language to build context-aware au
 <iframe
   width="100%"
   height="500"
-  src="https://www.loom.com/embed/d3206aa44aef4f65b9c5e94384a6bc53?sid=bd0aa63d-e45c-4704-91c8-5e793e433dd8"
+  src="https://fast.wistia.com/embed/iframe/ugtuwewztr"
   frameborder="0"
   webkitallowfullscreen="true"
   mozallowfullscreen="true"

--- a/content/docs/capabilities/routing.mdx
+++ b/content/docs/capabilities/routing.mdx
@@ -27,7 +27,7 @@ keywords:
 <iframe
   width="100%"
   height="500"
-  src="https://www.loom.com/embed/0c70371c2136417789d670e5358d30b6?sid=7227238d-e9c4-4d7b-b4e3-83c5fca0e1c9"
+  src="https://fast.wistia.com/embed/iframe/0xbvhbo2ki"
   frameborder="0"
   webkitallowfullscreen="true"
   mozallowfullscreen="true"


### PR DESCRIPTION
This PR adds the inline iframes from Wistia for the Routing, Policies, and Custom Domains videos. @nhayfield I had to manually add the `iframe` parameter to the URL. It seems to work, but I wanted to get your eyes on it to make sure in case I missed something. 