### PR TITLE
restore JSON syntax highlighting

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -222,6 +222,7 @@ const config = {
         'actionscript',
         'log',
         'ini',
+        'json',
         'nginx',
         'rego',
         'shell-session',


### PR DESCRIPTION
At some point between the v0.24 site and the v0.25 site we lost syntax highlighting on JSON code blocks (compare https://0-24-0.docs.pomerium.com/docs/reference/access-log-fields#access-log-behavior and https://0-25-0.docs.pomerium.com/docs/reference/access-log-fields#access-log-behavior). Update the docusaurus config file to restore JSON syntax highlighting.