### PR TITLE
add pomerium.jwt token to the headers page

### DIFF
--- a/content/docs/reference/routes/headers.mdx
+++ b/content/docs/reference/routes/headers.mdx
@@ -195,9 +195,10 @@ The following token substitutions are available:
 
 | **Token** | **Value** |
 | :-- | :-- |
-| `${pomerium.id_token}` | OIDC ID token from the identity provider\* |
 | `${pomerium.access_token}` | OAuth access token from the identity provider\* |
 | `${pomerium.client_cert_fingerprint}` | Short form SHA-256 fingerprint of the presented client certificate (if [downstream mTLS](/docs/capabilities/mtls-clients) is enabled) |
+| `${pomerium.id_token}` | OIDC ID token from the identity provider\* |
+| `${pomerium.jwt}` | [Pomerium JWT](/docs/capabilities/getting-users-identity) (this is the same value as in the `X-Pomerium-Jwt-Assertion` header, when the [Pass Identity Headers](/docs/reference/routes/pass-identity-headers-per-route) option is enabled) |
 
 \*The ID token and access token are not available when using the [Hosted Authenticate](/docs/capabilities/hosted-authenticate-service) service.
 

--- a/content/docs/reference/routes/headers.mdx
+++ b/content/docs/reference/routes/headers.mdx
@@ -198,7 +198,7 @@ The following token substitutions are available:
 | `${pomerium.access_token}` | OAuth access token from the identity provider\* |
 | `${pomerium.client_cert_fingerprint}` | Short form SHA-256 fingerprint of the presented client certificate (if [downstream mTLS](/docs/capabilities/mtls-clients) is enabled) |
 | `${pomerium.id_token}` | OIDC ID token from the identity provider\* |
-| `${pomerium.jwt}` | [Pomerium JWT](/docs/capabilities/getting-users-identity) (this is the same value as in the `X-Pomerium-Jwt-Assertion` header, when the [Pass Identity Headers](/docs/reference/routes/pass-identity-headers-per-route) option is enabled) |
+| `${pomerium.jwt}` | [Pomerium JWT](/docs/capabilities/getting-users-identity) (this is the same value as in the [`X-Pomerium-Jwt-Assertion` header](/docs/reference/routes/pass-identity-headers-per-route)) |
 
 \*The ID token and access token are not available when using the [Hosted Authenticate](/docs/capabilities/hosted-authenticate-service) service.
 


### PR DESCRIPTION
Add the new `${pomerium.jwt}` token to the list of available substitutions for the set_request_headers option on the route Headers Settings page. Alphabetize the rows in this table.

Related issue:
- https://github.com/pomerium/pomerium/issues/5342