### PR TITLE
Correct core/quickstart reference

### DIFF
--- a/content/docs/capabilities/self-hosted-authenticate-service.md
+++ b/content/docs/capabilities/self-hosted-authenticate-service.md
@@ -80,4 +80,4 @@ routes:
     pass_identity_headers: true
 ```
 
-See the [Pomerium Core Docker quickstart](/docs/quickstart) for more examples.
+See the [Pomerium Core Docker quickstart](/docs/core/quickstart) for more examples.


### PR DESCRIPTION
Saw this one points to the new Zero quickstart instead of the Core quickstart, but it specifically names core, so it should point there.

My first PR, please give any and all directions and advice!