### PR TITLE
k8s api access: add exec-api-version option to the command

### DIFF
--- a/content/docs/capabilities/kubernetes-access.md
+++ b/content/docs/capabilities/kubernetes-access.md
@@ -60,5 +60,6 @@ kubectl config set-cluster via-pomerium --server=https://mycluster.pomerium.io
 kubectl config set-context via-pomerium --user=via-pomerium --cluster=via-pomerium
 # Add credentials command
 kubectl config set-credentials via-pomerium --exec-command=pomerium-cli \
-  --exec-arg=k8s,exec-credential,https://mycluster.pomerium.io
+  --exec-arg=k8s,exec-credential,https://mycluster.pomerium.io \
+  --exec-api-version=client.authentication.k8s.io/v1beta1
 ```

--- a/content/docs/enterprise/install.mdx
+++ b/content/docs/enterprise/install.mdx
@@ -212,4 +212,33 @@ kubectl apply -k ./config
 [ingress]: /docs/k8s/ingress
 
 </TabItem>
+<TabItem label="Kubernetes with Terraform" value="Kubernetes with Terraform">
+These steps cover installing Pomerium Enterprise into your existing Kubernetes cluster using Terraform.
+It assumes the Pomerium Ingress Controller is already installed in the cluster.
+
+import TerraformLocals from '!!raw-loader!./tf/locals.tf';
+import TerraformMain from '!!raw-loader!./tf/main.tf';
+import TerraformIngress from '!!raw-loader!./tf/ingress.tf';
+
+### Configure
+
+This file contains the essential parameters for Pomerium Enterprise deployment.
+
+<CodeBlock language="terraform" title="locals.tf">
+  {TerraformLocals}
+</CodeBlock>
+
+### The Main Terraform File
+
+<CodeBlock language="terraform" title="locals.tf">
+  {TerraformMain}
+</CodeBlock>
+
+### Console Ingress
+
+<CodeBlock language="terraform" title="locals.tf">
+  {TerraformIngress}
+</CodeBlock>
+
+</TabItem>
 </Tabs>

--- a/content/docs/enterprise/tf/ingress.tf
+++ b/content/docs/enterprise/tf/ingress.tf
@@ -1,0 +1,70 @@
+resource "kubernetes_ingress_v1" "console" {
+  metadata {
+    name      = "console"
+    namespace = local.namespace_name
+    annotations = {
+      "ingress.pomerium.io/pass_identity_headers" = "true"
+      "ingress.pomerium.io/secure_upstream"       = "true"
+      # the below need be replaced with the policy referencing specific users
+      "ingress.pomerium.io/allow_any_authenticated_user" = "true"
+    }
+  }
+
+  spec {
+    ingress_class_name = "pomerium"
+
+    rule {
+      host = "console.${local.domain}"
+
+      http {
+        path {
+          path      = "/"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = "pomerium-console"
+              port {
+                name = "https"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_ingress_v1" "console-api" {
+  metadata {
+    name      = "console-api"
+    namespace = local.namespace_name
+    annotations = {
+      "ingress.pomerium.io/pass_identity_headers"        = "true"
+      "ingress.pomerium.io/secure_upstream"              = "true"
+      "ingress.pomerium.io/allow_any_authenticated_user" = "true"
+    }
+  }
+
+  spec {
+    ingress_class_name = "pomerium"
+
+    rule {
+      host = "console-api.${local.domain}"
+
+      http {
+        path {
+          path      = "/"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = "pomerium-console"
+              port {
+                name = "grpc"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/content/docs/enterprise/tf/locals.tf
+++ b/content/docs/enterprise/tf/locals.tf
@@ -1,0 +1,8 @@
+locals {
+  domain                  = "your-domain.com"
+  namespace_name          = "pomerium-enterprise"
+  license_key             = "your-license-key"
+  database_url            = "postgres://"
+  image_registry_password = "your-registry-password"
+  administrators          = ["you@your-domain.com"]
+}

--- a/content/docs/enterprise/tf/main.tf
+++ b/content/docs/enterprise/tf/main.tf
@@ -1,0 +1,40 @@
+provider "kubernetes" {}
+
+provider "random" {}
+
+module "pomerium_enterprise" {
+  source = "git::https://github.com/pomerium/documentation//terraform/enterprise-k8s?ref=v0.28.0"
+
+  database_url            = locals.database_url
+  license_key             = locals.license_key
+  image_registry_password = locals.image_registry_password
+
+  administrators = locals.administrators
+
+  audience = [
+    "console.${local.domain}",
+    "console-api.${local.domain}",
+  ]
+  database_encryption_key_b64 = random_bytes.database_encryption_key.base64
+  authenticate_service_url    = "https://authenticate.${local.domain}"
+  shared_secret_b64           = data.kubernetes_secret.core_secrets.binary_data["shared_secret"]
+  signing_key_b64             = data.kubernetes_secret.core_secrets.binary_data["signing_key"]
+  namespace_name              = local.namespace_name
+}
+
+resource "random_bytes" "database_encryption_key" {
+  length = 32
+}
+
+# certain secrets need be copied from the ingress-controller secrets to the enterprise namespace
+data "kubernetes_secret" "core_secrets" {
+  metadata {
+    name      = "bootstrap"
+    namespace = "pomerium-ingress-controller"
+  }
+  binary_data = {
+    // the key is required to be declared so that the value could be referenced 
+    shared_secret = ""
+    signing_key   = ""
+  }
+}

--- a/cspell.json
+++ b/cspell.json
@@ -184,5 +184,15 @@
     "zipkin",
     "zonefile"
   ],
-  "ignorePaths": ["*.mp4", "*.png2", "*.svg", "*.webm", "k8s", "examples", "docusaurus.config.js", "package.json"]
+  "ignorePaths": [
+    "*.mp4",
+    "*.png2",
+    "*.svg",
+    "*.webm",
+    "k8s",
+    "examples",
+    "docusaurus.config.js",
+    "package.json",
+    "*.tf"
+  ]
 }

--- a/terraform/enterprise-k8s/deployment.tf
+++ b/terraform/enterprise-k8s/deployment.tf
@@ -1,0 +1,226 @@
+resource "kubernetes_deployment" "pomerium-console" {
+  metadata {
+    name      = "pomerium-console"
+    namespace = var.namespace_name
+  }
+
+  depends_on = [
+    kubernetes_namespace.pomerium-enterprise,
+    kubernetes_secret.console,
+    kubernetes_secret.docker_registry
+  ]
+
+  lifecycle {
+    ignore_changes = [
+      metadata[0].annotations,
+    ]
+  }
+
+  spec {
+    replicas = var.deployment_replicas
+
+    selector {
+      match_labels = {
+        "app.kubernetes.io/name" = "pomerium-console"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          "app.kubernetes.io/name" = "pomerium-console"
+        }
+      }
+
+      spec {
+        termination_grace_period_seconds = 30
+
+        service_account_name = kubernetes_service_account.console.metadata[0].name
+
+        security_context {
+          run_as_non_root = true
+
+          seccomp_profile {
+            type = "RuntimeDefault"
+          }
+        }
+
+        os {
+          name = "linux"
+        }
+
+        node_selector = {
+          "kubernetes.io/os" = "linux"
+        }
+
+        image_pull_secrets {
+          name = var.image_pull_secret
+        }
+
+        volume {
+          name = "tmp"
+          empty_dir {
+            size_limit = var.resources_ephemeral_storage
+          }
+        }
+
+        dynamic "toleration" {
+          for_each = var.tolerations
+          content {
+            key                = lookup(toleration.value, "key", null)
+            operator           = lookup(toleration.value, "operator", null)
+            value              = lookup(toleration.value, "value", null)
+            effect             = lookup(toleration.value, "effect", null)
+            toleration_seconds = lookup(toleration.value, "toleration_seconds", null)
+          }
+        }
+
+        container {
+          name              = "pomerium-console"
+          image             = "${var.image_registry}/${var.image_name}:${var.image_tag}"
+          image_pull_policy = var.image_pull_policy
+
+          args = [
+            "--tls-derive=pomerium-console.${var.namespace_name}.svc.cluster.local",
+            "serve",
+          ]
+
+          env {
+            name  = "AUDIENCE"
+            value = join(",", var.audience)
+          }
+
+          env {
+            name  = "ADMINISTRATORS"
+            value = join(",", var.administrators)
+          }
+
+          env {
+            name  = "DATABROKER_SERVICE_URL"
+            value = "https://pomerium-databroker.${var.core_namespace_name}.svc"
+          }
+
+          env {
+            name = "SHARED_SECRET"
+            value_from {
+              secret_key_ref {
+                name = var.secrets_name
+                key  = "shared_secret_b64"
+              }
+            }
+          }
+
+          env {
+            name = "SIGNING_KEY"
+            value_from {
+              secret_key_ref {
+                name = var.secrets_name
+                key  = "signing_key_b64"
+              }
+            }
+          }
+
+          env {
+            name = "DATABASE_URL"
+            value_from {
+              secret_key_ref {
+                name     = var.secrets_name
+                key      = "database_url"
+                optional = false
+              }
+            }
+          }
+
+          env {
+            name = "DATABASE_ENCRYPTION_KEY"
+            value_from {
+              secret_key_ref {
+                name     = var.secrets_name
+                key      = "database_encryption_key_b64"
+                optional = false
+              }
+            }
+          }
+
+          env {
+            name = "LICENSE_KEY"
+            value_from {
+              secret_key_ref {
+                name     = var.secrets_name
+                key      = "license_key"
+                optional = false
+              }
+            }
+          }
+
+          env {
+            name  = "TMPDIR"
+            value = "/tmp"
+          }
+
+          env {
+            name  = "XDG_CACHE_HOME"
+            value = "/tmp"
+          }
+
+          volume_mount {
+            name       = "tmp"
+            mount_path = "/tmp"
+          }
+
+          port {
+            name           = "app"
+            container_port = 8701
+            protocol       = "TCP"
+          }
+
+          port {
+            name           = "grpc-api"
+            container_port = 8702
+            protocol       = "TCP"
+          }
+
+          resources {
+            limits = {
+              cpu                 = var.resources_limits_cpu
+              memory              = var.resources_limits_memory
+              "ephemeral-storage" = var.resources_ephemeral_storage
+            }
+            requests = {
+              cpu                 = var.resources_requests_cpu
+              memory              = var.resources_requests_memory
+              "ephemeral-storage" = var.resources_ephemeral_storage
+            }
+          }
+
+          security_context {
+            read_only_root_filesystem = true
+            capabilities {
+              drop = ["ALL"]
+              add  = []
+            }
+            allow_privilege_escalation = false
+          }
+        }
+
+        dynamic "container" {
+          for_each = var.sidecars
+          content {
+            name  = container.value.name
+            image = container.value.image
+            args  = container.value.args
+            security_context {
+              run_as_non_root            = true
+              allow_privilege_escalation = false
+              read_only_root_filesystem  = true
+              capabilities {
+                drop = ["ALL"]
+                add  = []
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/terraform/enterprise-k8s/docker_secret.tf
+++ b/terraform/enterprise-k8s/docker_secret.tf
@@ -1,0 +1,20 @@
+resource "kubernetes_secret" "docker_registry" {
+  metadata {
+    name      = var.image_pull_secret
+    namespace = var.namespace_name
+  }
+
+  type = "kubernetes.io/dockerconfigjson"
+
+  data = {
+    ".dockerconfigjson" = jsonencode({
+      auths = {
+        "${var.image_registry}" = {
+          username = var.image_registry_username
+          password = var.image_registry_password
+          auth     = base64encode("${var.image_registry_username}:${var.image_registry_password}")
+        }
+      }
+    })
+  }
+}

--- a/terraform/enterprise-k8s/namespace.tf
+++ b/terraform/enterprise-k8s/namespace.tf
@@ -1,0 +1,5 @@
+resource "kubernetes_namespace" "pomerium-enterprise" {
+  metadata {
+    name = var.namespace_name
+  }
+}

--- a/terraform/enterprise-k8s/secret.tf
+++ b/terraform/enterprise-k8s/secret.tf
@@ -1,0 +1,17 @@
+resource "kubernetes_secret" "console" {
+  metadata {
+    name      = var.secrets_name
+    namespace = var.namespace_name
+  }
+
+  type = "Opaque"
+
+  data = {
+    "license_key"                 = var.license_key
+    "database_url"                = var.database_url
+    "database_encryption_key_b64" = var.database_encryption_key_b64
+    "shared_secret_b64"           = var.shared_secret_b64
+    "signing_key_b64"             = var.signing_key_b64
+  }
+
+}

--- a/terraform/enterprise-k8s/service.tf
+++ b/terraform/enterprise-k8s/service.tf
@@ -1,0 +1,28 @@
+resource "kubernetes_service" "proxy" {
+  metadata {
+    name      = "pomerium-console"
+    namespace = var.namespace_name
+  }
+
+  spec {
+    selector = {
+      "app.kubernetes.io/name" = "pomerium-console"
+    }
+
+    port {
+      name        = "https"
+      port        = 443
+      target_port = "app"
+      protocol    = "TCP"
+    }
+
+    port {
+      name        = "grpc"
+      port        = 5443
+      target_port = "grpc-api"
+      protocol    = "TCP"
+    }
+
+    type = "ClusterIP"
+  }
+}

--- a/terraform/enterprise-k8s/service_account.tf
+++ b/terraform/enterprise-k8s/service_account.tf
@@ -1,0 +1,7 @@
+resource "kubernetes_service_account" "console" {
+  metadata {
+    name        = "pomerium-console"
+    namespace   = var.namespace_name
+    annotations = var.service_account_annotations
+  }
+}

--- a/terraform/enterprise-k8s/variables.tf
+++ b/terraform/enterprise-k8s/variables.tf
@@ -13,7 +13,7 @@ variable "image_name" {
 variable "image_tag" {
   description = "Container image tag"
   type        = string
-  default     = "v0.27.1"
+  default     = "v0.27.2"
 }
 
 variable "image_pull_policy" {

--- a/terraform/enterprise-k8s/variables.tf
+++ b/terraform/enterprise-k8s/variables.tf
@@ -1,0 +1,185 @@
+variable "namespace_name" {
+  description = "The name of the namespace to create"
+  type        = string
+  default     = "pomerium-enterprise"
+}
+
+variable "image_name" {
+  description = "Container image name"
+  type        = string
+  default     = "pomerium/enterprise/pomerium-console"
+}
+
+variable "image_tag" {
+  description = "Container image tag"
+  type        = string
+  default     = "v0.27.1"
+}
+
+variable "image_pull_policy" {
+  description = "Image pull policy"
+  type        = string
+  default     = "IfNotPresent"
+}
+
+variable "image_pull_secret" {
+  description = "Name of the Docker registry secret"
+  type        = string
+  default     = "pomerium-enterprise-docker-registry"
+}
+
+variable "image_registry" {
+  description = "Image registry"
+  type        = string
+  default     = "docker.cloudsmith.io"
+}
+
+variable "image_registry_username" {
+  description = "Docker registry username"
+  type        = string
+  default     = "pomerium/enterprise"
+}
+
+variable "image_registry_password" {
+  description = "Docker registry password"
+  type        = string
+}
+
+variable "tolerations" {
+  description = "List of tolerations for the pods."
+  type = list(object({
+    key                = optional(string)
+    operator           = optional(string, "Equal")
+    value              = optional(string)
+    effect             = optional(string)
+    toleration_seconds = optional(number)
+  }))
+  default = []
+}
+
+variable "audience" {
+  description = "List of audiences"
+  type        = list(string)
+  validation {
+    condition     = length(var.audience) >= 1
+    error_message = "Audience must be provided"
+  }
+}
+
+variable "administrators" {
+  description = "List of administrators (emails). this should only be used for the console bootstrap."
+  type        = list(string)
+  default     = []
+}
+
+variable "core_namespace_name" {
+  description = "The name of the namespace Pomerium Core was deployed to"
+  type        = string
+  default     = "pomerium-ingress-controller"
+}
+
+variable "authenticate_service_url" {
+  description = "The URL of the authenticate service"
+  type        = string
+}
+
+variable "shared_secret_b64" {
+  description = "Shared secret between the core and console, Base64 encoded binary data"
+  type        = string
+  sensitive   = true
+}
+
+variable "signing_key_b64" {
+  description = "PEM encoded signing key for the console, Base64 encoded"
+  type        = string
+  sensitive   = true
+}
+
+variable "database_url" {
+  description = "Postgres database DSN string, may be either URL or key-value format"
+  type        = string
+}
+
+variable "database_encryption_key_b64" {
+  description = "Key used to encrypt database data"
+  type        = string
+  sensitive   = true
+}
+
+variable "license_key" {
+  description = "Pomerium license key"
+  type        = string
+  sensitive   = true
+}
+
+variable "secrets_name" {
+  description = "Name of the secrets"
+  type        = string
+  default     = "enterprise"
+}
+
+
+variable "resources_requests" {
+  description = "Resource requests for the container"
+  type = object({
+    cpu               = string
+    memory            = string
+    ephemeral_storage = string
+  })
+  default = {
+    cpu               = "2"
+    memory            = "4Gi"
+    ephemeral_storage = "4Gi"
+  }
+}
+
+variable "resources_limits_cpu" {
+  description = "Resource CPU limits for the container"
+  type        = string
+  default     = "4"
+}
+
+variable "resources_limits_memory" {
+  description = "Resource RAM limits for the container"
+  type        = string
+  default     = "10Gi"
+}
+
+variable "resources_requests_cpu" {
+  description = "Resource CPU requests for the container"
+  type        = string
+  default     = "2"
+}
+
+variable "resources_requests_memory" {
+  description = "Resource RAM requests for the container"
+  type        = string
+  default     = "4Gi"
+}
+
+variable "resources_ephemeral_storage" {
+  description = "Resource ephemeral storage for the container"
+  type        = string
+  default     = "4Gi"
+}
+
+variable "deployment_replicas" {
+  description = "Number of replicas for the Pomerium Enterprise Deployment"
+  type        = number
+  default     = 1
+}
+
+variable "service_account_annotations" {
+  description = "Name of the service account"
+  type        = map(string)
+  default     = {}
+}
+
+variable "sidecars" {
+  description = "Additional sidecar containers to run in the pod"
+  type = list(object({
+    name  = string
+    image = string
+    args  = list(string)
+  }))
+}


### PR DESCRIPTION
newer versions of kubectl expect an api-version in the kubectl config

related: https://github.com/pomerium/internal/issues/1916


