### PR TITLE
fix table syntax for cookie SameSite options

### DIFF
--- a/content/docs/reference/cookies.mdx
+++ b/content/docs/reference/cookies.mdx
@@ -306,10 +306,10 @@ cookie:
 ### Cookie SameSite options
 
 | **Attribute** | **Value** |
-| :-- | :-- | --- |
+| :-- | :-- |
 | `Lax` | The cookie is _not_ sent on cross-site requests, such as on requests to load images or frames, but is sent when a user is navigating to the origin site from an external site (for example, when following a link). |
 | `Strict` | The browser sends the cookie only for same-site requests, that is, requests originating from the same site that set the cookie. |
-| `None` | The browser sends the cookie with both cross-site and same-site requests. If you set `SameSite=none`, the [HTTPS only](/docs/reference/cookies#cookie-secure) setting must be set to `true`. |  |
+| `None` | The browser sends the cookie with both cross-site and same-site requests. If you set `SameSite=none`, the [HTTPS only](/docs/reference/cookies#cookie-secure) setting must be set to `true`. |
 
 ## Cookie Secret File {#cookie-secret-file}
 


### PR DESCRIPTION
The Markdown formatting for the cookie SameSite options table appears to have gotten mangled in https://github.com/pomerium/documentation/pull/937.