### PR TITLE
oidc/azure: add a note to get v2 tokens

### DIFF
--- a/content/docs/identity-providers/azure.mdx
+++ b/content/docs/identity-providers/azure.mdx
@@ -92,7 +92,7 @@ You will use the [**Group ID**](https://docs.microsoft.com/en-us/graph/api/group
 
 :::note
 
-Pomerium uses v2.0 Entra Access Token, make sure your application manifest has [`accessTokenAcceptedVersion`](https://learn.microsoft.com/en-us/entra/identity-platform/reference-app-manifest#accesstokenacceptedversion-attribute) set to `2`. If you use Terraform to configure your Entra application, set [`requested_access_token_version = 2`](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/application.html#requested_access_token_version-1) of an `azuread_application`.
+We recommend using the v2.0 access token format, which you can request by setting the application manifest [`accessTokenAcceptedVersion`](https://learn.microsoft.com/en-us/entra/identity-platform/reference-app-manifest#accesstokenacceptedversion-attribute) attribute to `2`. If you use Terraform to configure your Entra application, set [`requested_access_token_version = 2`](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/application.html#requested_access_token_version-1) in your `azuread_application`.
 
 :::
 


### PR DESCRIPTION
Adds a note to obtain V2 tokens in Microsoft Entra.

Related: https://linear.app/pomerium/issue/ENG-1736/coreoidc-microsoft-entra-returns-v1-tokens-which-have-limited-set-of