### PR TITLE
add redirect for /docs/capabilities/hosted-authenticate-service

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -641,6 +641,9 @@ https://0-10-0.docs.pomerium.io/ https://0-10-0.docs.pomerium.com/:splat 301!
 /docs/capabilities/directory-sync                             /docs/integrations/user-standing/directory-sync
 /docs/capabilities/directory-sync.html                        /docs/integrations/user-standing/directory-sync
 
+/docs/capabilities/hosted-authenticate-service               /docs/capabilities/authentication#hosted-authenticate-service
+/docs/capabilities/hosted-authenticate-service.html          /docs/capabilities/authentication#hosted-authenticate-service
+
 /docs/integrations/zenefits                                  /docs/integrations/user-standing/zenefits
 /docs/integrations/zenefits.html                             /docs/integrations/user-standing/zenefits
 


### PR DESCRIPTION
The dedicated Hosted Authenticate Service page was combined with the main Authentication page in https://github.com/pomerium/documentation/pull/1726. Let's add a redirect for the old page URL.