### PR TITLE
Adds correct Zero Courses link

### DIFF
--- a/content/docs/quickstart.mdx
+++ b/content/docs/quickstart.mdx
@@ -127,7 +127,7 @@ You should land on the Verify page:
 
 :::info Build your own route
 
-Check out [**Pomerium Fundamentals: Build Routes**](/docs/courses/fundamentals/build-routes) to learn how to create a route to your own service behind Pomerium.
+Check out [**Pomerium Fundamentals: Build Routes**](/docs/courses/fundamentals/zero-build-routes) to learn how to create a route to your own service behind Pomerium.
 
 :::
 


### PR DESCRIPTION
The current link in our Quickstart to our "Build Routes" Zero course points to the Core guide. This PR adds the correct link.