### PR TITLE
Force index redirect

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -521,4 +521,4 @@ https://0-11-0.docs.pomerium.io/ https://0-11-0.docs.pomerium.com/:splat 301!
 https://0-10-0.docs.pomerium.io/ https://0-10-0.docs.pomerium.com/:splat 301!
 
 # Avoid the index flicker in the browser
-/ /docs
+/ /docs 301!


### PR DESCRIPTION
The index page exists, so it needs the forced redirect to avoid loading the shadowed file, per netlify behavior