### PR TITLE
Adds kubecon banner with google calendar link

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -84,6 +84,7 @@
     "Keycloak",
     "kubebuilder",
     "kubectl",
+    "kubecon",
     "kubernetes",
     "kustomization",
     "kustomize",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -90,6 +90,13 @@ const config = {
       contextualSearch: false,
       searchPagePath: false,
     },
+    announcementBar: {
+      id: 'kubecon-2024',
+      content: 'Meet the Pomerium Development Team at our KubeCon 2024 booth in Salt Lake City, Utah from November 12-15. <b><a href="https://calendar.google.com/calendar/appointments/schedules/AcZssZ0YfkyTbr2fYMyJvdPf7vsQ2xLkc77t1eGPiwM2jRkl8hBLubeOWjgX3dcFHjU_M86cgYhBIV_u?gv=true" target="_blank">Book an appointment now!</a></b>',
+      backgroundColor: '#039BE5',
+      textColor: '#FFFFFF',
+      isCloseable: true,
+    },
     navbar: {
       title: '',
       logo: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -93,7 +93,7 @@ const config = {
     announcementBar: {
       id: 'kubecon-2024',
       content: 'Meet the Pomerium Development Team at our KubeCon 2024 booth in Salt Lake City, Utah from November 12-15. <b><a href="https://calendar.google.com/calendar/appointments/schedules/AcZssZ0YfkyTbr2fYMyJvdPf7vsQ2xLkc77t1eGPiwM2jRkl8hBLubeOWjgX3dcFHjU_M86cgYhBIV_u?gv=true" target="_blank">Book an appointment now!</a></b>',
-      backgroundColor: '#039BE5',
+      backgroundColor: '#7C3AED',
       textColor: '#FFFFFF',
       isCloseable: true,
     },


### PR DESCRIPTION
Adds a Kubecon announcement bar to our docs with a link to the Google Calendar appointment page. It's not possible to selectively place this on certain pages; rather, you must apply it to all pages. 

It's also not possible to import the script @wasaga provided without swizzling the AnnouncementBar component, which seems a bit overkill when we can simply place the link in an anchor tag. 

Please let me know if this needs any other tweaks.


Resolves https://github.com/pomerium/internal/issues/1870