### PR TITLE
update redirects to address some 404s from GSC

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -88,7 +88,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /guides/vs-code-server.html /docs/guides/code-server
 /guides/local-oidc.html /docs/guides/local-oidc
 /docs/guides/local-oidc /docs/identity-providers/oidc
-/docs/identity-providers/dex-freeipa /docs/identity-providers
+/docs/identity-providers/dex-freeipa /docs 410
 
 # Reference, capabilities, topics, concepts links
 /docs/reference/readme.html /docs/
@@ -112,13 +112,13 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/topics/getting-users-identity /docs/concepts/getting-users-identity
 /docs/concepts/getting-users-identity /docs/capabilities/getting-users-identity
 /docs/topics/getting-users-identity.html /docs/capabilities/getting-users-identity
-/docs/reference/production-deployment.html /docs
-/docs/topics/production-deployment /docs
-/docs/topics/production-deployment.html /docs
-/docs/production-deployment /docs
-/docs/production-deployment.html /docs
-/docs/production/security /docs
-/docs/production/production-deployment /docs
+/docs/reference/production-deployment.html /docs 410
+/docs/topics/production-deployment /docs 410
+/docs/topics/production-deployment.html /docs 410
+/docs/production-deployment /docs 410
+/docs/production-deployment.html /docs 410
+/docs/production/security /docs 410
+/docs/production/production-deployment /docs 410
 
 # This links requires multiple redirects
 /docs/reference/programmatic-access.html /docs/topics/programmatic-access
@@ -177,8 +177,8 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/enterprise/install/installation /docs/enterprise/install
 /docs/releases/enterprise/install/quickstart /docs/enterprise/quickstart
 /docs/deploy /docs
