### PR TITLE
Changes highlighted code line color

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -14,7 +14,7 @@
   --ifm-color-primary-lighter: #8c69ec;
   --ifm-color-primary-lightest: #9a7bee;
   --ifm-code-font-size: 95%;
-  --docusaurus-highlighted-code-line-bg: #cdbcfc;
+  --docusaurus-highlighted-code-line-bg: #a387ef3d;
 }
 
 /* adjust headers because they are huge */


### PR DESCRIPTION
This PR updates the `--docusaurus-highlighted-code-line-bg` background color so that the contrast is more agreeable in dark and light mode. 

In light mode, the contrast ratio is 8.64. In dark mode, it's 9.1. I got these numbers by inspecting the text in Chrome dev tools.

@kralicky and/or @kenjenkins I'd appreciate your thoughts on this. 

Resolves https://github.com/pomerium/internal/issues/1839