### PR TITLE
Adds custom headers to set noindex rule for older versions

### DIFF
--- a/custom-headers/_0-1-0
+++ b/custom-headers/_0-1-0
@@ -1,0 +1,4 @@
+# See ./netlify.toml for more information about _headers files
+
+/*
+  X-Robots-Tag: noindex

--- a/custom-headers/_0-10-0
+++ b/custom-headers/_0-10-0
@@ -1,0 +1,4 @@
+# See ./netlify.toml for more information about _headers files
+
+/*
+  X-Robots-Tag: noindex

--- a/custom-headers/_0-11-0
+++ b/custom-headers/_0-11-0
@@ -1,0 +1,4 @@
+# See ./netlify.toml for more information about _headers files
+
+/*
+  X-Robots-Tag: noindex

--- a/custom-headers/_0-12-0
+++ b/custom-headers/_0-12-0
@@ -1,0 +1,4 @@
+# See ./netlify.toml for more information about _headers files
+
+/*
+  X-Robots-Tag: noindex

--- a/custom-headers/_0-13-0
+++ b/custom-headers/_0-13-0
@@ -1,0 +1,4 @@
+# See ./netlify.toml for more information about _headers files
+
+/*
+  X-Robots-Tag: noindex

--- a/custom-headers/_0-14-0
+++ b/custom-headers/_0-14-0
@@ -1,0 +1,4 @@
+# See ./netlify.toml for more information about _headers files
+
+/*
+  X-Robots-Tag: noindex

--- a/custom-headers/_0-15-0
+++ b/custom-headers/_0-15-0
@@ -1,0 +1,4 @@
+# See ./netlify.toml for more information about _headers files
+
+/*
+  X-Robots-Tag: noindex

--- a/custom-headers/_0-16-0
+++ b/custom-headers/_0-16-0
@@ -1,0 +1,4 @@
+# See ./netlify.toml for more information about _headers files
+
+/*
+  X-Robots-Tag: noindex

--- a/custom-headers/_0-17-0
+++ b/custom-headers/_0-17-0
@@ -1,0 +1,4 @@
+# See ./netlify.toml for more information about _headers files
+
+/*
+  X-Robots-Tag: noindex

--- a/custom-headers/_0-2-0
+++ b/custom-headers/_0-2-0
@@ -1,0 +1,4 @@
+# See ./netlify.toml for more information about _headers files
+
+/*
+  X-Robots-Tag: noindex

--- a/custom-headers/_0-3-0
+++ b/custom-headers/_0-3-0
@@ -1,0 +1,4 @@
+# See ./netlify.toml for more information about _headers files
+
+/*
+  X-Robots-Tag: noindex

--- a/custom-headers/_0-4-0
+++ b/custom-headers/_0-4-0
@@ -1,0 +1,4 @@
+# See ./netlify.toml for more information about _headers files
+
+/*
+  X-Robots-Tag: noindex

--- a/custom-headers/_0-5-0
+++ b/custom-headers/_0-5-0
@@ -1,0 +1,4 @@
+# See ./netlify.toml for more information about _headers files
+
+/*
+  X-Robots-Tag: noindex

--- a/custom-headers/_0-6-0
+++ b/custom-headers/_0-6-0
@@ -1,0 +1,4 @@
+# See ./netlify.toml for more information about _headers files
+
+/*
+  X-Robots-Tag: noindex

--- a/custom-headers/_0-7-0
+++ b/custom-headers/_0-7-0
@@ -1,0 +1,4 @@
+# See ./netlify.toml for more information about _headers files
+
+/*
+  X-Robots-Tag: noindex

--- a/custom-headers/_0-8-0
+++ b/custom-headers/_0-8-0
@@ -1,0 +1,4 @@
+# See ./netlify.toml for more information about _headers files
+
+/*
+  X-Robots-Tag: noindex

--- a/custom-headers/_0-9-0
+++ b/custom-headers/_0-9-0
@@ -1,0 +1,4 @@
+# See ./netlify.toml for more information about _headers files
+
+/*
+  X-Robots-Tag: noindex

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,56 @@
+# This config file sets the `noindex` rule for each branch (e.g. [0-17-0]) listed below
+# For Netlify instructions, see: https://docs.netlify.com/routing/headers/#custom-headers-for-different-branch-or-deploy-contexts
+# For more details about the netlify.toml file, see https://docs.netlify.com/configure-builds/file-based-configuration/
+# For _headers file syntax: https://docs.netlify.com/routing/headers/#syntax-for-the-headers-file
+
+[0-17-0]
+command = "yarn build && cp ./custom-headers/_0-17-0 ./build/_headers"
+
+[0-16-0]
+command = "yarn build && cp ./custom-headers/_0-16-0 ./build/_headers"
+
+[0-15-0]
+command = "yarn build && cp ./custom-headers/_0-15-0 ./build/_headers"
+
+[0-14-0]
+command = "yarn build && cp ./custom-headers/_0-14-0 ./build/_headers"
+
+[0-13-0]
+command = "yarn build && cp ./custom-headers/_0-13-0 ./build/_headers"
+
+[0-12-0]
+command = "yarn build && cp ./custom-headers/_0-12-0 ./build/_headers"
+
+[0-11-0]
+command = "yarn build && cp ./custom-headers/_0-11-0 ./build/_headers"
+
+[0-10-0]
+command = "yarn build && cp ./custom-headers/_0-10-0 ./build/_headers"
+
+[0-9-0]
+command = "yarn build && cp ./custom-headers/_0-9-0 ./build/_headers"
+
+[0-8-0]
+command = "yarn build && cp ./custom-headers/_0-8-0 ./build/_headers"
+
+[0-7-0]
+command = "yarn build && cp ./custom-headers/_0-7-0 ./build/_headers"
+
+[0-6-0]
+command = "yarn build && cp ./custom-headers/_0-6-0 ./build/_headers"
+
+[0-5-0]
+command = "yarn build && cp ./custom-headers/_0-5-0 ./build/_headers"
+
+[0-4-0]
+command = "yarn build && cp ./custom-headers/_0-4-0 ./build/_headers"
+
+[0-3-0]
+command = "yarn build && cp ./custom-headers/_0-3-0 ./build/_headers"
+
+[0-2-0]
+command = "yarn build && cp ./custom-headers/_0-2-0 ./build/_headers"
+
+[0-1-0]
+command = "yarn build && cp ./custom-headers/_0-1-0 ./build/_headers"
+


### PR DESCRIPTION
This PR adds custom `_headers` files that set a `noindex` rule for the branches specified in the `custom-headers` directory. Per the instructions in  [Netlify's docs](https://docs.netlify.com/routing/headers/#custom-headers-for-different-branch-or-deploy-contexts):

1. Create a `netlify.toml` file in the root of your project
2. Create a custom directory to store context-specific header files (`custom-headers`)
3. Create header files for each custom configuration, and store them in custom-headers
4. Modify the build command for each deploy context/branch that requires headers. Add the following script to the end of the build command: `&& cp path-to-your-header-file path-to-your-publish-dir/_headers`

In our case, the build command should look like, for example: 
- `"yarn build && cp ./custom-headers/_0-17-0 ./build/_headers"`
Where `./build` is the publish directory. (See the [Frameworks](https://docs.netlify.com/frameworks/#react-and-create-react-app) docs. Since Docusaurus is powered by React, this would be the `build` directory.)

Additional docs that may be helpful for review:
- Netlify config: https://docs.netlify.com/configure-builds/file-based-configuration/
- _header file syntax: https://docs.netlify.com/routing/headers/#syntax-for-the-headers-file

Resolves https://github.com/pomerium/internal/issues/1798