-/docs/deploy/production-deployment /docs
-/docs/deploying/production-deployment /docs
+/docs/deploy/production-deployment /docs 410
+/docs/deploying/production-deployment /docs 410
 /docs/releases/* /docs/deploy/:splat
 /docs/deploying/* /docs/deploy/:splat
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -479,8 +479,6 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/topics/device-identity /docs/concepts/device-identity
 /docs/topics/mutual-auth /docs/concepts/mutual-auth
 
-
-
 /docs/topics/original-request-context /docs/concepts/original-request-context
 /docs/concepts/original-request-context /docs/capabilities/original-request-context
 /docs/topics/ppl /docs/concepts/ppl

--- a/static/_redirects
+++ b/static/_redirects
@@ -77,8 +77,6 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/guides/upstream-mtls /docs/capabilities/mtls-services
 /docs/guides/upstream-mtls.html /docs/capabilities/mtls-services
 /guides/tcp /docs/capabilities/tcp
-
-# More docs guides redirects
 /recipes/* /docs/guides/:splat
 /category/guides /docs/guides
 
@@ -90,6 +88,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /guides/vs-code-server.html /docs/guides/code-server
 /guides/local-oidc.html /docs/guides/local-oidc
 /docs/guides/local-oidc /docs/identity-providers/oidc
+/docs/identity-providers/dex-freeipa /docs/identity-providers
 
 # Reference, capabilities, topics, concepts links
 /docs/reference/readme.html /docs/
@@ -112,17 +111,14 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/reference/getting-users-identity.html /docs/topics/getting-users-identity
 /docs/topics/getting-users-identity /docs/concepts/getting-users-identity
 /docs/concepts/getting-users-identity /docs/capabilities/getting-users-identity
-
 /docs/topics/getting-users-identity.html /docs/capabilities/getting-users-identity
-# This link requires multiple redirects
-/docs/reference/production-deployment.html /docs/topics/production-deployment
-/docs/topics/production-deployment /docs/deploying/production-deployment
-
-/docs/topics/production-deployment.html /docs/deploying/production-deployment
-/docs/production-deployment /docs/deploying/production-deployment
-/docs/production-deployment.html /docs/deploying/production-deployment
-/docs/production/security /docs/deploying/production-deployment
-/docs/production/production-deployment /docs/deploying/production-deployment
+/docs/reference/production-deployment.html /docs
+/docs/topics/production-deployment /docs
+/docs/topics/production-deployment.html /docs
+/docs/production-deployment /docs
+/docs/production-deployment.html /docs
+/docs/production/security /docs
+/docs/production/production-deployment /docs
 
 # This links requires multiple redirects
 /docs/reference/programmatic-access.html /docs/topics/programmatic-access
@@ -181,7 +177,8 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/enterprise/install/installation /docs/enterprise/install
 /docs/releases/enterprise/install/quickstart /docs/enterprise/quickstart
 /docs/deploy /docs
-/docs/deploy/production-deployment /docs 410
+/docs/deploy/production-deployment /docs
+/docs/deploying/production-deployment /docs
 /docs/releases/* /docs/deploy/:splat
 /docs/deploying/* /docs/deploy/:splat
 
@@ -252,7 +249,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/enterprise/branding /docs/capabilities/branding
 /docs/enterprise/branding/logo /docs/capabilities/branding#logo
 /docs/enterprise/branding/colors /docs/capabilities/branding#colors
-/docs/enterprise/branding/error_details /docs/capabilities/branding#error-details 
+/docs/enterprise/branding/error_details /docs/capabilities/branding#error-details
 /docs/enterprise/api.html /docs/capabilities/enterprise-api
 /docs/enterprise/api /docs/capabilities/enterprise-api
 
@@ -263,8 +260,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/enterprise/external-data/* /docs/integrations/:splat
 
 # TCP links
-
-# /docs/topics/tcp-support.html uses multiple redirects
+/topics/tcp-support.html /docs/tcp
 /docs/topics/tcp-support.html /docs/tcp/
 /docs/tcp /docs/capabilities/tcp
 /docs/topics/tcp-support /docs/tcp/
@@ -452,9 +448,8 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/reference/routes/load-balancing-policy /docs/reference/routes/load-balancing#load-balancing-policy
 /docs/reference/routes/health-checks /docs/reference/routes/load-balancing#health-checks
 
-/docs/internals/docs/reference/default-upstream-timeout /docs/reference/default-upstream-timeout
+/docs/reference/default-upstream-timeout /docs/reference/default-upstream-timeout
 /docs/reference/identity-provider-service-account /docs/releases/upgrading
-/reference/ /docs/reference/
 /docs/reference/routes/signout-redirect-url /docs/reference/signout-redirect-url
 /reference/* /docs/reference/:splat
 
@@ -472,33 +467,26 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/topics/single-sign-out /docs/capabilities/single-sign-out
 
 #redirects topics
-# /docs/topics/orc.html uses multiple redirects - still 404s
 /docs/topics/original-request-context.html /docs/concepts/original-request-context
 /docs/concepts/original-request-context /docs/capabilities/original-request-context
-
 /docs/topics/load-balancing.html /docs/capabilities/routing
 /docs/topics/certificates /docs/concepts/certificates
 /docs/certificates.html /docs/concepts/certificates
-
-# multiple redirects - still 404s
 /docs/topics/impersonation.html /docs/concepts/impersonation
 /docs/concepts/impersonation /docs/capabilities/service-accounts
-
 /docs/topics/ /docs/concepts/access-control
 /docs/topics/* /docs/concepts/:splat 301!
 /docs/topics/device-identity /docs/concepts/device-identity
 /docs/topics/mutual-auth /docs/concepts/mutual-auth
 
-# multiple redirects
+
+
 /docs/topics/original-request-context /docs/concepts/original-request-context
 /docs/concepts/original-request-context /docs/capabilities/original-request-context
-# multiple redirects
 /docs/topics/ppl /docs/concepts/ppl
 /docs/concepts/ppl /docs/capabilities/ppl
-# multiple redirects
 /docs/topics/ppl.html /docs/concepts/ppl.html
 /docs/concepts/ppl.html /docs/capabilities/ppl.html
-# multiple redirects
 /docs/topics/load-balancing /docs/concepts/load-balancing
 /docs/concepts/load-balancing /docs/capabilities/routing
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -46,16 +46,16 @@
 /guides/traefik-ingress.html https://0-20-0.docs.pomerium.com/docs/guides/traefik-ingress 301!
 /docs/reference/forward-auth https://0-20-0.docs.pomerium.com/docs/reference/forward-auth 301!
 https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.com/docs/guides
-/docs/reference/policy/allowed-domains https://0-14-0.docs.pomerium.com/reference
-/docs/reference/policy/allowed-idp-claims https://0-14-0.docs.pomerium.com/reference
-/docs/reference/policy/allowed-users https://0-14-0.docs.pomerium.com/reference
+/docs/reference/policy/allowed-domains https://0-14-0.docs.pomerium.com/reference/#allowed-domains
+/docs/reference/policy/allowed-idp-claims https://0-14-0.docs.pomerium.com/reference/#allowed-idp-claims
+/docs/reference/policy/allowed-groups https://0-14-0.docs.pomerium.com/reference/#allowed-groups
+/docs/reference/policy/allowed-users https://0-14-0.docs.pomerium.com/reference/#allowed-users
 /docs/reference/policy/policy-explanation https://0-14-0.docs.pomerium.com/reference
 /docs/reference/policy/policy-remediation https://0-14-0.docs.pomerium.com/reference
-/docs/reference/policy/policy https://0-14-0.docs.pomerium.com/reference
+/docs/reference/policy/policy https://0-14-0.docs.pomerium.com/reference/#policy
 
-# Link from v23 to v22
-/docs/reference/routes/headers#set-authorization-header https://0-22-0.docs.pomerium.com/reference/routes/headers#set-authorization-header
-
+# Removed in v25
+/docs/reference/debug https://0-24-0.docs.pomerium.com/docs/reference/debug
 
 # 301 Helm and Kubernetes redirects
 /docs/guides/helm https://0-19-0.docs.pomerium.com/docs/guides/helm 301!
@@ -250,8 +250,9 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/enterprise/external-data /docs/integrations/
 /docs/integrations /docs/capabilities/integrations
 /docs/enterprise/branding /docs/capabilities/branding
-/docs/enterprise/branding/logo /docs/capabilities/branding
-/docs/enterprise/branding/colors /docs/capabilities/branding
+/docs/enterprise/branding/logo /docs/capabilities/branding#logo
+/docs/enterprise/branding/colors /docs/capabilities/branding#colors
+/docs/enterprise/branding/error_details /docs/capabilities/branding#error-details 
 /docs/enterprise/api.html /docs/capabilities/enterprise-api
 /docs/enterprise/api /docs/capabilities/enterprise-api
 
@@ -367,9 +368,11 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/reference/expiration /docs/reference/cookies#expiration
 /docs/reference/cookie-http-only /docs/reference/cookies#cookie-http-only
 /docs/reference/cookie-name /docs/reference/cookies#cookie-name
+/docs/reference/cookie-same-site /docs/reference/cookies#cookie-samesite
 /docs/reference/cookie-secret-file /docs/reference/cookies#cookie-secret-file
 /docs/reference/cookie-secret /docs/reference/cookies#cookie-secret
 /docs/reference/cookie-secure /docs/reference/cookies#cookie-secure
+/docs/reference/https-only /docs/reference/cookies#cookie-secure
 /docs/reference/javascript-security /docs/reference/cookies#javascript-security
 /docs/reference/cookie-expire /docs/reference/cookies#cookie-expire
 
@@ -456,6 +459,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /reference/* /docs/reference/:splat
 
 # Pass Identity Headers
+/docs/reference/global-pass-identity-headers /docs/reference/pass-identity-headers
 /docs/reference/routes/pass-identity-headers /docs/reference/routes/pass-identity-headers-per-route
 
 # X-Forwarded-For Settings


### PR DESCRIPTION
We found a few reference setting 404s from the Google Search Console report. I don't think we have any logs from Netlify (which might be able to help us infer whether any real users are hitting these), but I thought it would make sense to add redirects for these.

Related issue:
- https://github.com/pomerium/internal/issues/1841