### PR TITLE
Fixes a few 404 links from GSC

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -153,19 +153,18 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /enterprise/service-accounts.html /docs/capabilities/service-accounts
 /enterprise/prometheus.html /docs/capabilities/metrics
 /enterprise/prometheus /docs/capabilities/metrics
-/docs/enterprise/reference/ /docs/releases/enterprise/configure
-/docs/enterprise/reference/configure /docs/releases/enterprise/configure
-/docs/enterprise/reference/configure.html /docs/releases/enterprise/configure
-/docs/enterprise/reference/config /docs/releases/enterprise/configure
-/docs/enterprise/reference/config.html /docs/releases/enterprise/configure
-/enterprise/reference/configure.html /docs/releases/enterprise/configure
-/enterprise/reference/config.html /docs/releases/enterprise/configure
+/docs/enterprise/reference/ /docs/enterprise/configure
+/docs/enterprise/reference/configure /docs/enterprise/configure
+/docs/enterprise/reference/configure.html /docs/enterprise/configure
+/docs/enterprise/reference/config /docs/enterprise/configure
+/docs/enterprise/reference/config.html /docs/enterprise/configure
+/enterprise/reference/configure.html /docs/enterprise/configure
+/enterprise/reference/config.html /docs/enterprise/configure
 /enterprise/concepts.html /docs/concepts/access-control
 # /docs/enterprise/about uses multiple redirects
 /docs/enterprise/about /docs/releases/enterprise
 /docs/releases/enterprise /docs/releases/enterprise/about
 /docs/releases/enterprise/about /docs/enterprise
-/docs/enterprise/about.html /docs/releases/enterprise/about
 /enterprise/reference/reports.html /docs/capabilities/reports
 
 /enterprise/install/helm.html /docs/releases/enterprise/install/helm
@@ -248,7 +247,6 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/enterprise/reference/reports /docs/capabilities/reports
 /docs/enterprise/external-data /docs/integrations/
 /docs/integrations /docs/capabilities/integrations
-/docs/integrations /docs/capabilities/integrations
 /docs/enterprise/branding /docs/capabilities/branding
 /docs/enterprise/branding/logo /docs/capabilities/branding
 /docs/enterprise/branding/colors /docs/capabilities/branding
@@ -266,7 +264,6 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 # /docs/topics/tcp-support.html uses multiple redirects
 /docs/topics/tcp-support.html /docs/tcp/
 /docs/tcp /docs/capabilities/tcp
-# multiple redirects
 /docs/topics/tcp-support /docs/tcp/
 /docs/tcp /docs/capabilities/tcp
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -247,6 +247,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/enterprise/reference/reports /docs/capabilities/reports
 /docs/enterprise/external-data /docs/integrations/
 /docs/integrations /docs/capabilities/integrations
+/docs/integrations /docs/capabilities/integrations
 /docs/enterprise/branding /docs/capabilities/branding
 /docs/enterprise/branding/logo /docs/capabilities/branding
 /docs/enterprise/branding/colors /docs/capabilities/branding

--- a/static/_redirects
+++ b/static/_redirects
@@ -245,6 +245,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/enterprise/reference/manage.html /docs/capabilities/authentication
 /docs/enterprise/reference/reports /docs/capabilities/reports
 /docs/enterprise/external-data /docs/integrations/
+/docs/integrations /docs/capabilities/integrations
 /docs/enterprise/branding /docs/capabilities/branding
 /docs/enterprise/branding/logo /docs/capabilities/branding
 /docs/enterprise/branding/colors /docs/capabilities/branding
@@ -254,7 +255,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 # redirects all /docs/enterprise/identity-providers to /docs/identity-providers
 /docs/enterprise/identity-providers/* /docs/identity-providers/:splat
 
-#redirects /docs/enterprise/external-data/* to /docs/integrations/
+#redirects External Data examples
 /docs/enterprise/external-data/* /docs/integrations/:splat
 
 # TCP links

--- a/static/_redirects
+++ b/static/_redirects
@@ -164,6 +164,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 # /docs/enterprise/about uses multiple redirects
 /docs/enterprise/about /docs/releases/enterprise
 /docs/releases/enterprise /docs/releases/enterprise/about
+/docs/releases/enterprise/about /docs/enterprise
 /docs/enterprise/about.html /docs/releases/enterprise/about
 /enterprise/reference/reports.html /docs/capabilities/reports
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -180,6 +180,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/releases/enterprise /docs/enterprise
 /docs/enterprise/install/installation /docs/enterprise/install
 /docs/releases/enterprise/install/quickstart /docs/enterprise/quickstart
+/docs/deploy /docs
 /docs/releases/* /docs/deploy/:splat
 /docs/deploying/* /docs/deploy/:splat
 


### PR DESCRIPTION
This PR fixes the following 404ing links pulled from GSC:

- [ ] #1498 
- [ ] #1499 
- [ ] #1500 
- [ ] #1501 
- [ ] #1502 

Related to https://github.com/pomerium/internal/issues/1841