### PR TITLE
footer: replace Slack link with Discuss forum

### DIFF
--- a/src/theme/Footer/Links/MultiColumn/index.js
+++ b/src/theme/Footer/Links/MultiColumn/index.js
@@ -77,8 +77,8 @@ export default function FooterLinksMultiColumn({columns}) {
           <li style={{display: 'inline-block'}}>
             <IconButton
               color="primary"
-              onClick={() => window.open('https://slack.pomerium.io/')}>
-              <span className="fa-brands fa-slack" />
+              onClick={() => window.open('https://discuss.pomerium.com/')}>
+              <span className="fa-brands fa-discourse" />
             </IconButton>
           </li>
         </ul>


### PR DESCRIPTION
Replace the footer link to the public Slack with a link to https://discuss.pomerium.com instead.