### PR TITLE
Adds jti recommendation

### DIFF
--- a/content/docs/capabilities/getting-users-identity.md
+++ b/content/docs/capabilities/getting-users-identity.md
@@ -220,6 +220,12 @@ The Pomerium JWT contains at least the following claims:
 | `groups` | The user's group memberships (if supported for the identity provider). |
 | `name` | The user's full name, as specified by the identity provider. |
 
+:::tip Prevent session replay attempts
+
+The `jti` claim (the JWT ID) contains a unique identifier assigned to each Pomerium JWT. You can prevent session replay attempts by implementing a system that monitors `jti` reuse either in real time or by checking session logs.
+
+:::
+
 ### JWT Settings
 
 Use these settings to configure Pomerium to forward the Pomerium JWT to upstream services:

--- a/content/docs/capabilities/getting-users-identity.md
+++ b/content/docs/capabilities/getting-users-identity.md
@@ -222,7 +222,7 @@ The Pomerium JWT contains at least the following claims:
 
 :::tip Prevent session replay attempts
 
-The `jti` claim (the JWT ID) contains a unique identifier assigned to each Pomerium JWT. You can prevent session replay attempts by implementing a system that monitors `jti` reuse either in real time or by checking session logs.
+The `jti` claim (the JWT ID) contains a unique identifier assigned to each Pomerium JWT. If you can implement a system that checks the `jti` value in real time, you can prevent session replay attempts. Or, if you persist the `jti` value in your logs, you can detect replayed JWTs after the fact.
 
 :::
 


### PR DESCRIPTION
This PR adds a tip admonition explaining how the `jti` claim can be used to prevent session replay attempts. 

Page: https://pomerium.com/docs/capabilities/getting-users-identity

Related to https://github.com/pomerium/internal/issues/1876