### PR TITLE
docs: improved self-managed Docker documentation example

### DIFF
--- a/content/docs/deploy/core.mdx
+++ b/content/docs/deploy/core.mdx
@@ -104,6 +104,10 @@ Example usage:
 ```bash
 # config.yaml is your Pomerium configuration.
 # See https://www.pomerium.com/docs/deploy/core#configuration
+#
+# Note: The external port (8443) can be changed without affecting your route configuration
+# as long as your routes don't specify explicit ports. See
+# https://pomerium.com/docs/reference/routes/from#port-matching-behavior for more information
 docker pull pomerium/pomerium:latest
 docker run --rm -it \
   -p 8443:443 \

--- a/content/docs/deploy/core.mdx
+++ b/content/docs/deploy/core.mdx
@@ -102,8 +102,13 @@ We also provide container images on [Docker Hub](https://hub.docker.com/r/pomeri
 Example usage:
 
 ```bash
+# config.yaml is your Pomerium configuration.
+# See https://www.pomerium.com/docs/deploy/core#configuration
 docker pull pomerium/pomerium:latest
-docker run --rm -it -p 443:443 pomerium/pomerium:latest --version
+docker run --rm -it \
+  -p 8443:443 \
+  -v $(pwd)/config.yaml:/pomerium/config.yaml \
+  pomerium/pomerium:latest
 ```
 
 If you plan to run on port 443 in a rootless environment, you may need extra [capabilities](https://linux-audit.com/linux-capabilities-hardening-linux-binaries-by-removing-setuid/) or choose a non-privileged port.


### PR DESCRIPTION
The PR improves the example docker snippet to demonstrate how to start Pomerium (self-managed) with a Pomerium configuration file.

closes #1746