### PR TITLE
update databroker settings reference page 

### DIFF
--- a/content/docs/reference/databroker.mdx
+++ b/content/docs/reference/databroker.mdx
@@ -1,4 +1,6 @@
 ---
+# cSpell:ignore mydb mydbuser
+
 id: databroker
 title: Databroker Storage Settings
 pagination_prev: null
@@ -10,13 +12,18 @@ import TabItem from '@theme/TabItem';
 
 The databroker service manages all persistent state within Pomerium. These settings control how the databroker service will store this state.
 
+For more information on the databroker service see [Persistence & Data storage](/docs/internals/data-storage).
+
 ## Databroker Storage Type {#databroker-storage-type}
 
 **Databroker Storage Type** sets the backend storage type:
+
 - `memory` — data is stored in main memory
 - `postgres` — data is stored in an external PostgreSQL database
 
 The in-memory option is sufficient for single-replica Pomerium deployments. A PostgreSQL database is required when running multiple replicas of Pomerium, in order to ensure that all replicas share a consistent view of the application state.
+
+For more information see [Persistence & Data storage: Backends](/docs/internals/data-storage#backends).
 
 ### How to configure {#databroker-storage-type-how-to-configure}
 

--- a/content/docs/reference/databroker.mdx
+++ b/content/docs/reference/databroker.mdx
@@ -1,7 +1,6 @@
 ---
 id: databroker
-title: Databroker Settings
-sidebar_label: Databroker Settings
+title: Databroker Storage Settings
 pagination_prev: null
 pagination_next: null
 ---
@@ -9,107 +8,39 @@ pagination_next: null
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Databroker Settings
+The databroker service manages all persistent state within Pomerium. These settings control how the databroker service will store this state.
 
-## Databroker Storage Certificate Authority {#databroker-storage-certificate-authority}
+## Databroker Storage Type {#databroker-storage-type}
 
-**Databroker Storage Certificate Authority** defines the set of root certificates used when verifying storage server connections.
+**Databroker Storage Type** sets the backend storage type:
+- `memory` — data is stored in main memory
+- `postgres` — data is stored in an external PostgreSQL database
 
-### How to configure {#databroker-storage-certificate-authority-how-to-configure}
+The in-memory option is sufficient for single-replica Pomerium deployments. A PostgreSQL database is required when running multiple replicas of Pomerium, in order to ensure that all replicas share a consistent view of the application state.
+
+### How to configure {#databroker-storage-type-how-to-configure}
 
 <Tabs>
 <TabItem value="Core" label="Core">
 
-| **Config file keys** | **Environment variables** | **Type** | **Usage** |
+| **Config file keys** | **Environment variables** | **Type** | **Default** |
 | :-- | :-- | :-- | :-- |
-| `databroker_storage_ca_file` | `DATABROKER_STORAGE_CA_FILE` | `string` | **optional** |
+| `databroker_storage_type` | `DATABROKER_STORAGE_TYPE` | `string` | `memory` |
 
-#### Examples {#databroker-storage-certificate-authority-examples}
+### Examples {#databroker-storage-type-example}
 
 ```yaml
-databroker_storage_ca_file: /relative/file/location
+databroker_storage_type: postgres
 ```
 
 ```bash
-DATABROKER_STORAGE_CA_FILE=/relative/file/location
+DATABROKER_STORAGE_TYPE=postgres
 ```
 
 </TabItem>
 <TabItem value="Enterprise" label="Enterprise">
 
-`databroker_storage_ca_file` is a bootstrap configuration setting and is not configurable in the Console.
-
-</TabItem>
-<TabItem value="Kubernetes" label="Kubernetes">
-
-See Kubernetes [Storage reference](/docs/k8s/reference#storage) for more information.
-
-</TabItem>
-</Tabs>
-
-## Databroker Storage Certificate File {#databroker-storage-certificate-file}
-
-**Databroker Storage Certificate File** stores the certificate used to connect to a storage backend.
-
-### How to configure {#databroker-storage-certificate-file-how-to-configure}
-
-<Tabs>
-<TabItem value="Core" label="Core">
-
-| **Config file keys** | **Environment variables** | **Type** | **Usage** |
-| :-- | :-- | :-- | :-- |
-| `databroker_storage_cert_file` | `DATABROKER_STORAGE_CERT_FILE` | `string` | **optional** |
-
-#### Examples {#databroker-storage-certificate-file-examples}
-
-```yaml
-databroker_storage_cert_file: /relative/file/location
-```
-
-```bash
-DATABROKER_STORAGE_CERT_FILE=/relative/file/location
-```
-
-</TabItem>
-<TabItem value="Enterprise" label="Enterprise">
-
-`databroker_storage_cert_file` is a bootstrap configuration setting and is not configurable in the Console.
-
-</TabItem>
-<TabItem value="Kubernetes" label="Kubernetes">
-
-See Kubernetes [Storage reference](/docs/k8s/reference#storage) for more information.
-
-</TabItem>
-</Tabs>
-
-## Databroker Storage Certificate Key File {#databroker-storage-certificate-key-file}
-
-**Databroker Storage Certificate Key File** stores the certificate key used to connect to a storage backend.
-
-### How to configure {#databroker-storage-certificate-key-file-how-to-configure}
-
-<Tabs>
-<TabItem value="Core" label="Core">
-
-| **Config file keys** | **Environment variables** | **Type** | **Usage** |
-| :-- | :-- | :-- | :-- |
-| `databroker_storage_key_file` | `DATABROKER_STORAGE_KEY_FILE` | `string` | **optional** |
-
-#### Examples {#databroker-storage-certificate-key-file-examples}
-
-```yaml
-databroker_storage_key_file: /relative/file/location
-```
-
-```bash
-DATABROKER_STORAGE_KEY_FILE=/relative/file/location
-```
-
-</TabItem>
-<TabItem value="Enterprise" label="Enterprise">
-
-`databroker_storage_key_file` is a bootstrap configuration setting and is not configurable in the Console.
+`databroker_storage_type` is a bootstrap configuration setting and is not configurable in the Console.
 
 </TabItem>
 <TabItem value="Kubernetes" label="Kubernetes">
@@ -121,26 +52,28 @@ See Kubernetes [Storage reference](/docs/k8s/reference#storage) for more informa
 
 ## Databroker Storage Connection String {#databroker-storage-connection-string}
 
-**Databroker Storage Connection String** sets the Postgres connection string that the Databroker service uses to connect to storage backend. The connection string may be provided directly in the configuration or read from a file.
+**Databroker Storage Connection String** tells Pomerium how to connect to an external PostgreSQL database. This connection string may be provided directly in the configuration or read from a file.
+
+This setting is **required** when the storage type is set to `postgres`.
 
 ### How to configure {#databroker-storage-connection-string-how-to-configure}
 
-For Postgres, the following URL types are supported:
+The connection string may be provided in either keyword/value format or URI format:
 
-- `postgres://[username:password@]host:port/[db]`
-- `postgresql://[userspec@][hostspec][/dbname][?paramspec]`
+- `host=localhost port=5432 dbname=mydb user=mydbuser`
+- `postgresql://[username:password@]host:port/[dbname][?paramspec]`
 
-See the [PostgreSQL connection URI docs](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING) for more information.
+See the [PostgreSQL documentation](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING) for more information on the available options.
 
 <Tabs>
 <TabItem value="Core" label="Core">
 
-| **Config file keys** | **Environment variables** | **Type** | **Usage** |
-| :-- | :-- | :-- | :-- |
-| `databroker_storage_connection_string` | `DATABROKER_STORAGE_CONNECTION_STRING` | `string` | **optional** |
-| `databroker_storage_connection_string_file` | `DATABROKER_STORAGE_CONNECTION_STRING_FILE` | `string` (file path) | **optional** |
+| **Config file keys** | **Environment variables** | **Type** |
+| :-- | :-- | :-- |
+| `databroker_storage_connection_string` | `DATABROKER_STORAGE_CONNECTION_STRING` | `string` |
+| `databroker_storage_connection_string_file` | `DATABROKER_STORAGE_CONNECTION_STRING_FILE` | `string` (file path) |
 
-#### Examples {#databroker-storage-connection-string-examples}
+### Examples {#databroker-storage-connection-string-examples}
 
 ```yaml
 databroker_storage_connection_string: postgresql://postgres:postgres@database/postgres?sslmode=disable
@@ -176,77 +109,3 @@ See Kubernetes [Storage reference](/docs/k8s/reference#storage) for more informa
 When using multiple hosts make sure to specify `target_session_attrs=read-write` so that the Databroker does not attempt to write to a read-only replica.
 
 :::
-
-## Databroker Storage TLS Skip Verify {#databroker-storage-tls-skip-verify}
-
-If **Databroker Storage TLS Skip Verify** is set, the TLS connection to the storage backend will not be verified.
-
-### How to configure {#databroker-storage-tls-skip-verify-how-to-configure}
-
-<Tabs>
-<TabItem value="Core" label="Core">
-
-| **Config file keys** | **Environment variables** | **Type** | **Usage** |
-| :-- | :-- | :-- | :-- |
-| `databroker_storage_tls_skip_verify` | `DATABROKER_STORAGE_TLS_SKIP_VERIFY` | `string` | **optional** |
-
-#### Examples {#databroker-storage-tls-skip-verify-examples}
-
-```yaml
-databroker_storage_tls_skip_verify: /relative/file/location
-```
-
-```bash
-DATABROKER_STORAGE_TLS_SKIP_VERIFY=/relative/file/location
-```
-
-</TabItem>
-<TabItem value="Enterprise" label="Enterprise">
-
-`databroker_storage_tls_skip_verify` is a bootstrap configuration setting and is not configurable in the Console.
-
-</TabItem>
-<TabItem value="Kubernetes" label="Kubernetes">
-
-See Kubernetes [Storage reference](/docs/k8s/reference#storage) for more information.
-
-</TabItem>
-</Tabs>
-
-## Databroker Storage Type {#databroker-storage-type}
-
-**Databroker Storage Type** sets the backend storage that the Databroker server will use.
-
-Only `memory` and `postgres` are supported.
-
-### How to configure {#databroker-storage-type-how-to-configure}
-
-<Tabs>
-<TabItem value="Core" label="Core">
-
-| **Config file keys** | **Environment variables** | **Type** | **Usage** | **Default** |
-| :-- | :-- | :-- | :-- | :-- |
-| `databroker_storage_type` | `DATABROKER_STORAGE_TYPE` | `string` | **required** | **memory** |
-
-### Examples {#databroker-storage-type-example}
-
-```yaml
-databroker_storage_type: postgres
-```
-
-```bash
-DATABROKER_STORAGE_TYPE=postgres
-```
-
-</TabItem>
-<TabItem value="Enterprise" label="Enterprise">
-
-`databroker_storage_type` is a bootstrap configuration setting and is not configurable in the Console.
-
-</TabItem>
-<TabItem value="Kubernetes" label="Kubernetes">
-
-See Kubernetes [Storage reference](/docs/k8s/reference#storage) for more information.
-
-</TabItem>
-</Tabs>

--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -774,34 +774,6 @@
     "services": [],
     "type": "string"
   },
-  "data-broker-storage-certificate-file": {
-    "id": "data-broker-storage-certificate-file",
-    "title": "Databroker Storage Certificate File",
-    "path": "/databroker#databroker-storage-certificate-file",
-    "services": [],
-    "type": "relative file location"
-  },
-  "data-broker-storage-certificate-key-file": {
-    "id": "data-broker-storage-certificate-key-file",
-    "title": "Databroker Storage Certificate Key File",
-    "path": "/databroker#databroker-storage-certificate-key-file",
-    "services": [],
-    "type": "relative file location"
-  },
-  "data-broker-storage-certificate-authority": {
-    "id": "data-broker-storage-certificate-authority",
-    "title": "Databroker Storage Certificate Authority",
-    "path": "/databroker#databroker-storage-certificate-authority",
-    "services": [],
-    "type": "relative file location"
-  },
-  "data-broker-storage-tls-skip-verify": {
-    "id": "data-broker-storage-tls-skip-verify",
-    "title": "Databroker Storage TLS Skip Verify",
-    "path": "/databroker#databroker-storage-tls-skip-verify",
-    "services": [],
-    "type": "bool"
-  },
   "allow-any-authenticated-user": {
     "id": "allow-any-authenticated-user",
     "title": "Allow Any Authenticated User",

--- a/static/_redirects
+++ b/static/_redirects
@@ -352,15 +352,15 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/reference/autocert/autocert-use-staging /docs/reference/autocert#autocert-use-staging
 
 # Databroker
-/docs/reference/data-broker-internal-service-url /docs/reference/databroker#data-broker-internal-service-url
-/docs/reference/data-broker-service /docs/reference/databroker#data-broker-service
-/docs/reference/data-broker-service-url /docs/reference/databroker#data-broker-service-url
-/docs/reference/data-broker-storage-certificate-authority /docs/reference/databroker#data-broker-storage-certificate-authority
-/docs/reference/data-broker-storage-certificate-file /docs/reference/databroker#data-broker-storage-certificate-file
-/docs/reference/data-broker-storage-certificate-key-file /docs/reference/databroker#data-broker-storage-certificate-key-file
-/docs/reference/data-broker-storage-connection-string /docs/reference/databroker#data-broker-storage-connection-string
-/docs/reference/data-broker-storage-tls-skip-verify /docs/reference/databroker#data-broker-storage-tls-skip-verify
-/docs/reference/data-broker-storage-type /docs/reference/databroker#data-broker-storage-type
+/docs/reference/data-broker-internal-service-url /docs/reference/service-urls#data-broker-internal-service-url
+/docs/reference/data-broker-service /docs/reference/databroker
+/docs/reference/data-broker-service-url /docs/reference/service-urls#data-broker-service-url
+/docs/reference/data-broker-storage-certificate-authority /docs/reference/databroker
+/docs/reference/data-broker-storage-certificate-file /docs/reference/databroker
+/docs/reference/data-broker-storage-certificate-key-file /docs/reference/databroker
+/docs/reference/data-broker-storage-connection-string /docs/reference/databroker#databroker-storage-connection-string
+/docs/reference/data-broker-storage-tls-skip-verify /docs/reference/databroker
+/docs/reference/data-broker-storage-type /docs/reference/databroker#databroker-storage-type
 
 # Cookies
 /docs/reference/cookie-domain /docs/reference/cookies#cookie-domain


### PR DESCRIPTION
Change the page title and add a couple introductory sentences to help clarify that these settings are specifically about the databroker storage backend. Put the storage type setting first as it is the most important. Remove the settings that are currently unused. Update databroker settings redirects.

Related issues:
- https://github.com/pomerium/documentation/issues/1585
- https://github.com/pomerium/pomerium/issues/5277