### PR TITLE
updates vNext versions dropdown label

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -57,7 +57,7 @@ const config = {
           },
           versions: {
             current: {
-              label: 'vNext (current)',
+              label: 'vNext (upcoming release)',
               badge: true,
             },
           },
@@ -164,7 +164,7 @@ const config = {
           dropdownItemsAfter: [
             {
               to: 'https://0-26-0.docs.pomerium.com/docs',
-              label: 'v0.26 (latest)',
+              label: 'v0.26 (latest release)',
             },
             {
               to: 'https://0-25-0.docs.pomerium.com/docs',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -164,7 +164,7 @@ const config = {
           dropdownItemsAfter: [
             {
               to: 'https://0-26-0.docs.pomerium.com/docs',
-              label: 'v0.26 (latest release)',
+              label: 'v0.26 (latest)',
             },
             {
               to: 'https://0-25-0.docs.pomerium.com/docs',


### PR DESCRIPTION
Updates the vNext label in the Docusaurus config file so that it says "upcoming release".  I also updated the latest release label to say "latest release".