### PR TITLE
Fixes typo in mTLS Clients guide

### DIFF
--- a/content/docs/capabilities/mtls-clients.mdx
+++ b/content/docs/capabilities/mtls-clients.mdx
@@ -165,7 +165,7 @@ Now you'll need to install the client certificate you created earlier. The follo
 
    ![chrome settings](img/mtls/01-chrome-settings-certificates.png)
 
-1. Click on **Import** and browse to the directory where you created the certificates above. Choose `_wildcard.localhost.pomerium.io-client.p12`:
+1. Click on **Import** and browse to the directory where you created the certificates above. Choose `yourUsername@localhost.pomerium.io-client.p12`:
 
    ![import client certificate](img/mtls/02-import-client-certificate.png)
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -87,6 +87,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/guides/securing-tcp /docs/capabilities/tcp
 /docs/guides/tcp.html /docs/guides/securing-tcp
 /guides/vs-code-server.html /docs/guides/code-server
+/docs/guides/vs-code-server.html /docs/guides/code-server
 /guides/local-oidc.html /docs/guides/local-oidc
 /docs/guides/local-oidc /docs/identity-providers/oidc
 /docs/identity-providers/dex-freeipa /docs 410


### PR DESCRIPTION
On [this page](https://www.pomerium.com/docs/capabilities/mtls-clients#install-your-client-certificate), we tell the user to import the `_wildcard` cert created from earlier in the guide. They should be importing the client cert instead. This PR updates the text to mention the correct cert.