### PR TITLE
docs: improved self-managed example configuration

### DIFF
--- a/content/docs/deploy/core.mdx
+++ b/content/docs/deploy/core.mdx
@@ -149,7 +149,7 @@ shared_secret: REPLACE_ME
 cookie_secret: REPLACE_ME
 
 # If these settings are omitted, the Pomerium Hosted Authenticate Service will be used.
-# idp_provider can be e,g, google
+# idp_provider can be e.g. google
 #
 # idp_provider: REPLACE_ME
 # idp_client_id: REPLACE_ME

--- a/content/docs/deploy/core.mdx
+++ b/content/docs/deploy/core.mdx
@@ -139,6 +139,7 @@ If you prefer building from source:
 Pomerium is configured via [configuration variables](/docs/reference) (environment variables) or a YAML file (`config.yaml`). Below is a minimal example referencing a single route and an identity provider:
 
 ```yaml title="config.yaml"
+# Minimal example route
 #
 # Generate a shared secret by running head -c32 /dev/urandom | base64
 # More on shared secrets at https://www.pomerium.com/docs/reference/shared-secret
@@ -148,8 +149,12 @@ shared_secret: REPLACE_ME
 # More on cookie secrets at https://www.pomerium.com/docs/reference/cookies#cookie-secret
 cookie_secret: REPLACE_ME
 
-# If these settings are omitted, the Pomerium Hosted Authenticate Service will be used.
-# idp_provider can be e.g. google
+# If the Authenticate Service URL is not set, the Pomerium Hosted Authenticate Service will be used.
+# See https://www.pomerium.com/docs/reference/service-urls#authenticate-service-url
+#
+# authenticate_service_url: REPLACE_ME
+#
+# For more information on identity provider settings, see https://pomerium.com/docs/reference/identity-provider-settings
 #
 # idp_provider: REPLACE_ME
 # idp_client_id: REPLACE_ME

--- a/content/docs/deploy/core.mdx
+++ b/content/docs/deploy/core.mdx
@@ -33,7 +33,8 @@ We publish official binaries for Linux and macOS on our [GitHub Releases](https:
 
 ### Standalone Binary
 
-1. **Download** Go to [GitHub Releases](https://github.com/pomerium/pomerium/releases) and look for the tarball corresponding to your operating system and architecture. For example:
+1. **Download**  
+   Go to [GitHub Releases](https://github.com/pomerium/pomerium/releases) and look for the tarball corresponding to your operating system and architecture. For example:
 
    ```bash
    ARCH=[amd64 or arm64]
