### PR TITLE
Adds versions dropdown to latest release

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -55,6 +55,17 @@ const config = {
             ],
             extendDefaults: true,
           },
+          versions: {
+            // Uncomment if pushing to latest release branch (e.g. 0-26-0)
+            current: {
+              label: 'v0.26 (latest)'
+            }
+            // Uncomment if pushing to main (vNext)
+            // current: {
+            //   label: 'vNext (current)',
+            //   badge: true,
+            // },
+          },
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
@@ -151,16 +162,32 @@ const config = {
           position: 'right',
         },
         {
-          type: 'dropdown',
-          label: 'v0.26',
+          type: 'docsVersionDropdown',
           position: 'right',
-          items: [
+          dropdownActiveClassDisabled: true,
+          dropdownItemsAfter: [
+            // {
+            // Comment out when pushing to latest release branch (e.g. 0-26-0)
+            //   to: 'https://0-26-0.docs.pomerium.com/docs',
+            //   label: 'v0.26 (latest)',
+            // },
             {
-              type: 'doc',
-              label: 'Archived Versions',
-              docId: 'docs/versions',
+              to: 'https://0-25-0.docs.pomerium.com/docs',
+              label: 'v0.25',
             },
-          ],
+            {
+              to: 'https://0-24-0.docs.pomerium.com/docs',
+              label: 'v0.24',
+            },
+            {
+              type: 'html',
+              value: '<hr>',
+            },
+            {
+              to: '/docs/versions',
+              label: 'All Versions',
+            },
+          ]
         },
       ],
     },


### PR DESCRIPTION
Related to https://github.com/pomerium/documentation/pull/1541. Pushes versions dropdown to v0.26. 