### PR TITLE
Updates clients redirects

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -183,11 +183,11 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/releases/* /docs/deploy/:splat
 /docs/deploying/* /docs/deploy/:splat
 
-# v22 sidebar client redirects
+# client redirects
 /docs/deploy/pomerium-cli /docs/deploy/clients/pomerium-cli
 /docs/deploy/pomerium-desktop /docs/deploy/clients/pomerium-desktop
-/docs/deploy/clients/pomerium-cli /docs/clients/pomerium-cli
-/docs/deploy/clients/pomerium-desktop /docs/clients/pomerium-desktop
+/docs/deploy/clients /docs/clients
+/docs/deploy/clients/* /docs/clients/:splat
 
 # Zero sidebar restructure
 /docs/deploy/enterprise /docs/enterprise


### PR DESCRIPTION
This PR adds redirects for pages in the `/docs/clients` directory. 

Related to https://github.com/pomerium/documentation/issues/1469