### PR TITLE
redirect docs.pomerium.com to www.pomerium.com

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -509,6 +509,11 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 # redirect all the `.io` domains to `com` for latest docs
 http://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
 https://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
+# redirect docs.pomerium.com to www.pomerium.com
+http://docs.pomerium.com/ https://www.pomerium.com/docs 301!
+https://docs.pomerium.com/ https://www.pomerium.com/docs 301!
+http://docs.pomerium.com/docs/* https://www.pomerium.com/docs/:splat 301!
+https://docs.pomerium.com/docs/* https://www.pomerium.com/docs/:splat 301!
 
 https://0-16-0.docs.pomerium.io/ https://0-16-0.docs.pomerium.com/:splat 301!
 https://0-15-0.docs.pomerium.io/ https://0-15-0.docs.pomerium.com/:splat 301!


### PR DESCRIPTION
Related issue:
- https://github.com/pomerium/documentation/issues/214

Unfortunately I don't know if there's any way to test this short of deploying it to production.