### PR TITLE
Updates v0.27 dropdown

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -162,10 +162,6 @@ const config = {
           position: 'right',
           dropdownActiveClassDisabled: true,
           dropdownItemsAfter: [
-            // {
-            //   to: 'https://0-26-0.docs.pomerium.com/docs',
-            //   label: 'v0.26 (latest)',
-            // },
             {
               to: 'https://0-26-0.docs.pomerium.com/docs',
               label: 'v0.26',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -57,7 +57,7 @@ const config = {
           },
           versions: {
             current: {
-              label: 'vNext (upcoming release)',
+              label: 'v0.27 (latest)',
               badge: true,
             },
           },
@@ -162,17 +162,17 @@ const config = {
           position: 'right',
           dropdownActiveClassDisabled: true,
           dropdownItemsAfter: [
+            // {
+            //   to: 'https://0-26-0.docs.pomerium.com/docs',
+            //   label: 'v0.26 (latest)',
+            // },
             {
               to: 'https://0-26-0.docs.pomerium.com/docs',
-              label: 'v0.26 (latest)',
+              label: 'v0.26',
             },
             {
               to: 'https://0-25-0.docs.pomerium.com/docs',
               label: 'v0.25',
-            },
-            {
-              to: 'https://0-24-0.docs.pomerium.com/docs',
-              label: 'v0.24',
             },
             {
               type: 'html',


### PR DESCRIPTION
Updates the v0.27 dropdown menu to display `v0.27 (latest)`, not vNext.