### PR TITLE
Fix formating around links and a grammar mistake

### DIFF
--- a/content/docs/concepts/device-identity.md
+++ b/content/docs/concepts/device-identity.md
@@ -26,7 +26,7 @@ Hardware-backed device identity is becoming more widely discussed as more produc
 
 | ![Verge Article Header and Apple Video Page](./img/verge-apple.png) |
 | :-- |
-| **Sources:**<br />- `https://www.theverge.com/2021/6/25/22550376/microsoft-windows-11-tpm-chips-requirement-security`<br/>- `https://developer.apple.com/videos/play/wwdc2021/10106` |
+| **Sources:**<br />- https://www.theverge.com/2021/6/25/22550376/microsoft-windows-11-tpm-chips-requirement-security<br/>- https://developer.apple.com/videos/play/wwdc2021/10106 |
 
 Device identity protects a trusted user from accessing sensitive data from a potentially unsafe device, like their personal computer or phone. Think of it as similar to multi-factor authentication (**MFA**); where MFA covers "what you know" (password) and "who you are" (biometrics, face recognition, etc), device identity asks "is this device safe?" by confirming that the device you are using to access a system is trusted.
 
@@ -46,7 +46,7 @@ Device identity is made possible through trusted execution environment (**TEE**)
 
 Also called platform or internal authenticators, a secure enclave is physically bound to a specific computing device.
 
-- TPM (Trusted Platform Module): These devices are usually built into a product's mainboard, or can be installed in devices with a TPM header, as shown [here][toms-hardware-tpm]. They include a small processor to carry out cryptographic functions on the device, instead of on the system's processor where it could be interfered with. Trust is usually derived from a private key or certificate signed by a trusted manufacture's certificate authority.
+- TPM (Trusted Platform Module): These devices are usually built into a product's mainboard, or can be installed in devices with a TPM header, as shown [here][toms-hardware-tpm]. They include a small processor to carry out cryptographic functions on the device, instead of on the system's processor where it could be interfered with. Trust is usually derived from a private key or certificate signed by a trusted manufacturer's certificate authority.
 
 - Mobile devices: Most newer Apple and Android devices include a [Secure Enclave][apple-enclave] or [Hardware-backed Keystore][android-keystore]
 


### PR DESCRIPTION
Links were unclickable when marked as code, so I removed that, so they hyperlink.