### PR TITLE
Adds a pushfeedback widget

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -184,5 +184,5 @@
     "zipkin",
     "zonefile"
   ],
-  "ignorePaths": ["*.mp4", "*.png2", "*.svg", "*.webm", "k8s", "examples"]
+  "ignorePaths": ["*.mp4", "*.png2", "*.svg", "*.webm", "k8s", "examples", "docusaurus.config.js", "package.json"]
 }

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -273,6 +273,15 @@ const config = {
       },
     ],
     './docusaurus-plugins/src/webpackDebugFix.js',
+    [
+      'docusaurus-pushfeedback',{
+          project: 'esgee0kxds',
+          buttonPosition: 'center-right',
+          modalPosition: 'sidebar-right',
+          buttonStyle: 'dark',
+          modalTitle: 'Share your thoughts'
+      }
+    ]
   ],
 };
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -280,7 +280,6 @@ const config = {
           modalPosition: 'sidebar-right',
           buttonStyle: 'dark',
           modalTitle: 'Share your thoughts',
-          hideEmail: true,
       }
     ]
   ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -279,7 +279,8 @@ const config = {
           buttonPosition: 'center-right',
           modalPosition: 'sidebar-right',
           buttonStyle: 'dark',
-          modalTitle: 'Share your thoughts'
+          modalTitle: 'Share your thoughts',
+          hideEmail: true,
       }
     ]
   ],

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@mui/x-data-grid-pro": "^6.18.6",
     "clsx": "^2.1.0",
     "docusaurus-gtm-plugin": "^0.0.2",
+    "docusaurus-pushfeedback": "^1.0.1",
     "dotenv": "^16.3.1",
     "mdx-mermaid": "^2.0.0",
     "mermaid": "^10.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4502,6 +4502,11 @@ docusaurus-plugin-redoc@2.1.1:
     "@redocly/openapi-core" "1.16.0"
     redoc "2.1.5"
 
+docusaurus-pushfeedback@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/docusaurus-pushfeedback/-/docusaurus-pushfeedback-1.0.1.tgz#9bff88b897ed8024c95eef1c4a5a163f7c32cd71"
+  integrity sha512-pD9RvbKKivQmIcGrXfDD+UMlavK0yAt/OhhUG/pz8sdfgSU0Hx5AmlEc/xJAsEYj78aVSWX3SV6/XXoksudjDg==
+
 docusaurus-theme-redoc@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/docusaurus-theme-redoc/-/docusaurus-theme-redoc-2.1.1.tgz#2e6ba70aac88e053cc7f527970a7b22a66424012"


### PR DESCRIPTION
This PR adds the pushfeedback widget to our docs pages. I added the `hideEmail` property to remove the email input, but we can also include the input if we want to support that option.

Tagging @gaurdro here in case he has any input as well.