### PR TITLE
Fix ServiceMonitor in k8s install.md

### DIFF
--- a/content/docs/k8s/install.md
+++ b/content/docs/k8s/install.md
@@ -38,13 +38,13 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: pomerium
-  namespace: pomerium-master-postgres
+  namespace: pomerium
 spec:
   endpoints:
     - port: metrics
   selector:
     matchLabels:
-      app.kubernetes.io/instance: pomerium
+      app.kubernetes.io/name: pomerium
 ```
 
 ## Advanced


### PR DESCRIPTION
1. `app.kubernetes.io/instance` is the wrong label. Current `ServiceMonitor` config doesn't select the right pods.
2. For consistency, change the example namespace.