### PR TITLE
Adds 410 redirect to Production Deployment page

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -181,6 +181,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/enterprise/install/installation /docs/enterprise/install
 /docs/releases/enterprise/install/quickstart /docs/enterprise/quickstart
 /docs/deploy /docs
+/docs/deploy/production-deployment /docs 410
 /docs/releases/* /docs/deploy/:splat
 /docs/deploying/* /docs/deploy/:splat
 


### PR DESCRIPTION
Based on Netlify's [redirect docs](https://docs.netlify.com/routing/redirects/redirect-options/#http-status-codes), I think we have to specify a page to redirect to, so I pointed this page to our docs homepage. I also added a `410` status code. 

Resolves https://github.com/pomerium/documentation/issues/1469