### PR TITLE
fix code block title syntax

### DIFF
--- a/content/docs/capabilities/authorization.mdx
+++ b/content/docs/capabilities/authorization.mdx
@@ -82,7 +82,7 @@ PPL is intuitive by design and defines policy with one or more rules composed of
 
 In Pomerium Core, you can build a policy with PPL and apply it to a route in your configuration file:
 
-```yaml title=pomerium-config.yaml
+```yaml title="pomerium-config.yaml"
 policy:
   - allow:
       or:

--- a/content/docs/capabilities/hosted-authenticate-service.md
+++ b/content/docs/capabilities/hosted-authenticate-service.md
@@ -46,7 +46,7 @@ The hosted authenticate service requires no configuration to use.
 
 Add the following route and policy to your configuration file:
 
-```yaml title=pomerium-config.yaml
+```yaml title="pomerium-config.yaml"
 routes:
   - from: https://verify.localhost.pomerium.io
     to: http://verify:8000
@@ -62,7 +62,7 @@ This minimal configuration is all you need to connect to an upstream service wit
 
 If you want, you can still include the hosted URL in your configuration:
 
-```yaml title=pomerium-config.yaml
+```yaml title="pomerium-config.yaml"
 authenticate_service_url: https://authenticate.pomerium.app
 
 routes:
@@ -78,7 +78,7 @@ routes:
 
 If you use the hosted URL and include your own IdP settings, Pomerium will override your IdP configuration and use the hosted IdP instead:
 
-```yaml title=pomerium-config.yaml
+```yaml title="pomerium-config.yaml"
 authenticate_service_url: https://authenticate.pomerium.app
 
 idp_provider: google

--- a/content/docs/guides/tooljet.mdx
+++ b/content/docs/guides/tooljet.mdx
@@ -154,7 +154,7 @@ Add the signing key you generated in `config.yaml` to the `SIGNING_KEY` environm
 
 Add the following configuration settings to `console-config.yaml` and replace the values with your own:
 
-```yaml title=console-config.yaml
+```yaml title="console-config.yaml"
 administrators: admin@example.com
 license_key: YOUR_LICENSE_KEY
 ```

--- a/content/docs/identity-providers/apple.md
+++ b/content/docs/identity-providers/apple.md
@@ -105,7 +105,7 @@ Once you've generated a signed JWT, you can configure Pomerium.
 
 In your Pomerium configuration file, add the following identity provider settings:
 
-```yaml title=pomerium-config
+```yaml title="pomerium-config"
 idp_provider: apple
 idp_client_id: app_or_service_id
 idp_client_secret: signed_apple_jwt

--- a/content/docs/identity-providers/google.mdx
+++ b/content/docs/identity-providers/google.mdx
@@ -70,7 +70,7 @@ Edit `config.yaml` or set your [environment variables] to connect Pomerium to Go
 <Tabs>
 <TabItem value="config-file-keys" label="config.yaml">
 
-```yaml title=/etc/pomerium/config.yaml
+```yaml title="/etc/pomerium/config.yaml"
 idp_provider: 'google'
 idp_client_id: 'yyyy.apps.googleusercontent.com'
 idp_client_secret: 'xxxxxx'

--- a/content/docs/k8s/quickstart.mdx
+++ b/content/docs/k8s/quickstart.mdx
@@ -120,7 +120,7 @@ See the [**Verify examples**](https://github.com/pomerium/verify/blob/main/examp
 
 1. Define a test service. We'll use the Pomerium Verify app:
 
-   ```yaml title=verify-service.yaml
+   ```yaml title="verify-service.yaml"
    apiVersion: v1
    kind: Service
    metadata:
@@ -164,7 +164,7 @@ See the [**Verify examples**](https://github.com/pomerium/verify/blob/main/examp
 
 2. Define an Ingress for the new service:
 
-   ```yaml title=verify-ingress.yaml {8} showLineNumbers
+   ```yaml title="verify-ingress.yaml" {8} showLineNumbers
    apiVersion: networking.k8s.io/v1
    kind: Ingress
    metadata:

--- a/content/examples/kubernetes/pomerium-global-settings.md
+++ b/content/examples/kubernetes/pomerium-global-settings.md
@@ -1,4 +1,4 @@
-```yaml title=pomerium.yaml
+```yaml title="pomerium.yaml"
 apiVersion: ingress.pomerium.io/v1
 kind: Pomerium
 metadata:
@@ -9,4 +9,4 @@ spec:
       url: https://authenticate.pomerium.app
   certificates:
       - pomerium/pomerium-wildcard-tls
-  ```
+```

--- a/content/examples/tooljet/config-console.yaml.md
+++ b/content/examples/tooljet/config-console.yaml.md
@@ -1,4 +1,4 @@
-```yaml title=config.yaml
+```yaml title="config.yaml"
 idp_provider: REPLACE_ME
 idp_provider_url: REPLACE_ME
 idp_client_id: REPLACE_ME

--- a/content/examples/tooljet/config-tooljet.yaml.md
+++ b/content/examples/tooljet/config-tooljet.yaml.md
@@ -1,4 +1,4 @@
-```yaml title=config.yaml
+```yaml title="config.yaml"
 authenticate_service_url: https://authenticate.localhost.pomerium.io
 
 

--- a/content/examples/tooljet/console-compose.yaml.md
+++ b/content/examples/tooljet/console-compose.yaml.md
@@ -1,4 +1,4 @@
-```yaml title=docker-compose.yaml
+```yaml title="docker-compose.yaml"
 networks:
   main: {}
 services:

--- a/content/examples/tooljet/docker-compose.yaml.md
+++ b/content/examples/tooljet/docker-compose.yaml.md
@@ -1,4 +1,4 @@
-```yaml title=docker-compose.yaml
+```yaml title="docker-compose.yaml"
 networks:
   main: {}
 services:


### PR DESCRIPTION
Docusaurus v3 appears to require double quotes around code block titles.

Related issue:
- https://github.com/pomerium/documentation/issues/1656