### PR TITLE
add reference entry for JWT groups filter

### DIFF
--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -701,6 +701,13 @@
     "services": [],
     "type": "slice of string"
   },
+  "jwt-groups-filter": {
+    "id": "jwt-groups-filter",
+    "title": "JWT Groups Filter",
+    "description": "If set, filters the set of group memberships in the Pomerium JWT and Impersonate-Group headers to this subset of groups (based on an exact string match).",
+    "services": [],
+    "type": "array of string"
+  },
   "override-certificate-name": {
     "id": "override-certificate-name",
     "title": "Override Certificate Name",


### PR DESCRIPTION
Add an entry to reference.json with help text for the upcoming JWT groups filter input.

Related issue: https://linear.app/pomerium/issue/ENG-1843/enterprise-console-ui-for-jwt-group-filter