### PR TITLE
Adds CVE link to v0.26.1 entry in core changelog

### DIFF
--- a/content/docs/core/changelog.mdx
+++ b/content/docs/core/changelog.mdx
@@ -23,7 +23,7 @@ Please refer to the [upgrade guide](/docs/core/upgrading) before upgrading.
 
 Pomerium v0.26.1 includes multiple security updates:
 
-- The Pomerium user info page (at `/.pomerium`) unintentionally included serialized OAuth 2.0 access and ID tokens from the logged-in user's session. These tokens are not intended to be exposed to end users, and have now been removed.
+- The Pomerium user info page (at `/.pomerium`) unintentionally included serialized OAuth 2.0 access and ID tokens from the logged-in user's session. These tokens are not intended to be exposed to end users, and have now been removed. For more details, please see the official [CVE statement](https://github.com/pomerium/pomerium/security/advisories/GHSA-rrqr-7w59-637v).
 
   Credit to Vadim Sheydaev, also known as Enr1g for reporting this issue.
 


### PR DESCRIPTION
Adds a link to the official [CVE statement](https://github.com/pomerium/pomerium/security/advisories/GHSA-rrqr-7w59-637v) in the `v0.26.1` Core changelog entry. 