### PR TITLE
Adds envoy-error-messages header id

### DIFF
--- a/content/docs/troubleshooting.mdx
+++ b/content/docs/troubleshooting.mdx
@@ -298,7 +298,7 @@ If you wanted to add an email address like `John.Admin@example.com` to the `admi
 
 ---
 
-## Upstream connection errors
+## Upstream connection errors {#envoy-error-messages}
 
 Upstream connection errors indicate that something is wrong with the upstream server, not Pomerium. Please refer to the list of errors below to learn more about a specific issue, and how you can resolve it.
 


### PR DESCRIPTION
This PR adds an [explicit heading ID](https://docusaurus.io/docs/next/markdown-features/toc#heading-ids) to the [Upstream connection errors](https://www.pomerium.com/docs/troubleshooting#upstream-connection-errors) section on the Troubleshooting page. This should fix the linking issue described in https://github.com/pomerium/pomerium/issues/5189.

Resolves https://github.com/pomerium/pomerium/issues/5189