### PR TITLE
Manual Backport 1649 to 0 27 0

### DIFF
--- a/content/docs/courses/fundamentals/conclusion.md
+++ b/content/docs/courses/fundamentals/conclusion.md
@@ -20,7 +20,7 @@ You’ve made it! Congratulations on completing our Guided Tutorials series! Let
 - You configured Pomerium to run in a VM instance
 - You enabled Autocert, which automatically generates certificates for upstream connections between Pomerium and your services
 
-Now, you have a production-ready Pomerium instance. You have everything you need to be able to secure tools like [Grafana](https://www.pomerium.com/docs/guides/grafana), [Jenkins](https://www.pomerium.com/docs/guides/jenkins), [Code-server](https://www.pomerium.com/docs/guides/code-server), and more!
+Now, you have a production-ready Pomerium instance. You have everything you need to be able to secure tools like [Grafana](https://www.pomerium.com/docs/guides/grafana), [Jenkins](https://www.pomerium.com/docs/guides/jenkins), [Code-server](https://www.pomerium.com/integrations/code-server), and more!
 
 ## So, what’s next?
 

--- a/content/docs/zero.mdx
+++ b/content/docs/zero.mdx
@@ -30,4 +30,4 @@ Check out these guides for real-world examples:
 
 - [**Jenkins**](/docs/guides/jenkins)
 - [**Grafana**](/docs/guides/grafana)
-- [**Code-server**](/docs/guides/code-server)
+- [**Code-server**](https://www.pomerium.com/integrations/code-server)

--- a/sidebars.js
+++ b/sidebars.js
@@ -286,10 +286,6 @@ const sidebars = {
             },
             {
               type: 'doc',
-              id: 'docs/guides/code-server',
-            },
-            {
-              type: 'doc',
               id: 'docs/guides/gitlab',
             },
             {

--- a/static/_redirects
+++ b/static/_redirects
@@ -88,6 +88,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/guides/tcp.html /docs/guides/securing-tcp
 /guides/vs-code-server.html /docs/guides/code-server
 /docs/guides/vs-code-server.html /docs/guides/code-server
+/docs/guides/code-server https://www.pomerium.com/integrations/code-server
 /guides/local-oidc.html /docs/guides/local-oidc
 /docs/guides/local-oidc /docs/identity-providers/oidc
 /docs/identity-providers/dex-freeipa /docs 410


### PR DESCRIPTION
Manually backports changes from https://github.com/pomerium/documentation/pull/1649 to the 0-27-0 branch.