### PR TITLE
changelog: add link to security advisory for v0.27.1

### DIFF
--- a/content/docs/core/changelog.mdx
+++ b/content/docs/core/changelog.mdx
@@ -21,7 +21,7 @@ Please refer to the [upgrade guide](/docs/core/upgrading) before upgrading.
 
 [Full Changelog](https://github.com/pomerium/pomerium/compare/v0.27.0...v0.27.1)
 
-Pomerium v0.27.1 includes a fix to the databroker service API authorization logic. Certain service account tokens from Pomerium Zero or Pomerium Enterprise could grant unintended authorization to the databroker service API. [CVE-2024-47616](https://github.com/pomerium/pomerium/security/advisories/GHSA-r7rh-jww5-5fjr)
+Pomerium v0.27.1 includes a fix to the databroker service API authorization logic. Certain service account tokens from Pomerium Zero or Pomerium Enterprise could grant unintended authorization to the databroker service API. See the [CVE-2024-47616](https://github.com/pomerium/pomerium/security/advisories/GHSA-r7rh-jww5-5fjr) for more information.
 
 ### Security
 

--- a/content/docs/core/changelog.mdx
+++ b/content/docs/core/changelog.mdx
@@ -21,6 +21,8 @@ Please refer to the [upgrade guide](/docs/core/upgrading) before upgrading.
 
 [Full Changelog](https://github.com/pomerium/pomerium/compare/v0.27.0...v0.27.1)
 
+Pomerium v0.27.1 includes a fix to the databroker service API authorization logic. Certain service account tokens from Pomerium Zero or Pomerium Enterprise could grant unintended authorization to the databroker service API. [CVE-2024-47616](https://github.com/pomerium/pomerium/security/advisories/GHSA-r7rh-jww5-5fjr)
+
 ### Security
 
 - Additional validation checks for gRPC API authorization. This update resolves a security vulnerability that we believe affects only certain Pomerium Enterprise and Pomerium Zero deployments.


### PR DESCRIPTION
Update the changelog for v0.27.1 to link to the GitHub security advisory for CVE-2024-47616, matching the updated release notes at https://github.com/pomerium/pomerium/releases/tag/v0.27.1.