### PR TITLE
Replaces loom with wistia iframes

### DIFF
--- a/content/docs/capabilities/ppl.mdx
+++ b/content/docs/capabilities/ppl.mdx
@@ -11,7 +11,7 @@ description: Learn how to use Pomerium Policy Language to build context-aware au
 <iframe
   width="100%"
   height="500"
-  src="https://www.loom.com/embed/d3206aa44aef4f65b9c5e94384a6bc53?sid=bd0aa63d-e45c-4704-91c8-5e793e433dd8"
+  src="https://fast.wistia.com/embed/iframe/ugtuwewztr"
   frameborder="0"
   webkitallowfullscreen="true"
   mozallowfullscreen="true"

--- a/content/docs/capabilities/routing.mdx
+++ b/content/docs/capabilities/routing.mdx
@@ -27,7 +27,7 @@ keywords:
 <iframe
   width="100%"
   height="500"
-  src="https://www.loom.com/embed/0c70371c2136417789d670e5358d30b6?sid=7227238d-e9c4-4d7b-b4e3-83c5fca0e1c9"
+  src="https://fast.wistia.com/embed/iframe/0xbvhbo2ki"
   frameborder="0"
   webkitallowfullscreen="true"
   mozallowfullscreen="true"


### PR DESCRIPTION
I think the backport for the original PR failed at https://github.com/pomerium/documentation/pull/1443#issuecomment-2155036133 because the Custom Domains page is not in the `0-26-0` branch.  However, the other Loom videos are. 

This PR replaces the Policies and Routing iframes to use Wistia. 