### PR TITLE
add new mTLS user_principal_name matcher

### DIFF
--- a/content/docs/reference/downstream-mtls-settings.mdx
+++ b/content/docs/reference/downstream-mtls-settings.mdx
@@ -219,6 +219,7 @@ Supported SAN types include:
 - `email` — an email address (this is the `rfc822Name` as specified in [RFC 5280 §4.2.1.6](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.6))
 - `ip_address` — an IP address (either IPv4 or IPv6)
 - `uri` — a Uniform Resource Identifier (URI)
+- `user_principal_name` — a User Principal Name (UPN), commonly used with smart cards
 
 The provided regular expression must match against the entire SAN entry. The regular expressions use Google's [RE2 syntax](https://github.com/google/re2/wiki/Syntax).
 


### PR DESCRIPTION
Add `user_principal_name` to the list of supported mTLS "Match Subject Alt Names" types.

Related issue:
 - https://github.com/pomerium/pomerium/issues/5176