### PR TITLE
reference: add custom-domains link path

### DIFF
--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -1586,6 +1586,7 @@
   "custom-domains": {
     "id": "custom-domains",
     "title": "Custom Domains",
-    "description": "A custom wildcard subdomain used to define routes in this cluster. Can only be associated with 1 cluster."
+    "description": "A custom wildcard subdomain used to define routes in this cluster. Can only be associated with 1 cluster.",
+    "path": "/../capabilities/custom-domains"
   }
 }


### PR DESCRIPTION
Add 'path' property to the custom-domains entry in reference.json, now that we have a published Capabilities page for custom domains in Zero.