@@ -43,7 +44,8 @@ We publish official binaries for Linux and macOS on our [GitHub Releases](https:
        | tar -z -x
    ```
 
-2. **Run** Once extracted, you have a `pomerium` binary. Supply configuration via environment variables or a config file:
+2. **Run**  
+   Once extracted, you have a `pomerium` binary. Supply configuration via environment variables or a config file:
 
    ```bash
    ./pomerium -config config.yaml
@@ -115,7 +117,8 @@ If you prefer building from source:
    git clone https://github.com/pomerium/pomerium.git $HOME/pomerium
    cd $HOME/pomerium
    ```
-2. **(Optional) Generate Local Certs** For local development, use [mkcert](https://mkcert.dev/):
+2. **(Optional) Generate Local Certs**  
+   For local development, use [mkcert](https://mkcert.dev/):
    ```bash
    go install filippo.io/mkcert@latest
    mkcert -install
@@ -176,7 +179,8 @@ For local testing, specify the `certificate_file` and `certificate_key_file` if 
 
 If you installed via `rpm` or `deb`, we ship a systemd service unit:
 
-1. **Bind to Port 443** Allow the `pomerium` service to listen on a privileged port:
+1. **Bind to Port 443**  
+   Allow the `pomerium` service to listen on a privileged port:
    ```bash
    echo -e "[Service]\nAmbientCapabilities=CAP_NET_BIND_SERVICE" | sudo SYSTEMD_EDITOR=tee systemctl edit pomerium
    ```

--- a/content/docs/deploy/core.mdx
+++ b/content/docs/deploy/core.mdx
@@ -139,12 +139,22 @@ If you prefer building from source:
 Pomerium is configured via [configuration variables](/docs/reference) (environment variables) or a YAML file (`config.yaml`). Below is a minimal example referencing a single route and an identity provider:
 
 ```yaml title="config.yaml"
-# Minimal example route
+#
+# Generate a shared secret by running head -c32 /dev/urandom | base64
+# More on shared secrets at https://www.pomerium.com/docs/reference/shared-secret
 shared_secret: REPLACE_ME
+
+# Generate a cookie secret by running head -c32 /dev/urandom | base64
+# More on cookie secrets at https://www.pomerium.com/docs/reference/cookies#cookie-secret
 cookie_secret: REPLACE_ME
-idp_provider: google
-idp_client_id: REPLACE_ME
-idp_client_secret: REPLACE_ME
+
+# If these settings are omitted, the out of the box Pomerium Identity Provider (idP) will be used.
+# idp_provider can be e,g, google
+#
+# idp_provider: REPLACE_ME
+# idp_client_id: REPLACE_ME
+# idp_client_secret: REPLACE_ME
+
 address: :443
 
 routes:

--- a/content/docs/deploy/core.mdx
+++ b/content/docs/deploy/core.mdx
@@ -33,8 +33,7 @@ We publish official binaries for Linux and macOS on our [GitHub Releases](https:
 
 ### Standalone Binary
 
-1. **Download**  
-   Go to [GitHub Releases](https://github.com/pomerium/pomerium/releases) and look for the tarball corresponding to your operating system and architecture. For example:
+1. **Download** Go to [GitHub Releases](https://github.com/pomerium/pomerium/releases) and look for the tarball corresponding to your operating system and architecture. For example:
 
    ```bash
    ARCH=[amd64 or arm64]
@@ -44,8 +43,7 @@ We publish official binaries for Linux and macOS on our [GitHub Releases](https:
        | tar -z -x
    ```
 
-2. **Run**  
-   Once extracted, you have a `pomerium` binary. Supply configuration via environment variables or a config file:
+2. **Run** Once extracted, you have a `pomerium` binary. Supply configuration via environment variables or a config file:
 
    ```bash
    ./pomerium -config config.yaml
@@ -117,8 +115,7 @@ If you prefer building from source:
    git clone https://github.com/pomerium/pomerium.git $HOME/pomerium
    cd $HOME/pomerium
    ```
-2. **(Optional) Generate Local Certs**  
-   For local development, use [mkcert](https://mkcert.dev/):
+2. **(Optional) Generate Local Certs** For local development, use [mkcert](https://mkcert.dev/):
    ```bash
    go install filippo.io/mkcert@latest
    mkcert -install
@@ -148,7 +145,7 @@ shared_secret: REPLACE_ME
 # More on cookie secrets at https://www.pomerium.com/docs/reference/cookies#cookie-secret
 cookie_secret: REPLACE_ME
 
-# If these settings are omitted, the out of the box Pomerium Identity Provider (idP) will be used.
+# If these settings are omitted, the Pomerium Hosted Authenticate Service will be used.
 # idp_provider can be e,g, google
 #
 # idp_provider: REPLACE_ME
@@ -179,8 +176,7 @@ For local testing, specify the `certificate_file` and `certificate_key_file` if 
 
 If you installed via `rpm` or `deb`, we ship a systemd service unit:
 
-1. **Bind to Port 443**  
-   Allow the `pomerium` service to listen on a privileged port:
+1. **Bind to Port 443** Allow the `pomerium` service to listen on a privileged port:
    ```bash
    echo -e "[Service]\nAmbientCapabilities=CAP_NET_BIND_SERVICE" | sudo SYSTEMD_EDITOR=tee systemctl edit pomerium
    ```


### PR DESCRIPTION
This improves the example Pomerium configuration file to allow someone to get up and running with Pomerium Core.

Closes #1745

![CleanShot 2025-01-22 at 09 24 19](https://github.com/user-attachments/assets/08a9ae7d-acb7-4cce-b3ee-8a0b2bd684f1)
