### PR TITLE
Documents envoy resource manager runtime flag

### DIFF
--- a/content/docs/reference/runtime-flags.md
+++ b/content/docs/reference/runtime-flags.md
@@ -34,7 +34,7 @@ The available flags are:
 
 | Runtime Flag | Description | Default |
 | :-- | :-- | :-- |
-| `grpc_databroker_keepalive` | _(experimental)_ Enable gRPC keepalive (HTTP/2 PING) requests on the databroker service connection. This may improve service reliability in [split service mode](/docs/capabilities/high-availability#service-mode) deployments where there are multiple firewalls in the connection path between different Pomerium services. | `false` |
+| `grpc_databroker_keepalive` | _(experimental)_ Enables gRPC keep-alive (HTTP/2 PING) requests on the databroker service connection. This may improve service reliability in [split service mode](/docs/capabilities/high-availability#service-mode) deployments where there are multiple firewalls in the connection path between different Pomerium services. | `false` |
 | `match_any_incoming_port` | For a route where the From URL does not contain a port number, allow it to match incoming requests with any port number. See the section on [Port matching behavior](/docs/reference/routes/from#port-matching-behavior) for more details. | `true` |
 | `legacy_identity_manager` | The way Pomerium manages IdP session refresh has been newly rewritten in v0.26 for enhanced performance and reliability. When this flag is enabled, Pomerium will revert to the older implementation. | `false` |
 | `envoy_resource_manager_enabled` | Monitors control group (cgroup) memory usage of containerized processes (including Pomerium, Envoy, and client connections and requests) and applies overload actions when memory thresholds are exceeded to reduce memory consumption. See [memory thresholds](#envoy-resource-manager-memory-thresholds) to review thresholds and their corresponding overload actions. | `true` |

--- a/content/docs/reference/runtime-flags.md
+++ b/content/docs/reference/runtime-flags.md
@@ -37,7 +37,7 @@ The available flags are:
 | `grpc_databroker_keepalive` | _(experimental)_ Enable gRPC keepalive (HTTP/2 PING) requests on the databroker service connection. This may improve service reliability in [split service mode](/docs/capabilities/high-availability#service-mode) deployments where there are multiple firewalls in the connection path between different Pomerium services. | `false` |
 | `match_any_incoming_port` | For a route where the From URL does not contain a port number, allow it to match incoming requests with any port number. See the section on [Port matching behavior](/docs/reference/routes/from#port-matching-behavior) for more details. | `true` |
 | `legacy_identity_manager` | The way Pomerium manages IdP session refresh has been newly rewritten in v0.26 for enhanced performance and reliability. When this flag is enabled, Pomerium will revert to the older implementation. | `false` |
-| `envoy_resource_manager_enabled` | Description | `true` | 
+| `envoy_resource_manager_enabled` | Monitors control group (cgroup) memory usage of containerized processes (including Pomerium, Envoy, and client connections and requests) and applies overload actions when memory thresholds are exceeded to reduce memory consumption. See [memory thresholds](#envoy-resource-manager-memory-thresholds) to review thresholds and their corresponding overload actions. | `true` |
 
 ### Examples
 
@@ -49,3 +49,22 @@ runtime_flags:
 ```bash
 RUNTIME_FLAGS='{"match_any_incoming_port": false}'
 ```
+
+### Envoy resource manager memory thresholds
+
+If you set this runtime flag to `false`, Pomerium will regard the memory saturation value as `0`, which disables all overload actions. 
+
+| **Memory percentage threshold** | **Overload action** | **Description** |
+| :--- | :--- | :--- |
+| **90%** | `shrink_heap` | Envoy will shrink its heap memory every 10 seconds. |
+| **90%** | `reset_high_memory_stream` | Envoy will start resetting streams using the most memory. As memory usage increases, the eligibility threshold is reduced. |
+| **>85%** | `reduce_timeouts` | Envoy will gradually reduce timeouts by up to 50%. |
+| **95%** | `stop_accepting_connections` | Envoy will stop accepting new connections, but keep existing ones open. |
+| **98%** | `disable_http_keepalive` | Envoy will disable HTTP keep-alive, which prevents starting new HTTP/2 streams and cancels existing ones. |
+| **99%** | `stop_accepting_requests` | Envoy will stop accepting all new requests. |
+
+:::note Pod resource limits behavior
+
+If you [specify memory limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for containers in a Pod, the `envoy_resource_manager_enabled` runtime flag will be **enabled** by default.
+
+:::

--- a/content/docs/reference/runtime-flags.md
+++ b/content/docs/reference/runtime-flags.md
@@ -65,6 +65,6 @@ If you set this runtime flag to `false`, Pomerium will regard the memory saturat
 
 :::note Pod resource limits behavior
 
-If you [specify memory limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for containers in a Pod, the `envoy_resource_manager_enabled` runtime flag will be **enabled** by default.
+The `envoy_resource_manager_enabled` runtime flag is set to **true** by default, but only takes effect if you [specify memory limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the Pomerium pod.
 
 :::

--- a/content/docs/reference/runtime-flags.md
+++ b/content/docs/reference/runtime-flags.md
@@ -37,6 +37,7 @@ The available flags are:
 | `grpc_databroker_keepalive` | _(experimental)_ Enable gRPC keepalive (HTTP/2 PING) requests on the databroker service connection. This may improve service reliability in [split service mode](/docs/capabilities/high-availability#service-mode) deployments where there are multiple firewalls in the connection path between different Pomerium services. | `false` |
 | `match_any_incoming_port` | For a route where the From URL does not contain a port number, allow it to match incoming requests with any port number. See the section on [Port matching behavior](/docs/reference/routes/from#port-matching-behavior) for more details. | `true` |
 | `legacy_identity_manager` | The way Pomerium manages IdP session refresh has been newly rewritten in v0.26 for enhanced performance and reliability. When this flag is enabled, Pomerium will revert to the older implementation. | `false` |
+| `envoy_resource_manager_enabled` | Description | `true` | 
 
 ### Examples
 

--- a/content/docs/reference/runtime-flags.md
+++ b/content/docs/reference/runtime-flags.md
@@ -37,7 +37,7 @@ The available flags are:
 | `grpc_databroker_keepalive` | _(experimental)_ Enables gRPC keep-alive (HTTP/2 PING) requests on the databroker service connection. This may improve service reliability in [split service mode](/docs/capabilities/high-availability#service-mode) deployments where there are multiple firewalls in the connection path between different Pomerium services. | `false` |
 | `match_any_incoming_port` | For a route where the From URL does not contain a port number, allow it to match incoming requests with any port number. See the section on [Port matching behavior](/docs/reference/routes/from#port-matching-behavior) for more details. | `true` |
 | `legacy_identity_manager` | The way Pomerium manages IdP session refresh has been newly rewritten in v0.26 for enhanced performance and reliability. When this flag is enabled, Pomerium will revert to the older implementation. | `false` |
-| `envoy_resource_manager_enabled` | Monitors control group (cgroup) memory usage of containerized processes (including Pomerium, Envoy, and client connections and requests) and applies overload actions when memory thresholds are exceeded to reduce memory consumption. See [memory thresholds](#envoy-resource-manager-memory-thresholds) to review thresholds and their corresponding overload actions. | `true` |
+| `envoy_resource_manager_enabled` | Monitors control group (cgroup) memory usage of all processes running in the container (including both Pomerium and Envoy) and applies overload actions when memory thresholds are exceeded to reduce memory consumption. See [memory thresholds](#envoy-resource-manager-memory-thresholds) to review thresholds and their corresponding overload actions. | `true` |
 
 ### Examples
 

--- a/content/docs/reference/runtime-flags.md
+++ b/content/docs/reference/runtime-flags.md
@@ -52,10 +52,10 @@ RUNTIME_FLAGS='{"match_any_incoming_port": false}'
 
 ### Envoy resource manager memory thresholds
 
-If you set this runtime flag to `false`, Pomerium will regard the memory saturation value as `0`, which disables all overload actions. 
+If you set this runtime flag to `false`, Pomerium will regard the memory saturation value as `0`, which disables all overload actions.
 
 | **Memory percentage threshold** | **Overload action** | **Description** |
-| :--- | :--- | :--- |
+| :-- | :-- | :-- |
 | **90%** | `shrink_heap` | Envoy will shrink its heap memory every 10 seconds. |
 | **90%** | `reset_high_memory_stream` | Envoy will start resetting streams using the most memory. As memory usage increases, the eligibility threshold is reduced. |
 | **>85%** | `reduce_timeouts` | Envoy will gradually reduce timeouts by up to 50%. |


### PR DESCRIPTION
This PR documents the new Envoy resource manager runtime flag behavior. It also updates the text in other parts of the page for consistency.

@kralicky if you could review for technical accuracy, that would be appreciated. If you find the text isn't clear, or if you have suggestions for improvement, please let me know as well. Thanks!

Resolves https://github.com/pomerium/documentation/issues/1432