### PR TITLE
Adds upgrading steps to install page 

### DIFF
--- a/content/docs/zero/install.mdx
+++ b/content/docs/zero/install.mdx
@@ -104,7 +104,7 @@ Use the following values as necessary to install or update Pomerium in accordanc
 
 Pass the provided **Cluster Token** into the `POMERIUM_ZERO_TOKEN` environment variable.
 
-The **Domain Name** refers to the cluster [starter domain](/docs/concepts/clusters#starter-domain) that's assigned to your cluster during onboarding.
+**Domain Name** refers to your cluster's [starter domain](/docs/concepts/clusters#starter-domain).
 
 </TabItem>
 </Tabs>
@@ -170,6 +170,11 @@ To update Pomerium in Kubernetes, run the following command:
 ```bash
 $ kubectl apply -k github.com/pomerium/pomerium/k8s/zero\?ref=<X.Y.Z>
 ```
+
+</TabItem>
+<TabItem value="manual" label="Manual">
+
+For custom configurations, update the Pomerium image tag to the latest version.
 
 </TabItem>
 </Tabs>

--- a/content/docs/zero/install.mdx
+++ b/content/docs/zero/install.mdx
@@ -9,16 +9,16 @@ import TabItem from '@theme/TabItem';
 
 # Install Pomerium Zero
 
-This page provides steps to install Pomerium Zero for each supported deploy environment.
+Learn how to install Pomerium Zero.
 
 :::note
 
-If you don't have an account yet, you can [**create a Pomerium Zero account**](https://console.pomerium.app/create-account) for free.
+If you haven't signed up for Pomerium Zero, you can [**create an account**](https://console.pomerium.app/create-account) for free.
 
 :::
 
 <Tabs>
-<TabItem value="Linux" label="linux">
+<TabItem value="linux" label="Linux">
 
 Install Pomerium with the following shell script:
 
@@ -104,9 +104,72 @@ Use the following values as necessary to install or update Pomerium in accordanc
 
 Pass the provided **Cluster Token** into the `POMERIUM_ZERO_TOKEN` environment variable.
 
-The **Domain Name** refers to the cluster starter domain that's assigned to your cluster during onboarding.
+The **Domain Name** refers to the cluster [starter domain](/docs/concepts/clusters#starter-domain) that's assigned to your cluster during onboarding.
 
-For example, `sure-colt-611.pomerium.app`.
+</TabItem>
+</Tabs>
+
+## Upgrade Pomerium Zero
+
+Learn how to upgrade Pomerium Zero.
+
+<Tabs>
+<TabItem label="Docker" value="docker">
+
+To update Pomerium in Docker:
+
+1. In your `compose.yaml` file, update the Pomerium image tag to specify the [latest tagged release](https://github.com/pomerium/pomerium/tags):
+
+```yaml
+pomerium:
+  image: pomerium/pomerium:<vX.Y.Z>
+```
+
+1. Run the following command:
+
+```bash
+$ docker compose up -d
+```
+
+Docker should automatically pull the new image of Pomerium before running the container. If for some reason Docker doesn't pull the image, you can manually run:
+
+```bash
+$ docker pull pomerium/pomerium:<vX.Y.Z>
+```
+
+</TabItem>
+<TabItem label="Linux" value="linux">
+
+To update Pomerium in Debian-based Linux systems:
+
+1. Check for new package updates and install Pomerium:
+
+```bash
+$ sudo apt update && sudo apt install pomerium
+```
+
+To update Pomerium in Red Hat-based Linux systems:
+
+1. Check for new package updates
+
+```bash
+$ sudo yum list updates
+```
+
+1. Install the latest version of Pomerium:
+
+```bash
+$ sudo yum update pomerium
+```
+
+</TabItem>
+<TabItem value="kubernetes" label="Kubernetes">
+
+To update Pomerium in Kubernetes, run the following command:
+
+```bash
+$ kubectl apply -k github.com/pomerium/pomerium/k8s/zero\?ref=<X.Y.Z>
+```
 
 </TabItem>
 </Tabs>

--- a/static/_redirects
+++ b/static/_redirects
@@ -197,6 +197,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/deploy/k8s /docs/k8s/quickstart
 /docs/deploy/k8s/* /docs/k8s/:splat
 /docs/zero/cluster-status /docs/troubleshooting/cluster-status
+/docs/zero/upgrading /docs/zero/install
 
 #  Installation and deployment methods redirects
 /docs/enterprise/install/docker /docs/enterprise/install


### PR DESCRIPTION
This PR adds upgrading steps for Zero installations to the Zero Install at https://www.pomerium.com/docs/zero/install. 

It also adds a redirect for the removed Zero Upgrading page. 

@kralicky I requested a review from you here because I believe you pushed for the `manual` configuration steps in onboarding. Do you have suggestions for upgrade steps for manual installations? 

Resolves https://github.com/pomerium/internal/issues/1845

Related to https://github.com/pomerium/documentation/issues/1469