### PR TITLE
remove note about older mTLS setting keys

### DIFF
--- a/content/docs/reference/downstream-mtls-settings.mdx
+++ b/content/docs/reference/downstream-mtls-settings.mdx
@@ -32,12 +32,6 @@ The Subject Name of all configured CA certificates will be advertised in the ini
 
 The CA setting is **required** for downstream mTLS.
 
-:::info
-
-This setting previously used the config file keys `client_ca` and `client_ca_file` and the environment variables `CLIENT_CA` and `CLIENT_CA_FILE`.
-
-:::
-
 ### How to configure {#ca-how-to-configure}
 
 The CA bundle can be specified inline (with the `ca` key or the `DOWNSTREAM_MTLS_CA` environment variable) or as a path to a file on disk (with the `ca_file` key or the `DOWNSTREAM_MTLS_CA_FILE` environment variable). It is considered an error to specify both.


### PR DESCRIPTION
The `client_ca` / `client_ca_file` config keys were [deprecated in v0.23](https://www.pomerium.com/docs/core/upgrading#new-downstream-mtls-settings) and finally [removed in v0.26](https://www.pomerium.com/docs/core/upgrading#deprecations:~:text=Support%20for%20the,about%20this%20option.). I think we can remove this note about them from the Downstream mTLS settings page. (No need to backport.)