### PR TITLE
removes jti claim from claims table

### DIFF
--- a/content/docs/capabilities/getting-users-identity.md
+++ b/content/docs/capabilities/getting-users-identity.md
@@ -210,7 +210,6 @@ The Pomerium JWT contains at least the following claims:
 
 | JWT Claim | Description |
 | :-: | --- |
-| `jti` | A randomly generated UUID that represents the JWT ID. |
 | `exp` | Expiration time in seconds since the UNIX epoch. Set to expire 5 minutes after `iat` time. |
 | `iat` | Issued-at time in seconds since the UNIX epoch. |
 | `aud` | The domain for the upstream application (for example, `httpbin.corp.example.com`). |


### PR DESCRIPTION
Removes the `jti` claim from the JWT claims table on page https://pomerium.com/docs/capabilities/getting-users-identity