### PR TITLE
code-server: add preserve host header instruction

### DIFF
--- a/content/docs/guides/code-server.mdx
+++ b/content/docs/guides/code-server.mdx
@@ -82,6 +82,7 @@ In the Zero Console:
 5. In `To:`, add the internal URL
 6. In the **Policies** field, select the Codeserver policy
 7. Select the **Timeouts** tab and **Allow Websockets**
+8. Select the **Headers** tab and **Preserve Host Header**
 
 ## Add Docker Compose Services
 


### PR DESCRIPTION
For the `code-server` guide, `code-server` was updated in [v4.10.1](https://github.com/coder/code-server/releases/tag/v4.10.1) to check the host header of incoming websocket requests. Because of this users need to use the "Preserve Host Header" option on a route for `code-server` to work.