### PR TITLE
Add server-side redirect from root to real content

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -519,3 +519,6 @@ https://0-13-0.docs.pomerium.io/ https://0-13-0.docs.pomerium.com/:splat 301!
 https://0-12-0.docs.pomerium.io/ https://0-12-0.docs.pomerium.com/:splat 301!
 https://0-11-0.docs.pomerium.io/ https://0-11-0.docs.pomerium.com/:splat 301!
 https://0-10-0.docs.pomerium.io/ https://0-10-0.docs.pomerium.com/:splat 301!
+
+# Avoid the index flicker in the browser
+/ /docs


### PR DESCRIPTION
In order to avoid loading an index page that immediately replaces the content with content from /docs, we are instructing the web server to 301 redirect to /docs before rendering anything in the browser.

This fixes a blank Index flash that can be seen when visiting docs.pomerium.com without a path like /docs.