### PR TITLE
chore: update _redirects to match new sitemap (27 vs 28) and reorganized docs

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -232,3 +232,14 @@ https://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
 /docs/capabilities/programmatic-access.html /docs/internals/programmatic-access
 /docs/manage/troubleshooting /docs/internals/troubleshooting
 /docs/manage/troubleshooting.html /docs/internals/troubleshooting
+
+# Additional old capabilities => new locations
+/docs/capabilities/rego /docs/internals/ppl
+/docs/capabilities/namespacing /docs/internals/namespacing
+/docs/capabilities/load-balancing /docs/capabilities/routing
+/docs/capabilities/device-identity /docs/integrations/device-context/device-identity
+/docs/capabilities/single-sign-out /docs/capabilities/authentication
+/docs/capabilities/mtls-clients /docs/internals/mutual-auth
+/docs/capabilities/mtls-services /docs/internals/mutual-auth
+/docs/capabilities/hosted-authenticate-service /docs/deploy/cloud/install
+/docs/capabilities/self-hosted-authenticate-service /docs/capabilities/authentication

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,500 +1,204 @@
-# redirects will process the first matching rule it finds, reading from top to bottom.
+# Netlify Redirects
 # https://docs.netlify.com/routing/redirects/
 
-# Releases
+###############################
+# Domain-level & legacy doc references
+###############################
+
+# Root domain => new docs
+http://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
+https://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
+
+###############################
+# Root => /docs
+###############################
+/ /docs
+
+###############################
+# Releases & Versions
+###############################
 /docs/releases /docs/versions
 /docs/releases/changelog /docs/deploy/upgrading
+/docs/releases/upgrading /docs/deploy/upgrading
 
-# Configuration & Settings Reference
-/docs/reference/reference /docs/reference
-/docs/reference/reference.html /docs/reference
-/docs/configuration/ /docs/reference
-/docs/config-reference.html /docs/reference
-/configuration/ /docs/reference
+# Consolidate old "changelog" => /docs/deploy/upgrading
+/docs/changelog /docs/deploy/upgrading
+/docs/changelog.html /docs/deploy/upgrading
+/docs/CHANGELOG /docs/deploy/upgrading
+/docs/CHANGELOG.html /docs/deploy/upgrading
 
-# Community links
-/community/ /docs/community/
-/community/index.html /docs/community/
-/community/contributing /docs/community/contributing
-/community/contributing.html /docs/community/contributing
-/community/code-of-conduct /docs/community/code-of-conduct
-/community/code-of-conduct.html /docs/community/code-of-conduct
-/community/security /docs/internals/security
-/community/security.html /docs/internals/security
-/docs/community/security /docs/internals/security
-/docs/security /docs/internals/security
-/docs/security.html /docs/internals/security
-/docs/community/security.html /docs/internals/security
+###############################
+# Old debug => new Troubleshooting
+###############################
+/docs/reference/debug /docs/internals/troubleshooting
 
-# Guide and examples
-/guide/ /docs/quick-start/
-/guide/kubernetes.html /docs/deploy/k8s/
-/guide/kubernetes /docs/deploy/k8s/
+###############################
+# Guide references => new pages
+###############################
+/guide/ /docs/get-started/quickstart
+/guide/kubernetes.html /docs/deploy/k8s
+/guide/kubernetes /docs/deploy/k8s
+/docs/deploy/k8s/ /docs/deploy/k8s/quickstart
+
+# Synology
 /guide/synology /docs/guides/synology
 /guide/synology.html /docs/guides/synology
 /docs/quick-start/synology.html /docs/guides/synology
-/docs/guides/jwt-verification /docs/deploy/jwt-verification-with-envoy
-/docs/examples.html /docs/guides
-/docs/examples /docs/guides
 
-# Deprecated guides in v21→v20
-/docs/guides/nginx https://0-20-0.docs.pomerium.com/docs/guides/nginx 301!
-/docs/guides/nginx.html https://0-20-0.docs.pomerium.com/docs/guides/nginx 301!
-/docs/guides/traefik-ingress https://0-20-0.docs.pomerium.com/docs/guides/traefik-ingress 301!
-/docs/guides/traefik-ingress.html https://0-20-0.docs.pomerium.com/docs/guides/traefik-ingress 301!
-/guides/traefik-ingress.html https://0-20-0.docs.pomerium.com/docs/guides/traefik-ingress 301!
-/docs/reference/forward-auth https://0-20-0.docs.pomerium.com/docs/reference/forward-auth 301!
-https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.com/docs/guides
-/docs/reference/policy/allowed-domains https://0-14-0.docs.pomerium.com/reference/#allowed-domains
-/docs/reference/policy/allowed-idp-claims https://0-14-0.docs.pomerium.com/reference/#allowed-idp-claims
-/docs/reference/policy/allowed-groups https://0-14-0.docs.pomerium.com/reference/#allowed-groups
-/docs/reference/policy/allowed-users https://0-14-0.docs.pomerium.com/reference/#allowed-users
-/docs/reference/policy/policy-explanation https://0-14-0.docs.pomerium.com/reference
-/docs/reference/policy/policy-remediation https://0-14-0.docs.pomerium.com/reference
-/docs/reference/policy/policy https://0-14-0.docs.pomerium.com/reference/#policy
+# JWT verification => "getting-users-identity"
+/docs/guides/jwt-verification /docs/capabilities/getting-users-identity
+/docs/guides/jwt-verification.html /docs/capabilities/getting-users-identity
 
-# Removed in v25
-/docs/reference/debug https://0-24-0.docs.pomerium.com/docs/reference/debug
-
-# Helm and Kubernetes to older docs
-/docs/guides/helm https://0-19-0.docs.pomerium.com/docs/guides/helm 301!
-/docs/releases/enterprise/install/helm https://0-19-0.docs.pomerium.com/docs/enterprise/install/helm 301!
-/docs/enterprise/install/helm.html https://0-19-0.docs.pomerium.com/docs/enterprise/install/helm 301!
-/docs/guides/kubernetes https://0-19-0.docs.pomerium.com/docs/guides/kubernetes 301!
-/docs/guides/kubernetes-dashboard https://0-19-0.docs.pomerium.com/docs/guides/kubernetes-dashboard 301!
-/docs/guides/kubernetes-dashboard.html https://0-19-0.docs.pomerium.com/docs/guides/kubernetes-dashboard 301!
-/guides/kubernetes-dashboard.html https://0-19-0.docs.pomerium.com/docs/guides/kubernetes-dashboard 301!
-/recipes/kubernetes.html https://0-20-0.docs.pomerium.com/docs/guides/kubernetes 301!
-
-# Guides → device identity, mTLS, etc.
-/docs/guides/enroll-device /docs/integrations/device-context/device-identity
-/docs/guides/enroll-device.html /docs/integrations/device-context/device-identity
-/docs/guides/admin-enroll-device.html /docs/integrations/device-context/device-identity
-/docs/guides/admin-enroll-device /docs/integrations/device-context/device-identity
-/docs/guides/mtls /docs/capabilities/mtls-clients
-/docs/guides/mtls.html /docs/capabilities/mtls-clients
-/docs/guides/upstream-mtls /docs/capabilities/mtls-services
-/docs/guides/upstream-mtls.html /docs/capabilities/mtls-services
-/guides/tcp /docs/capabilities/non-http
-/recipes/* /docs/guides/:splat
-/category/guides /docs/guides
-
-# Additional /guides/ splats
+# Catch-all for /guides
 /guides/* /docs/guides/:splat
-/docs/guides/tcp /docs/guides/securing-tcp
-/docs/guides/securing-tcp /docs/capabilities/non-http
-/docs/guides/tcp.html /docs/guides/securing-tcp
+
+# Additional direct re-routes
+/docs/guides/tcp /docs/capabilities/non-http
 /guides/vs-code-server.html /docs/guides/code-server
 /docs/guides/vs-code-server.html /docs/guides/code-server
 /guides/local-oidc.html /docs/guides/local-oidc
-/docs/guides/local-oidc /docs/integrations/user-identity/identity-providers/oidc
-/docs/integrations/user-identity/identity-providers/dex-freeipa /docs 410
+/docs/guides/local-oidc /docs/integrations/user-identity/oidc
 
-# Reference and concepts
-/docs/reference/readme.html /docs/
-/docs/concepts/namespacing /docs/internals/namespacing
-/docs/concepts/policies /docs/internals/glossary#policy
-/docs/concepts/routes /docs/internals/glossary#route
-/docs/concepts/service-accounts /docs/internals/glossary#service-account
-/docs/reference/certificates.html /docs/topics/certificates
-/docs/topics/certificates /docs/concepts/certificates
-/docs/concepts/certificates /docs/internals/certificates-and-tls
+###############################
+# Programmatic access
+###############################
+/docs/reference/programmatic-access.html /docs/capabilities/programmatic-access
 
-# Multi-hop data-storage link
-/docs/reference/data-storage.html /docs/topics/data-storage
-/docs/topics/data-storage /docs/concepts/data-storage
-/docs/concepts/data-storage /docs/internals/data-storage
-/docs/topics/data-storage.html /docs/internals/data-storage
+###############################
+# Enterprise => /docs/deploy/enterprise
+###############################
+/enterprise /docs/deploy/enterprise
+/docs/enterprise /docs/deploy/enterprise
 
-# Multi-hop getting-users-identity
-/docs/reference/getting-users-identity.html /docs/topics/getting-users-identity
-/docs/topics/getting-users-identity /docs/concepts/getting-users-identity
-/docs/concepts/getting-users-identity /docs/capabilities/getting-users-identity
-/docs/topics/getting-users-identity.html /docs/capabilities/getting-users-identity
-
-# Old production-deployment references to 410
-/docs/reference/production-deployment.html /docs 410
-/docs/topics/production-deployment /docs 410
-/docs/topics/production-deployment.html /docs 410
-/docs/production-deployment /docs 410
-/docs/production-deployment.html /docs 410
-/docs/production/security /docs 410
-/docs/production/production-deployment /docs 410
-
-# Multi-hop programmatic-access
-/docs/reference/programmatic-access.html /docs/topics/programmatic-access
-/docs/topics/programmatic-access /docs/concepts/programmatic-access
-/docs/concepts/programmatic-access /docs/capabilities/programmatic-access
-/docs/topics/programmatic-access.html /docs/capabilities/programmatic-access
-
-# Blog posts
-/posts/2020/06/01/release-0-9/ /blog/posts-2020-06-01-release-0-9/
-/posts/2020/05/11/release-0-8/ /blog/announcing-pomerium-0-8/
-/posts/2020/04/16/release-0-7/ /blog/announcing-pomerium-0-7/
-/blog/tag/releases /blog
-/blog/tag/tcp /blog
-/blog/tag/kubernetes /blog
-/blog/tag/istio /blog
-/blog/author/pomerium/feed /blog
-
-# Careers
-/jobs/ /careers/
-/jobs/Frontend-Engineer.html /careers/frontend-engineer/
-/jobs/Backend-Engineer.html /careers/backend-engineer/
-
-# Enterprise links
-/enterprise/ /docs/enterprise
-/docs/enterprise /docs/releases/enterprise/about
-/enterprise/service-accounts/ /docs/capabilities/service-accounts
+# Old service-accounts => new capabilities
+/enterprise/service-accounts /docs/capabilities/service-accounts
 /enterprise/service-accounts.html /docs/capabilities/service-accounts
-/enterprise/prometheus.html /docs/capabilities/metrics
-/enterprise/prometheus /docs/capabilities/metrics
-/docs/enterprise/reference/ /docs/enterprise/configure
-/docs/enterprise/reference/configure /docs/enterprise/configure
-/docs/enterprise/reference/configure.html /docs/enterprise/configure
-/docs/enterprise/reference/config /docs/enterprise/configure
-/docs/enterprise/reference/config.html /docs/enterprise/configure
-/enterprise/reference/configure.html /docs/enterprise/configure
-/enterprise/reference/config.html /docs/enterprise/configure
-/enterprise/concepts.html /docs/concepts/access-control
-/docs/enterprise/about /docs/releases/enterprise
-/docs/releases/enterprise /docs/releases/enterprise/about
-/docs/releases/enterprise/about /docs/enterprise
-/enterprise/reference/reports.html /docs/capabilities/reports
-/docs/capabilities/reports /docs/capabilities/metrics
 
-/enterprise/install/helm.html /docs/guides/helm
-/enterprise/* /docs/enterprise/:splat
+# Old Prometheus references => new "configure-metrics"
+/enterprise/prometheus /docs/deploy/enterprise/configure-metrics
+/enterprise/prometheus.html /docs/deploy/enterprise/configure-metrics
 
-# v22 structure
-/docs/releases/upgrading /docs/deploy/upgrading
-/docs/deploying/binary /docs/deploy/core/binary
-/docs/deploying/from-source /docs/deploy/core/from-source
-/enterprise/about /docs/enterprise
-/docs/enterprise/about /docs/enterprise
-/docs/releases/enterprise /docs/enterprise
-/docs/enterprise/install/installation /docs/enterprise/install
-/docs/releases/enterprise/install/quickstart /docs/enterprise/quickstart
-/docs/deploy /docs
-/docs/deploy/production-deployment /docs 410
-/docs/deploying/production-deployment /docs 410
-/docs/releases/* /docs/deploy/:splat
-/docs/deploying/* /docs/deploy/:splat
+# Old "concepts" => "authentication"
+/docs/enterprise/concepts.html /docs/capabilities/authentication
+/docs/enterprise/concepts /docs/capabilities/authentication
 
-# Client redirects
-/docs/deploy/pomerium-cli /docs/deploy/clients/pomerium-cli
-/docs/deploy/pomerium-desktop /docs/deploy/clients/pomerium-desktop
-/docs/deploy/clients /docs/clients
-/docs/deploy/clients/* /docs/clients/:splat
+# Old "about" => enterprise root
+/docs/enterprise/about /docs/deploy/enterprise
 
-# Zero restructure
-/docs/deploy/enterprise /docs/enterprise
-/docs/deploy/enterprise/* /docs/enterprise/:splat
-# The next two lines are effectively no-ops; removing to avoid confusion
-# /docs/deploy/core /docs/deploy/core
-# /docs/deploy/core/* /docs/deploy/core/:splat
-/docs/deploy/k8s /docs/deploy/k8s/quickstart
-/docs/deploy/k8s/* /docs/deploy/k8s/:splat
+# Old "reports" => "audit-logs"
+/docs/capabilities/reports /docs/capabilities/audit-logs
+
+# Enterprise quickstart
+/docs/enterprise/install/quickstart /docs/deploy/enterprise/quickstart
+/docs/enterprise/install/quickstart.html /docs/deploy/enterprise/quickstart
+/docs/enterprise/install /docs/deploy/enterprise/quickstart
+/enterprise/install/ /docs/deploy/enterprise/quickstart
+
+# Old enterprise changelog => new /docs/versions
+/docs/enterprise/changelog /docs/versions
+/docs/enterprise/changelog.html /docs/versions
+
+# Catch-all for enterprise subpaths
+/enterprise/* /docs/deploy/enterprise/:splat
+
+###############################
+# Clients
+###############################
+/docs/deploy/pomerium-cli /docs/deploy/clients
+/docs/deploy/pomerium-desktop /docs/deploy/clients
+/docs/deploy/clients /docs/deploy/clients
+/docs/deploy/clients/* /docs/deploy/clients
+
+###############################
+# Zero references
+###############################
 /docs/zero/cluster-status /docs/troubleshooting/cluster-status
-/docs/zero/upgrading /docs/get-started/quickstart
+/docs/zero/upgrading /docs/deploy/upgrading
 
-# Installation and deployment
-/docs/installation.html /docs/get-started/quickstart
-/docs/installation /docs/get-started/quickstart
+###############################
+# Old "quickstart" => /get-started/quickstart
+###############################
 /docs/quick-start /docs/get-started/quickstart
+/docs/quickstart /docs/get-started/quickstart
 /docs/install /docs/get-started/quickstart
+/docs/installation /docs/get-started/quickstart
+/docs/installation.html /docs/get-started/quickstart
+
+# Binary / from-source => /docs/deploy/core
+/docs/deploying/binary /docs/deploy/core
+/docs/deploying/from-source /docs/deploy/core
+/docs/releases/core /docs/deploy/core
+/docs/install/binary /docs/deploy/core
+/docs/install/binary.html /docs/deploy/core
 /docs/quick-start/binary /docs/deploy/core
 /docs/quick-start/binary.html /docs/deploy/core
-/docs/install/binary /docs/deploy/core
-/docs/releases/core /docs/deploy/core
-/docs/install/binary.html /docs/deploy/core/binary
 
-# Consolidate Helm links → /docs/guides/helm
-/docs/quick-start/helm.html /docs/guides/helm
-/docs/enterprise/install/helm /docs/guides/helm
-/docs/install/helm.html /docs/guides/helm
-/docs/install/helm /docs/guides/helm
+# Helm references
+/docs/quick-start/helm.html /docs/deploy/k8s/helm
 /docs/deploy/k8s/helm /docs/guides/helm
+/docs/enterprise/install/helm /docs/guides/helm
+/docs/install/helm /docs/guides/helm
+/docs/install/helm.html /docs/guides/helm
 /docs/deploy/k8s/helm.html /docs/guides/helm
 
-# From-source
-/docs/quick-start/from-source.html /docs/install/from-source
-/docs/install/from-source /docs/deploying/from-source
-/docs/install/from-source.html /docs/deploying/from-source
+# From-source => /docs/deploy/core
+/docs/quick-start/from-source.html /docs/deploy/core
+/docs/install/from-source /docs/deploy/core
+/docs/install/from-source.html /docs/deploy/core
 
-# Enterprise and Core quickstarts
-/docs/install/quickstart /docs/get-started/quickstart
-/docs/enterprise/install/quickstart /docs/enterprise/quickstart
-/docs/enterprise/install/quickstart.html /docs/enterprise/quickstart
-/docs/enterprise/install /docs/enterprise/quickstart
-/enterprise/install/ /docs/enterprise/quickstart
-
-/docs/enterprise/concepts /docs/capabilities/authentication
-/docs/enterprise/concepts.html /docs/capabilities/authentication
-/docs/enterprise/reference/manage /docs/capabilities/authentication
-/docs/enterprise/reference/manage.html /docs/capabilities/authentication
-/docs/enterprise/reference/reports /docs/capabilities/reports
-/docs/enterprise/external-data /docs/integrations/
-/docs/integrations /docs/capabilities/integrations
-/docs/enterprise/branding /docs/capabilities/branding
-/docs/enterprise/branding/logo /docs/capabilities/branding#logo
-/docs/enterprise/branding/colors /docs/capabilities/branding#colors
-/docs/enterprise/branding/error_details /docs/capabilities/branding#error-details
-/docs/enterprise/api.html /docs/capabilities/enterprise-api
-/docs/enterprise/api /docs/capabilities/enterprise-api
-
-# Enterprise IdP → user-identity
-/docs/enterprise/identity-providers/* /docs/integrations/user-identity/identity-providers/:splat
-
-# External data → /docs/integrations
-/docs/enterprise/external-data/* /docs/integrations/:splat
-
-# TCP links
-/topics/tcp-support.html /docs/tcp
-/docs/topics/tcp-support.html /docs/tcp/
+###############################
+# TCP & Non-HTTP
+###############################
 /docs/tcp /docs/capabilities/non-http
-/docs/topics/tcp-support /docs/tcp/
-/docs/tcp /docs/capabilities/non-http
-
-# /docs/client.html multi-hop
-/docs/client.html /docs/tcp/client
-/docs/tcp/client.html /docs/capabilities/non-http/client
 /docs/tcp/client /docs/capabilities/non-http/client
-
+/docs/tcp/client.html /docs/capabilities/non-http/client
 /docs/capabilities/non-http/tcp-cli-reference /docs/capabilities/non-http
 /docs/capabilities/non-http/examples/service-template.html /docs/capabilities/non-http
 /docs/tcp/examples/* /docs/capabilities/non-http/examples/:splat
 /docs/tcp/* /docs/capabilities/non-http/examples/:splat
 
-# Enterprise metrics
-/docs/enterprise/metrics.html /docs/capabilities/metrics
-/docs/enterprise/metrics /docs/capabilities/metrics
+###############################
+# /examples/
+###############################
+/examples/js-sdk/express-server /docs/capabilities/getting-users-identity
 
-# JS/Go examples → JWT docs
-/examples/js-sdk/express-server /docs/capabilities/jwt-verification
-/docs/guides/js-sdk /docs/capabilities/jwt-verification
-/docs/capabilities/jwt-verification /docs/capabilities/getting-users-identity.mdx
-
-# Kubernetes
-/docs/topics/kubernetes-integration.html /docs/deploy/k8s/
+###############################
+# K8s references
+###############################
+/docs/topics/kubernetes-integration.html /docs/deploy/k8s
 /docs/deploying/k8s/install /docs/deploy/k8s/install
 /docs/quick-start/kubernetes.html /docs/deploy/k8s/quickstart
-/docs/deploy/k8s/configure /docs/deploying/k8s/configure
-/docs/topics/kubernetes-integration /docs/deploying/k8s/quickstart
+/docs/deploy/k8s/configure /docs/deploy/k8s/configure
+/docs/topics/kubernetes-integration /docs/deploy/k8s/quickstart
 /docs/topics/ingress /docs/deploy/k8s/ingress
-/kubernetes/ /docs/deploying/k8s/quickstart
+/kubernetes/ /docs/deploy/k8s/quickstart
 
-# Troubleshooting and FAQ
-/docs/FAQ.html /docs/troubleshooting
-/docs/internals/troubleshooting /docs/troubleshooting
-/docs/internals/troubleshooting.html /docs/troubleshooting
-/docs/faq /docs/troubleshooting
+###############################
+# Troubleshooting & FAQ
+###############################
+/docs/FAQ.html /docs/internals/troubleshooting
+/docs/faq /docs/internals/troubleshooting
+/docs/internals/troubleshooting /docs/internals/troubleshooting
+/docs/internals/troubleshooting.html /docs/internals/troubleshooting
 
-# Glossary multi-hop
-/docs/glossary.html /docs/overview/glossary
-/docs/glossary /docs/internals/glossary
-/docs/overview/glossary /docs/internals/glossary
-
-# Architecture, background, upgrading, changelog
-/docs/releases.html /docs/overview/releases
-/docs/overview/releases /docs/releases
-/docs/architecture.html /docs/overview/architecture
-/docs/overview/architecture /docs/internals/architecture
+###############################
+# Architecture / background / upgrading
+###############################
+/docs/architecture.html /docs/internals/architecture
 /docs/architecture /docs/internals/architecture
-/docs/background /docs/concepts/zero-trust
-/docs/background.html /docs/overview/background
-/docs/overview/background /docs/concepts/zero-trust
-/docs/upgrading.html /docs/overview/upgrading
-/docs/upgrading /docs/releases/upgrading
-/docs/changelog.html /docs/overview/changelog
-/docs/changelog /docs/overview/changelog
-/docs/overview/changelog /docs/releases/changelog
-/docs/CHANGELOG /docs/releases/changelog
-/docs/CHANGELOG.html /docs/deploy/enterprise/changelog
+/docs/background /docs/internals/zero-trust
+/docs/background.html /docs/internals/zero-trust
+/docs/upgrading.html /docs/deploy/upgrading
+/docs/upgrading /docs/deploy/upgrading
 
-# Autocert
-/docs/reference/autocert/autocert-ca /docs/reference/autocert#autocert-ca
-/docs/reference/autocert-directory /docs/reference/autocert#autocert-directory
-/docs/reference/autocert/autocert-directory /docs/reference/autocert#autocert-directory
-/docs/reference/autocert/autocert-eab-mac-key /docs/reference/autocert#autocert-eab-mac-key
-/docs/reference/autocert/autocert-eab-key-id /docs/reference/autocert#autocert-eab-key-id
-/docs/reference/autocert/autocert-email /docs/reference/autocert#autocert-email
-/docs/reference/autocert/autocert-must-staple /docs/reference/autocert#autocert-must-staple
-/docs/reference/autocert/autocert-trusted-certificate-authority /docs/reference/autocert#autocert-trusted-certificate-authority
-/docs/reference/autocert/autocert-use-staging /docs/reference/autocert#autocert-use-staging
-
-# Databroker
-/docs/reference/data-broker-internal-service-url /docs/reference/service-urls#data-broker-internal-service-url
-/docs/reference/data-broker-service /docs/reference/databroker
-/docs/reference/data-broker-service-url /docs/reference/service-urls#data-broker-service-url
-/docs/reference/data-broker-storage-certificate-authority /docs/reference/databroker
-/docs/reference/data-broker-storage-certificate-file /docs/reference/databroker
-/docs/reference/data-broker-storage-certificate-key-file /docs/reference/databroker
-/docs/reference/data-broker-storage-connection-string /docs/reference/databroker#databroker-storage-connection-string
-/docs/reference/data-broker-storage-tls-skip-verify /docs/reference/databroker
-/docs/reference/data-broker-storage-type /docs/reference/databroker#databroker-storage-type
-
-# Cookies
-/docs/reference/cookie-domain /docs/reference/cookies#cookie-domain
-/docs/reference/expiration /docs/reference/cookies#expiration
-/docs/reference/cookie-http-only /docs/reference/cookies#cookie-http-only
-/docs/reference/cookie-name /docs/reference/cookies#cookie-name
-/docs/reference/cookie-same-site /docs/reference/cookies#cookie-samesite
-/docs/reference/cookie-secret-file /docs/reference/cookies#cookie-secret-file
-/docs/reference/cookie-secret /docs/reference/cookies#cookie-secret
-/docs/reference/cookie-secure /docs/reference/cookies#cookie-secure
-/docs/reference/https-only /docs/reference/cookies#cookie-secure
-/docs/reference/javascript-security /docs/reference/cookies#javascript-security
-/docs/reference/cookie-expire /docs/reference/cookies#cookie-expire
-
-# IdP Settings
-/docs/reference/identity-provider-client-id /docs/reference/identity-provider-settings#identity-provider-client-id
-/docs/reference/identity-provider-client-secret /docs/reference/identity-provider-settings#identity-provider-client-secret
-/docs/reference/identity-provider-client-secret-file /docs/reference/identity-provider-settings#identity-provider-client-secret-file
-/docs/reference/identity-provider-name /docs/reference/identity-provider-settings#identity-provider-name
-/docs/reference/identity-provider-request-params /docs/reference/identity-provider-settings#identity-provider-request-params
-/docs/reference/identity-provider-scopes /docs/reference/identity-provider-settings#identity-provider-scopes
-/docs/reference/identity-provider-url /docs/reference/identity-provider-settings#identity-provider-url
-/docs/reference/identity-provider-refresh-directory-settings /docs/releases/upgrading#idp-directory-sync
-
-# Certificates
-/docs/reference/certificate-authority /docs/reference/certificates#certificate-authority
-/docs/reference/certificates /docs/reference/certificates#certificates
-/docs/reference/client-certificate-authority /docs/reference/downstream-mtls-settings#ca
-/docs/reference/client-crl /docs/reference/downstream-mtls-settings#crl
-
-# Branding
-/docs/reference/branding/darkmode-primary-color /docs/reference/branding#darkmode-primary-color
-/docs/reference/branding/darkmode-secondary-color /docs/reference/branding#darkmode-secondary-color
-/docs/reference/branding/error-message-first-paragraph /docs/reference/branding#error-message-first-paragraph
-/docs/reference/branding/favicon-url /docs/reference/branding#favicon-url
-/docs/reference/branding/logo-url /docs/reference/branding#logo-url
-/docs/reference/branding/primary-color /docs/reference/branding#primary-color
-/docs/reference/branding/secondary-color /docs/reference/branding#secondary-color
-
-# TLS
-/docs/reference/routes/tls-server-name /docs/reference/routes/tls#tls-upstream-server-name
-/docs/reference/tls-upstream-server-name /docs/reference/routes/tls#tls-upstream-server-name
-/docs/reference/routes/tls-upstream-server-name /docs/reference/routes/tls#tls-upstream-server-name
-/docs/reference/tls-downstream-server-name /docs/reference/routes/tls#tls-downstream-server-name
-/docs/reference/routes/tls-downstream-server-name /docs/reference/routes/tls#tls-downstream-server-name
-/docs/reference/routes/tls-client-certificate /docs/reference/routes/tls#tls-client-certificate
-/docs/reference/routes/tls-custom-certificate-authority /docs/reference/routes/tls#tls-custom-certificate-authority
-/docs/reference/routes/tls-downstream-client-certificate-authority /docs/reference/routes/tls#tls-downstream-client-certificate-authority
-/docs/reference/routes/tls-skip-verification /docs/reference/routes/tls#tls-skip-verification
-/docs/reference/routes/tls-upstream-allow-renegotiation /docs/reference/routes/tls#tls-upstream-allow-renegotiation
-
-# Metrics
-/docs/reference/metrics-client-certificate-authority /docs/reference/metrics#metrics-client-certificate-authority
-/docs/reference/metrics-address /docs/reference/metrics#metrics-address
-/docs/reference/metrics-basic-authentication /docs/reference/metrics#metrics-basic-authentication
-/docs/reference/metrics-certificate /docs/reference/metrics#metrics-certificate
-
-# gRPC
-/docs/reference/grpc-client-dns-roundrobin /docs/reference/grpc
-/docs/reference/grpc-address /docs/reference/grpc#grpc-address
-/docs/reference/grpc-insecure /docs/reference/grpc#grpc-insecure
-/docs/reference/grpc-client-timeout /docs/reference/grpc#grpc-client-timeout
-
-# Headers
-/docs/reference/routes/host-rewrite /docs/reference/routes/headers#host-rewrite
-/docs/reference/routes/set-request-headers /docs/reference/routes/headers#set-request-headers
-/docs/reference/routes/remove-request-headers /docs/reference/routes/headers#remove-request-headers
-/docs/reference/routes/set-response-headers /docs/reference/routes/headers#set-response-headers
-/docs/reference/routes/rewrite-response-headers /docs/reference/routes/headers#rewrite-response-headers
-/docs/reference/routes/set-authorization-header /docs/reference/routes/headers#set-authorization-header
-
-# Timeouts
-/docs/reference/default-upstream-timeout /docs/reference/global-timeouts#default-upstream-timeout
-/docs/reference/routes/websocket-connections /docs/reference/routes/timeouts#websocket-connections
-/docs/reference/routes/spdy /docs/reference/routes/timeouts#spdy
-/docs/reference/routes/route-timeout /docs/reference/routes/timeouts#route-timeout
-/docs/reference/routes/idle-timeout /docs/reference/routes/timeouts#idle-timeout
-
-# Path Matching
-/docs/reference/routes/path /docs/reference/routes/path-matching#path
-/docs/reference/routes/prefix /docs/reference/routes/path-matching#prefix
-/docs/reference/routes/regex /docs/reference/routes/path-matching#regex
-
-# Path Rewriting
-/docs/reference/routes/prefix-rewrite /docs/reference/routes/path-rewriting#prefix-rewrite
-/docs/reference/routes/regex-rewrite /docs/reference/routes/path-rewriting#regex-rewrite
-
-# Load Balancer
-/docs/reference/routes/load-balancing-policy /docs/reference/routes/load-balancing#load-balancing-policy
-/docs/reference/routes/health-checks /docs/reference/routes/load-balancing#health-checks
-
-/docs/reference/default-upstream-timeout /docs/reference/default-upstream-timeout
-/docs/reference/identity-provider-service-account /docs/releases/upgrading
-/docs/reference/routes/signout-redirect-url /docs/reference/signout-redirect-url
-/reference/* /docs/reference/:splat
-
-# Pass Identity Headers
-/docs/reference/global-pass-identity-headers /docs/reference/pass-identity-headers
-/docs/reference/routes/pass-identity-headers /docs/reference/routes/pass-identity-headers-per-route
-
-# X-Forwarded-For
-/docs/reference/x-forwarded-for-http-header /docs/reference/x-forwarded-for-settings#skip-xff-append
-/docs/reference/the-number-of-trusted-hops /docs/reference/x-forwarded-for-settings#xff-number-of-trusted-hops
-
-# Signing Key
-/docs/reference/signing-key-file /docs/reference/signing-key
-
-# Shared Secret
-/docs/reference/shared-secret-file /docs/reference/shared-secret
-
-# Topics → new pages
-/docs/topics/auth-logs /docs/capabilities/audit-logs
-/docs/topics/single-sign-out.html /docs/capabilities/single-sign-out
-/docs/topics/single-sign-out /docs/capabilities/single-sign-out
-/docs/topics/original-request-context.html /docs/concepts/original-request-context
-/docs/concepts/original-request-context /docs/capabilities/original-request-context
-/docs/topics/load-balancing.html /docs/capabilities/routing
-/docs/topics/certificates /docs/concepts/certificates
-/docs/certificates.html /docs/concepts/certificates
-/docs/topics/impersonation.html /docs/concepts/impersonation
-/docs/concepts/impersonation /docs/capabilities/service-accounts
-/docs/topics/ /docs/concepts/access-control
-/docs/topics/* /docs/concepts/:splat 301!
-/docs/topics/device-identity /docs/concepts/device-identity
-/docs/topics/mutual-auth /docs/internals/mutual-auth
-/docs/topics/original-request-context /docs/concepts/original-request-context
-/docs/concepts/original-request-context /docs/capabilities/original-request-context
-/docs/topics/ppl /docs/concepts/ppl
-/docs/concepts/ppl /docs/internals/ppl
-/docs/topics/ppl.html /docs/concepts/ppl.html
-/docs/concepts/ppl.html /docs/internals/ppl.html
-/docs/topics/load-balancing /docs/concepts/load-balancing
-/docs/concepts/load-balancing /docs/capabilities/routing
-
-# Flattened changelog & upgrading
-/docs/overview/upgrading/archive /docs/overview/upgrading
-/docs/overview/changelog/archive /docs/overview/upgrading
-/docs/overview/upgrading /docs/releases/upgrading
-/enterprise/changelog /docs/releases/enterprise/changelog
-/docs/enterprise/changelog /docs/releases/enterprise/changelog
-/docs/enterprise/changelog.html /docs/releases/enterprise/changelog
-
-# Domain-level
-http://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
-https://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
-
-https://0-16-0.docs.pomerium.io/ https://0-16-0.docs.pomerium.com/:splat 301!
-https://0-15-0.docs.pomerium.io/ https://0-15-0.docs.pomerium.com/:splat 301!
-https://0-14-0.docs.pomerium.io/ https://0-14-0.docs.pomerium.com/:splat 301!
-https://0-13-0.docs.pomerium.io/ https://0-13-0.docs.pomerium.com/:splat 301!
-https://0-12-0.docs.pomerium.io/ https://0-12-0.docs.pomerium.com/:splat 301!
-https://0-11-0.docs.pomerium.io/ https://0-11-0.docs.pomerium.com/:splat 301!
-https://0-10-0.docs.pomerium.io/ https://0-10-0.docs.pomerium.com/:splat 301!
-
-# Avoid flicker
-/ /docs
-
-# Newly renamed pages (post-2024 reorg)
+###############################
+# Newly renamed pages
+###############################
 /_generate-recovery-token /docs/admonitions/_generate-recovery-token
 /_generate-recovery-token.html /docs/admonitions/_generate-recovery-token
 /_install-mkcert /docs/admonitions/_install-mkcert
 /_install-mkcert.html /docs/admonitions/_install-mkcert
+
 /docs/manage/custom-domains /docs/capabilities/custom-domains
 /docs/manage/custom-domains.html /docs/capabilities/custom-domains
 
@@ -518,7 +222,6 @@ https://0-10-0.docs.pomerium.io/ https://0-10-0.docs.pomerium.com/:splat 301!
 /docs/get-started/fundamentals/self-hosted-pomerium.html /docs/get-started/fundamentals/core/self-hosted-pomerium
 /docs/get-started/fundamentals/tcp-routes /docs/get-started/fundamentals/core/tcp-routes
 /docs/get-started/fundamentals/tcp-routes.html /docs/get-started/fundamentals/core/tcp-routes
-
 /docs/get-started/fundamentals/zero-advanced-policies /docs/get-started/fundamentals/zero/zero-advanced-policies
 /docs/get-started/fundamentals/zero-advanced-policies.html /docs/get-started/fundamentals/zero/zero-advanced-policies
 /docs/get-started/fundamentals/zero-advanced-routes /docs/get-started/fundamentals/zero/zero-advanced-routes
@@ -534,8 +237,10 @@ https://0-10-0.docs.pomerium.io/ https://0-10-0.docs.pomerium.com/:splat 301!
 /docs/get-started/fundamentals/zero-tcp-routes /docs/get-started/fundamentals/zero/zero-tcp-routes
 /docs/get-started/fundamentals/zero-tcp-routes.html /docs/get-started/fundamentals/zero/zero-tcp-routes
 
-/docs/integrations/integrations /docs/integrations
-/docs/integrations/integrations.html /docs/integrations
+/docs/integrations/integrations /docs/capabilities/integrations
+/docs/integrations/integrations.html /docs/capabilities/integrations
+
+# Fleets, geoip, ip-ranges => new "request-context" or "device-context"
 /docs/integrations/fleetdm /docs/integrations/device-context/fleetdm
 /docs/integrations/fleetdm.html /docs/integrations/device-context/fleetdm
 /docs/integrations/geoip /docs/integrations/request-context/geoip
@@ -546,6 +251,8 @@ https://0-10-0.docs.pomerium.io/ https://0-10-0.docs.pomerium.com/:splat 301!
 /docs/integrations/tor-exit-nodes.html /docs/integrations/request-context/tor-exit-nodes
 /docs/integrations/vpn-providers /docs/integrations/request-context/vpn-providers
 /docs/integrations/vpn-providers.html /docs/integrations/request-context/vpn-providers
+
+# OIDC, Okta, Ping, etc. => new "user-identity"
 /docs/integrations/apple /docs/integrations/user-identity/apple
 /docs/integrations/apple.html /docs/integrations/user-identity/apple
 /docs/integrations/auth0 /docs/integrations/user-identity/auth0
@@ -568,6 +275,8 @@ https://0-10-0.docs.pomerium.io/ https://0-10-0.docs.pomerium.com/:splat 301!
 /docs/integrations/one-login.html /docs/integrations/user-identity/one-login
 /docs/integrations/ping /docs/integrations/user-identity/ping
 /docs/integrations/ping.html /docs/integrations/user-identity/ping
+
+# BambooHR, directory-sync => user-standing
 /docs/integrations/bamboohr /docs/integrations/user-standing/bamboohr
 /docs/integrations/bamboohr.html /docs/integrations/user-standing/bamboohr
 /docs/capabilities/directory-sync /docs/integrations/user-standing/directory-sync
@@ -575,6 +284,7 @@ https://0-10-0.docs.pomerium.io/ https://0-10-0.docs.pomerium.com/:splat 301!
 /docs/integrations/zenefits /docs/integrations/user-standing/zenefits
 /docs/integrations/zenefits.html /docs/integrations/user-standing/zenefits
 
+# TLS, clusters, mutual-auth => new "internals"
 /docs/capabilities/certificates-and-tls /docs/internals/certificates-and-tls
 /docs/capabilities/certificates-and-tls.html /docs/internals/certificates-and-tls
 /docs/manage/clusters /docs/internals/clusters
@@ -585,23 +295,19 @@ https://0-10-0.docs.pomerium.io/ https://0-10-0.docs.pomerium.com/:splat 301!
 /docs/capabilities/enterprise-api.html /docs/internals/management-api-enterprise
 /docs/deploy/cloud/api-guide /docs/internals/management-api-zero
 /docs/deploy/cloud/api-guide.html /docs/internals/management-api-zero
-/docs/capabilities/metrics /docs/internals/metrics
-/docs/capabilities/metrics.html /docs/internals/metrics
 /docs/manage/mutual-auth /docs/internals/mutual-auth
 /docs/manage/mutual-auth.html /docs/internals/mutual-auth
+
+# "metrics" => internals or enterprise config
+/docs/capabilities/metrics /docs/internals/metrics
+/docs/capabilities/metrics.html /docs/internals/metrics
+
+# PPL, programmatic
 /docs/capabilities/ppl /docs/internals/ppl
 /docs/capabilities/ppl.html /docs/internals/ppl
 /docs/capabilities/programmatic-access /docs/internals/programmatic-access
 /docs/capabilities/programmatic-access.html /docs/internals/programmatic-access
+
+# Troubleshooting
 /docs/manage/troubleshooting /docs/internals/troubleshooting
 /docs/manage/troubleshooting.html /docs/internals/troubleshooting
-
-# Additional fixes for pages that 404 after reorg
-/docs/quickstart /docs/get-started/quickstart
-/docs/capabilities/tcp /docs/capabilities/non-http
-/docs/capabilities/tcp/examples/* /docs/capabilities/non-http/examples/:splat
-/docs/capabilities/device-identity /docs/integrations/device-context/device-identity
-/docs/capabilities/mtls-clients /docs/internals/mutual-auth
-/docs/capabilities/mtls-services /docs/internals/mutual-auth
-/docs/capabilities/hosted-authenticate-service /docs/capabilities/authentication
-/docs/capabilities/self-hosted-authenticate-service /docs/capabilities/authentication

--- a/static/_redirects
+++ b/static/_redirects
@@ -2,17 +2,17 @@
 # https://docs.netlify.com/routing/redirects/
 
 # Releases
-/docs/releases /docs/deploy/releases
-/docs/deploy/releases /docs/community/contributing
+/docs/releases /docs/versions
+/docs/releases/changelog /docs/deploy/upgrading
 
-# Configuration & Settings Reference (reference links redirect correctly)
+# Configuration & Settings Reference
 /docs/reference/reference /docs/reference
 /docs/reference/reference.html /docs/reference
 /docs/configuration/ /docs/reference
 /docs/config-reference.html /docs/reference
 /configuration/ /docs/reference
 
-# Community links (community links redirect correctly)
+# Community links
 /community/ /docs/community/
 /community/index.html /docs/community/
 /community/contributing /docs/community/contributing
@@ -26,20 +26,18 @@
 /docs/security.html /docs/internals/security
 /docs/community/security.html /docs/internals/security
 
-# Guide and examples links
+# Guide and examples
 /guide/ /docs/quick-start/
 /guide/kubernetes.html /docs/deploy/k8s/
 /guide/kubernetes /docs/deploy/k8s/
-/docs/deploy/k8s/ /docs/deploying/k8s/quickstart
 /guide/synology /docs/guides/synology
 /guide/synology.html /docs/guides/synology
 /docs/quick-start/synology.html /docs/guides/synology
 /docs/guides/jwt-verification /docs/deploy/jwt-verification-with-envoy
-
 /docs/examples.html /docs/guides
 /docs/examples /docs/guides
 
-# 301 deprecated guides in v21 to v20 guides
+# Deprecated guides in v21→v20
 /docs/guides/nginx https://0-20-0.docs.pomerium.com/docs/guides/nginx 301!
 /docs/guides/nginx.html https://0-20-0.docs.pomerium.com/docs/guides/nginx 301!
 /docs/guides/traefik-ingress https://0-20-0.docs.pomerium.com/docs/guides/traefik-ingress 301!
@@ -58,7 +56,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 # Removed in v25
 /docs/reference/debug https://0-24-0.docs.pomerium.com/docs/reference/debug
 
-# 301 Helm and Kubernetes redirects
+# Helm and Kubernetes to older docs
 /docs/guides/helm https://0-19-0.docs.pomerium.com/docs/guides/helm 301!
 /docs/releases/enterprise/install/helm https://0-19-0.docs.pomerium.com/docs/enterprise/install/helm 301!
 /docs/enterprise/install/helm.html https://0-19-0.docs.pomerium.com/docs/enterprise/install/helm 301!
@@ -68,7 +66,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /guides/kubernetes-dashboard.html https://0-19-0.docs.pomerium.com/docs/guides/kubernetes-dashboard 301!
 /recipes/kubernetes.html https://0-20-0.docs.pomerium.com/docs/guides/kubernetes 301!
 
-# /guides/ redirects to capabilities pages
+# Guides → device identity, mTLS, etc.
 /docs/guides/enroll-device /docs/integrations/device-context/device-identity
 /docs/guides/enroll-device.html /docs/integrations/device-context/device-identity
 /docs/guides/admin-enroll-device.html /docs/integrations/device-context/device-identity
@@ -81,7 +79,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /recipes/* /docs/guides/:splat
 /category/guides /docs/guides
 
-# /guides/ splat
+# Additional /guides/ splats
 /guides/* /docs/guides/:splat
 /docs/guides/tcp /docs/guides/securing-tcp
 /docs/guides/securing-tcp /docs/capabilities/non-http
@@ -92,28 +90,29 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/guides/local-oidc /docs/integrations/user-identity/identity-providers/oidc
 /docs/integrations/user-identity/identity-providers/dex-freeipa /docs 410
 
-# Reference, capabilities, topics, concepts links
+# Reference and concepts
 /docs/reference/readme.html /docs/
 /docs/concepts/namespacing /docs/internals/namespacing
 /docs/concepts/policies /docs/internals/glossary#policy
 /docs/concepts/routes /docs/internals/glossary#route
 /docs/concepts/service-accounts /docs/internals/glossary#service-account
-# Redirects incorrectly
 /docs/reference/certificates.html /docs/topics/certificates
 /docs/topics/certificates /docs/concepts/certificates
 /docs/concepts/certificates /docs/internals/certificates-and-tls
 
-# This link requires multiple redirects
+# Multi-hop data-storage link
 /docs/reference/data-storage.html /docs/topics/data-storage
 /docs/topics/data-storage /docs/concepts/data-storage
 /docs/concepts/data-storage /docs/internals/data-storage
 /docs/topics/data-storage.html /docs/internals/data-storage
 
-# This link requires multiple redirects
+# Multi-hop getting-users-identity
 /docs/reference/getting-users-identity.html /docs/topics/getting-users-identity
 /docs/topics/getting-users-identity /docs/concepts/getting-users-identity
 /docs/concepts/getting-users-identity /docs/capabilities/getting-users-identity
 /docs/topics/getting-users-identity.html /docs/capabilities/getting-users-identity
+
+# Old production-deployment references to 410
 /docs/reference/production-deployment.html /docs 410
 /docs/topics/production-deployment /docs 410
 /docs/topics/production-deployment.html /docs 410
@@ -122,13 +121,11 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/production/security /docs 410
 /docs/production/production-deployment /docs 410
 
-# This links requires multiple redirects
+# Multi-hop programmatic-access
 /docs/reference/programmatic-access.html /docs/topics/programmatic-access
 /docs/topics/programmatic-access /docs/concepts/programmatic-access
 /docs/concepts/programmatic-access /docs/capabilities/programmatic-access
-
 /docs/topics/programmatic-access.html /docs/capabilities/programmatic-access
-
 
 # Blog posts
 /posts/2020/06/01/release-0-9/ /blog/posts-2020-06-01-release-0-9/
@@ -139,12 +136,13 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /blog/tag/kubernetes /blog
 /blog/tag/istio /blog
 /blog/author/pomerium/feed /blog
+
 # Careers
 /jobs/ /careers/
 /jobs/Frontend-Engineer.html /careers/frontend-engineer/
 /jobs/Backend-Engineer.html /careers/backend-engineer/
 
-# Redirects enterprise links
+# Enterprise links
 /enterprise/ /docs/enterprise
 /docs/enterprise /docs/releases/enterprise/about
 /enterprise/service-accounts/ /docs/capabilities/service-accounts
@@ -159,19 +157,17 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /enterprise/reference/configure.html /docs/enterprise/configure
 /enterprise/reference/config.html /docs/enterprise/configure
 /enterprise/concepts.html /docs/concepts/access-control
-# /docs/enterprise/about uses multiple redirects
 /docs/enterprise/about /docs/releases/enterprise
 /docs/releases/enterprise /docs/releases/enterprise/about
 /docs/releases/enterprise/about /docs/enterprise
 /enterprise/reference/reports.html /docs/capabilities/reports
 /docs/capabilities/reports /docs/capabilities/metrics
 
-/enterprise/install/helm.html /docs/releases/enterprise/install/helm
+/enterprise/install/helm.html /docs/guides/helm
 /enterprise/* /docs/enterprise/:splat
 
-# /docs/releases/ and /docs/deploying/ splats for v22 sidebar restructure
-/docs/releases/changelog /docs/deploy/core/changelog
-/docs/releases/upgrading /docs/deploy/upgrading.mdx
+# v22 structure
+/docs/releases/upgrading /docs/deploy/upgrading
 /docs/deploying/binary /docs/deploy/core/binary
 /docs/deploying/from-source /docs/deploy/core/from-source
 /enterprise/about /docs/enterprise
@@ -185,52 +181,43 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/releases/* /docs/deploy/:splat
 /docs/deploying/* /docs/deploy/:splat
 
-# client redirects
+# Client redirects
 /docs/deploy/pomerium-cli /docs/deploy/clients/pomerium-cli
 /docs/deploy/pomerium-desktop /docs/deploy/clients/pomerium-desktop
 /docs/deploy/clients /docs/clients
 /docs/deploy/clients/* /docs/clients/:splat
 
-# Zero sidebar restructure
+# Zero restructure
 /docs/deploy/enterprise /docs/enterprise
 /docs/deploy/enterprise/* /docs/enterprise/:splat
-/docs/deploy/core /docs/deploy/core
-/docs/deploy/core/* /docs/deploy/core/:splat
+# The next two lines are effectively no-ops; removing to avoid confusion
+# /docs/deploy/core /docs/deploy/core
+# /docs/deploy/core/* /docs/deploy/core/:splat
 /docs/deploy/k8s /docs/deploy/k8s/quickstart
 /docs/deploy/k8s/* /docs/deploy/k8s/:splat
 /docs/zero/cluster-status /docs/troubleshooting/cluster-status
 /docs/zero/upgrading /docs/get-started/quickstart
 
-#  Installation and deployment methods redirects
-/docs/enterprise/install/docker /docs/enterprise/install
-/docs/enterprise/install/kustomize /docs/enterprise/install
-/docs/enterprise/install/os-packages /docs/enterprise/install
-
+# Installation and deployment
 /docs/installation.html /docs/get-started/quickstart
 /docs/installation /docs/get-started/quickstart
 /docs/quick-start /docs/get-started/quickstart
 /docs/install /docs/get-started/quickstart
-
 /docs/quick-start/binary /docs/deploy/core
 /docs/quick-start/binary.html /docs/deploy/core
 /docs/install/binary /docs/deploy/core
 /docs/releases/core /docs/deploy/core
-
 /docs/install/binary.html /docs/deploy/core/binary
 
-# Helm links
-/docs/quick-start/helm.html /docs/deploy/k8s/helm
-/docs/deploy/k8s/helm /docs/guides/helm
+# Consolidate Helm links → /docs/guides/helm
+/docs/quick-start/helm.html /docs/guides/helm
 /docs/enterprise/install/helm /docs/guides/helm
-
-# /docs/install/helm.html uses multiple redirects
-/docs/install/helm.html /docs/deploy/k8s/helm
+/docs/install/helm.html /docs/guides/helm
+/docs/install/helm /docs/guides/helm
 /docs/deploy/k8s/helm /docs/guides/helm
-
 /docs/deploy/k8s/helm.html /docs/guides/helm
-/docs/install/helm /docs/releases/enterprise/install/helm
 
-# From-source links
+# From-source
 /docs/quick-start/from-source.html /docs/install/from-source
 /docs/install/from-source /docs/deploying/from-source
 /docs/install/from-source.html /docs/deploying/from-source
@@ -256,10 +243,10 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/enterprise/api.html /docs/capabilities/enterprise-api
 /docs/enterprise/api /docs/capabilities/enterprise-api
 
-# redirects all /docs/enterprise/identity-providers to /docs/integrations/user-identity/identity-providers
+# Enterprise IdP → user-identity
 /docs/enterprise/identity-providers/* /docs/integrations/user-identity/identity-providers/:splat
 
-#redirects External Data examples
+# External data → /docs/integrations
 /docs/enterprise/external-data/* /docs/integrations/:splat
 
 # TCP links
@@ -269,78 +256,62 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/topics/tcp-support /docs/tcp/
 /docs/tcp /docs/capabilities/non-http
 
-
-# /docs/client.html uses multiple redirects
+# /docs/client.html multi-hop
 /docs/client.html /docs/tcp/client
 /docs/tcp/client.html /docs/capabilities/non-http/client
 /docs/tcp/client /docs/capabilities/non-http/client
 
 /docs/capabilities/non-http/tcp-cli-reference /docs/capabilities/non-http
 /docs/capabilities/non-http/examples/service-template.html /docs/capabilities/non-http
-# splats
 /docs/tcp/examples/* /docs/capabilities/non-http/examples/:splat
 /docs/tcp/* /docs/capabilities/non-http/examples/:splat
 
-# Enterprise metrics links
+# Enterprise metrics
 /docs/enterprise/metrics.html /docs/capabilities/metrics
 /docs/enterprise/metrics /docs/capabilities/metrics
 
-# redirects /examples/ links
+# JS/Go examples → JWT docs
 /examples/js-sdk/express-server /docs/capabilities/jwt-verification
 /docs/guides/js-sdk /docs/capabilities/jwt-verification
 /docs/capabilities/jwt-verification /docs/capabilities/getting-users-identity.mdx
 
-# Kubernetes links
-# /docs/topics/kubernetes-integration.html uses multiple redirects
+# Kubernetes
 /docs/topics/kubernetes-integration.html /docs/deploy/k8s/
 /docs/deploying/k8s/install /docs/deploy/k8s/install
 /docs/quick-start/kubernetes.html /docs/deploy/k8s/quickstart
-
 /docs/deploy/k8s/configure /docs/deploying/k8s/configure
 /docs/topics/kubernetes-integration /docs/deploying/k8s/quickstart
 /docs/topics/ingress /docs/deploy/k8s/ingress
-# Still 404s...
 /kubernetes/ /docs/deploying/k8s/quickstart
 
-# Troubleshooting and FAQs
+# Troubleshooting and FAQ
 /docs/FAQ.html /docs/troubleshooting
 /docs/internals/troubleshooting /docs/troubleshooting
 /docs/internals/troubleshooting.html /docs/troubleshooting
 /docs/faq /docs/troubleshooting
 
-# /docs/glossary.html uses multiple redirects
+# Glossary multi-hop
 /docs/glossary.html /docs/overview/glossary
 /docs/glossary /docs/internals/glossary
 /docs/overview/glossary /docs/internals/glossary
 
-
-# Releases and upgrading guides
-# /docs/releases.html has multiple redirects
+# Architecture, background, upgrading, changelog
 /docs/releases.html /docs/overview/releases
 /docs/overview/releases /docs/releases
-# /docs/architecture.html has multiple redirects
 /docs/architecture.html /docs/overview/architecture
 /docs/overview/architecture /docs/internals/architecture
-
 /docs/architecture /docs/internals/architecture
-# /docs/background.html has multiple redirects
 /docs/background /docs/concepts/zero-trust
 /docs/background.html /docs/overview/background
 /docs/overview/background /docs/concepts/zero-trust
-
 /docs/upgrading.html /docs/overview/upgrading
 /docs/upgrading /docs/releases/upgrading
-# /docs/changelog.html has multiple redirects
 /docs/changelog.html /docs/overview/changelog
-/docs/overview/changelog /docs/releases/changelog
-# /docs/changelog has multiple redirects
 /docs/changelog /docs/overview/changelog
 /docs/overview/changelog /docs/releases/changelog
-# Redirects are case sensitive https://answers.netlify.com/t/case-sensitivity-with-redirects/956/2
 /docs/CHANGELOG /docs/releases/changelog
-/docs/CHANGELOG.html /docs/deploy/core/changelog
+/docs/CHANGELOG.html /docs/deploy/enterprise/changelog
 
-# Consolidated Reference Page redirects
 # Autocert
 /docs/reference/autocert/autocert-ca /docs/reference/autocert#autocert-ca
 /docs/reference/autocert-directory /docs/reference/autocert#autocert-directory
@@ -462,7 +433,7 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/reference/global-pass-identity-headers /docs/reference/pass-identity-headers
 /docs/reference/routes/pass-identity-headers /docs/reference/routes/pass-identity-headers-per-route
 
-# X-Forwarded-For Settings
+# X-Forwarded-For
 /docs/reference/x-forwarded-for-http-header /docs/reference/x-forwarded-for-settings#skip-xff-append
 /docs/reference/the-number-of-trusted-hops /docs/reference/x-forwarded-for-settings#xff-number-of-trusted-hops
 
@@ -472,12 +443,10 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 # Shared Secret
 /docs/reference/shared-secret-file /docs/reference/shared-secret
 
-# Topics links - now concepts
+# Topics → new pages
 /docs/topics/auth-logs /docs/capabilities/audit-logs
 /docs/topics/single-sign-out.html /docs/capabilities/single-sign-out
 /docs/topics/single-sign-out /docs/capabilities/single-sign-out
-
-#redirects topics
 /docs/topics/original-request-context.html /docs/concepts/original-request-context
 /docs/concepts/original-request-context /docs/capabilities/original-request-context
 /docs/topics/load-balancing.html /docs/capabilities/routing
@@ -489,7 +458,6 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/topics/* /docs/concepts/:splat 301!
 /docs/topics/device-identity /docs/concepts/device-identity
 /docs/topics/mutual-auth /docs/internals/mutual-auth
-
 /docs/topics/original-request-context /docs/concepts/original-request-context
 /docs/concepts/original-request-context /docs/capabilities/original-request-context
 /docs/topics/ppl /docs/concepts/ppl
@@ -499,16 +467,15 @@ https://0-20-0.docs.pomerium.com/category/guides https://0-20-0.docs.pomerium.co
 /docs/topics/load-balancing /docs/concepts/load-balancing
 /docs/concepts/load-balancing /docs/capabilities/routing
 
-# flattened the changelog, and upgrading guide
-/docs/overview/upgrading/archive  /docs/overview/upgrading
-/docs/overview/changelog/archive  /docs/overview/upgrading
+# Flattened changelog & upgrading
+/docs/overview/upgrading/archive /docs/overview/upgrading
+/docs/overview/changelog/archive /docs/overview/upgrading
 /docs/overview/upgrading /docs/releases/upgrading
 /enterprise/changelog /docs/releases/enterprise/changelog
 /docs/enterprise/changelog /docs/releases/enterprise/changelog
 /docs/enterprise/changelog.html /docs/releases/enterprise/changelog
 
-# domain
-# redirect all the `.io` domains to `com` for latest docs
+# Domain-level
 http://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
 https://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
 
@@ -520,156 +487,121 @@ https://0-12-0.docs.pomerium.io/ https://0-12-0.docs.pomerium.com/:splat 301!
 https://0-11-0.docs.pomerium.io/ https://0-11-0.docs.pomerium.com/:splat 301!
 https://0-10-0.docs.pomerium.io/ https://0-10-0.docs.pomerium.com/:splat 301!
 
-# Avoid the index flicker in the browser
+# Avoid flicker
 / /docs
 
-# Newly renamed pages from bdd/2024-reorg-andconsolidate
-/_generate-recovery-token               /docs/admonitions/_generate-recovery-token
-/_generate-recovery-token.html          /docs/admonitions/_generate-recovery-token
+# Newly renamed pages (post-2024 reorg)
+/_generate-recovery-token /docs/admonitions/_generate-recovery-token
+/_generate-recovery-token.html /docs/admonitions/_generate-recovery-token
+/_install-mkcert /docs/admonitions/_install-mkcert
+/_install-mkcert.html /docs/admonitions/_install-mkcert
+/docs/manage/custom-domains /docs/capabilities/custom-domains
+/docs/manage/custom-domains.html /docs/capabilities/custom-domains
 
-/_install-mkcert                        /docs/admonitions/_install-mkcert
-/_install-mkcert.html                   /docs/admonitions/_install-mkcert
+/docs/get-started/fundamentals/advanced-policies /docs/get-started/fundamentals/core/advanced-policies
+/docs/get-started/fundamentals/advanced-policies.html /docs/get-started/fundamentals/core/advanced-policies
+/docs/get-started/fundamentals/advanced-routes /docs/get-started/fundamentals/core/advanced-routes
+/docs/get-started/fundamentals/advanced-routes.html /docs/get-started/fundamentals/core/advanced-routes
+/docs/get-started/fundamentals/build-policies /docs/get-started/fundamentals/core/build-policies
+/docs/get-started/fundamentals/build-policies.html /docs/get-started/fundamentals/core/build-policies
+/docs/get-started/fundamentals/build-routes /docs/get-started/fundamentals/core/build-routes
+/docs/get-started/fundamentals/build-routes.html /docs/get-started/fundamentals/core/build-routes
+/docs/get-started/fundamentals/conclusion /docs/get-started/fundamentals/core/conclusion
+/docs/get-started/fundamentals/conclusion.html /docs/get-started/fundamentals/core/conclusion
+/docs/get-started/fundamentals/get-started /docs/get-started/fundamentals/core/get-started
+/docs/get-started/fundamentals/get-started.html /docs/get-started/fundamentals/core/get-started
+/docs/get-started/fundamentals/jwt-verification /docs/get-started/fundamentals/core/jwt-verification
+/docs/get-started/fundamentals/jwt-verification.html /docs/get-started/fundamentals/core/jwt-verification
+/docs/get-started/fundamentals/production-certificates /docs/get-started/fundamentals/core/production-certificates
+/docs/get-started/fundamentals/production-certificates.html /docs/get-started/fundamentals/core/production-certificates
+/docs/get-started/fundamentals/self-hosted-pomerium /docs/get-started/fundamentals/core/self-hosted-pomerium
+/docs/get-started/fundamentals/self-hosted-pomerium.html /docs/get-started/fundamentals/core/self-hosted-pomerium
+/docs/get-started/fundamentals/tcp-routes /docs/get-started/fundamentals/core/tcp-routes
+/docs/get-started/fundamentals/tcp-routes.html /docs/get-started/fundamentals/core/tcp-routes
 
-/docs/manage/custom-domains             /docs/capabilities/custom-domains
-/docs/manage/custom-domains.html        /docs/capabilities/custom-domains
+/docs/get-started/fundamentals/zero-advanced-policies /docs/get-started/fundamentals/zero/zero-advanced-policies
+/docs/get-started/fundamentals/zero-advanced-policies.html /docs/get-started/fundamentals/zero/zero-advanced-policies
+/docs/get-started/fundamentals/zero-advanced-routes /docs/get-started/fundamentals/zero/zero-advanced-routes
+/docs/get-started/fundamentals/zero-advanced-routes.html /docs/get-started/fundamentals/zero/zero-advanced-routes
+/docs/get-started/fundamentals/zero-build-policies /docs/get-started/fundamentals/zero/zero-build-policies
+/docs/get-started/fundamentals/zero-build-policies.html /docs/get-started/fundamentals/zero/zero-build-policies
+/docs/get-started/fundamentals/zero-build-routes /docs/get-started/fundamentals/zero/zero-build-routes
+/docs/get-started/fundamentals/zero-build-routes.html /docs/get-started/fundamentals/zero/zero-build-routes
+/docs/get-started/fundamentals/zero-custom-idp /docs/get-started/fundamentals/zero/zero-custom-idp
+/docs/get-started/fundamentals/zero-custom-idp.html /docs/get-started/fundamentals/zero/zero-custom-idp
+/docs/get-started/fundamentals/zero-single-sign-on /docs/get-started/fundamentals/zero/zero-single-sign-on
+/docs/get-started/fundamentals/zero-single-sign-on.html /docs/get-started/fundamentals/zero/zero-single-sign-on
+/docs/get-started/fundamentals/zero-tcp-routes /docs/get-started/fundamentals/zero/zero-tcp-routes
+/docs/get-started/fundamentals/zero-tcp-routes.html /docs/get-started/fundamentals/zero/zero-tcp-routes
 
-/docs/get-started/fundamentals/advanced-policies              /docs/get-started/fundamentals/core/advanced-policies
-/docs/get-started/fundamentals/advanced-policies.html         /docs/get-started/fundamentals/core/advanced-policies
+/docs/integrations/integrations /docs/integrations
+/docs/integrations/integrations.html /docs/integrations
+/docs/integrations/fleetdm /docs/integrations/device-context/fleetdm
+/docs/integrations/fleetdm.html /docs/integrations/device-context/fleetdm
+/docs/integrations/geoip /docs/integrations/request-context/geoip
+/docs/integrations/geoip.html /docs/integrations/request-context/geoip
+/docs/integrations/ip-ranges /docs/integrations/request-context/ip-ranges
+/docs/integrations/ip-ranges.html /docs/integrations/request-context/ip-ranges
+/docs/integrations/tor-exit-nodes /docs/integrations/request-context/tor-exit-nodes
+/docs/integrations/tor-exit-nodes.html /docs/integrations/request-context/tor-exit-nodes
+/docs/integrations/vpn-providers /docs/integrations/request-context/vpn-providers
+/docs/integrations/vpn-providers.html /docs/integrations/request-context/vpn-providers
+/docs/integrations/apple /docs/integrations/user-identity/apple
+/docs/integrations/apple.html /docs/integrations/user-identity/apple
+/docs/integrations/auth0 /docs/integrations/user-identity/auth0
+/docs/integrations/auth0.html /docs/integrations/user-identity/auth0
+/docs/integrations/azure /docs/integrations/user-identity/azure
+/docs/integrations/azure.html /docs/integrations/user-identity/azure
+/docs/integrations/cognito /docs/integrations/user-identity/cognito
+/docs/integrations/cognito.html /docs/integrations/user-identity/cognito
+/docs/integrations/github /docs/integrations/user-identity/github
+/docs/integrations/github.html /docs/integrations/user-identity/github
+/docs/integrations/gitlab /docs/integrations/user-identity/gitlab
+/docs/integrations/gitlab.html /docs/integrations/user-identity/gitlab
+/docs/integrations/google /docs/integrations/user-identity/google
+/docs/integrations/google.html /docs/integrations/user-identity/google
+/docs/integrations/index /docs/integrations/user-identity/identity-providers
+/docs/integrations/index.html /docs/integrations/user-identity/identity-providers
+/docs/integrations/okta /docs/integrations/user-identity/okta
+/docs/integrations/okta.html /docs/integrations/user-identity/okta
+/docs/integrations/one-login /docs/integrations/user-identity/one-login
+/docs/integrations/one-login.html /docs/integrations/user-identity/one-login
+/docs/integrations/ping /docs/integrations/user-identity/ping
+/docs/integrations/ping.html /docs/integrations/user-identity/ping
+/docs/integrations/bamboohr /docs/integrations/user-standing/bamboohr
+/docs/integrations/bamboohr.html /docs/integrations/user-standing/bamboohr
+/docs/capabilities/directory-sync /docs/integrations/user-standing/directory-sync
+/docs/capabilities/directory-sync.html /docs/integrations/user-standing/directory-sync
+/docs/integrations/zenefits /docs/integrations/user-standing/zenefits
+/docs/integrations/zenefits.html /docs/integrations/user-standing/zenefits
 
-/docs/get-started/fundamentals/advanced-routes                /docs/get-started/fundamentals/core/advanced-routes
-/docs/get-started/fundamentals/advanced-routes.html           /docs/get-started/fundamentals/core/advanced-routes
+/docs/capabilities/certificates-and-tls /docs/internals/certificates-and-tls
+/docs/capabilities/certificates-and-tls.html /docs/internals/certificates-and-tls
+/docs/manage/clusters /docs/internals/clusters
+/docs/manage/clusters.html /docs/internals/clusters
+/docs/capabilities/high-availability /docs/internals/configuration
+/docs/capabilities/high-availability.html /docs/internals/configuration
+/docs/capabilities/enterprise-api /docs/internals/management-api-enterprise
+/docs/capabilities/enterprise-api.html /docs/internals/management-api-enterprise
+/docs/deploy/cloud/api-guide /docs/internals/management-api-zero
+/docs/deploy/cloud/api-guide.html /docs/internals/management-api-zero
+/docs/capabilities/metrics /docs/internals/metrics
+/docs/capabilities/metrics.html /docs/internals/metrics
+/docs/manage/mutual-auth /docs/internals/mutual-auth
+/docs/manage/mutual-auth.html /docs/internals/mutual-auth
+/docs/capabilities/ppl /docs/internals/ppl
+/docs/capabilities/ppl.html /docs/internals/ppl
+/docs/capabilities/programmatic-access /docs/internals/programmatic-access
+/docs/capabilities/programmatic-access.html /docs/internals/programmatic-access
+/docs/manage/troubleshooting /docs/internals/troubleshooting
+/docs/manage/troubleshooting.html /docs/internals/troubleshooting
 
-/docs/get-started/fundamentals/build-policies                 /docs/get-started/fundamentals/core/build-policies
-/docs/get-started/fundamentals/build-policies.html            /docs/get-started/fundamentals/core/build-policies
-
-/docs/get-started/fundamentals/build-routes                   /docs/get-started/fundamentals/core/build-routes
-/docs/get-started/fundamentals/build-routes.html              /docs/get-started/fundamentals/core/build-routes
-
-/docs/get-started/fundamentals/conclusion                     /docs/get-started/fundamentals/core/conclusion
-/docs/get-started/fundamentals/conclusion.html                /docs/get-started/fundamentals/core/conclusion
-
-/docs/get-started/fundamentals/get-started                    /docs/get-started/fundamentals/core/get-started
-/docs/get-started/fundamentals/get-started.html               /docs/get-started/fundamentals/core/get-started
-
-/docs/get-started/fundamentals/jwt-verification               /docs/get-started/fundamentals/core/jwt-verification
-/docs/get-started/fundamentals/jwt-verification.html          /docs/get-started/fundamentals/core/jwt-verification
-
-/docs/get-started/fundamentals/production-certificates        /docs/get-started/fundamentals/core/production-certificates
-/docs/get-started/fundamentals/production-certificates.html   /docs/get-started/fundamentals/core/production-certificates
-
-/docs/get-started/fundamentals/self-hosted-pomerium           /docs/get-started/fundamentals/core/self-hosted-pomerium
-/docs/get-started/fundamentals/self-hosted-pomerium.html      /docs/get-started/fundamentals/core/self-hosted-pomerium
-
-/docs/get-started/fundamentals/tcp-routes                     /docs/get-started/fundamentals/core/tcp-routes
-/docs/get-started/fundamentals/tcp-routes.html                /docs/get-started/fundamentals/core/tcp-routes
-
-/docs/get-started/fundamentals/zero-advanced-policies         /docs/get-started/fundamentals/zero/zero-advanced-policies
-/docs/get-started/fundamentals/zero-advanced-policies.html    /docs/get-started/fundamentals/zero/zero-advanced-policies
-
-/docs/get-started/fundamentals/zero-advanced-routes           /docs/get-started/fundamentals/zero/zero-advanced-routes
-/docs/get-started/fundamentals/zero-advanced-routes.html      /docs/get-started/fundamentals/zero/zero-advanced-routes
-
-/docs/get-started/fundamentals/zero-build-policies            /docs/get-started/fundamentals/zero/zero-build-policies
-/docs/get-started/fundamentals/zero-build-policies.html       /docs/get-started/fundamentals/zero/zero-build-policies
-
-/docs/get-started/fundamentals/zero-build-routes              /docs/get-started/fundamentals/zero/zero-build-routes
-/docs/get-started/fundamentals/zero-build-routes.html         /docs/get-started/fundamentals/zero/zero-build-routes
-
-/docs/get-started/fundamentals/zero-custom-idp                /docs/get-started/fundamentals/zero/zero-custom-idp
-/docs/get-started/fundamentals/zero-custom-idp.html           /docs/get-started/fundamentals/zero/zero-custom-idp
-
-/docs/get-started/fundamentals/zero-single-sign-on            /docs/get-started/fundamentals/zero/zero-single-sign-on
-/docs/get-started/fundamentals/zero-single-sign-on.html       /docs/get-started/fundamentals/zero/zero-single-sign-on
-
-/docs/get-started/fundamentals/zero-tcp-routes                /docs/get-started/fundamentals/zero/zero-tcp-routes
-/docs/get-started/fundamentals/zero-tcp-routes.html           /docs/get-started/fundamentals/zero/zero-tcp-routes
-
-/docs/integrations/integrations                               /docs/integrations
-/docs/integrations/integrations.html                          /docs/integrations
-
-/docs/integrations/fleetdm                                    /docs/integrations/device-context/fleetdm
-/docs/integrations/fleetdm.html                               /docs/integrations/device-context/fleetdm
-
-/docs/integrations/geoip                                      /docs/integrations/request-context/geoip
-/docs/integrations/geoip.html                                 /docs/integrations/request-context/geoip
-
-/docs/integrations/ip-ranges                                  /docs/integrations/request-context/ip-ranges
-/docs/integrations/ip-ranges.html                             /docs/integrations/request-context/ip-ranges
-
-/docs/integrations/tor-exit-nodes                             /docs/integrations/request-context/tor-exit-nodes
-/docs/integrations/tor-exit-nodes.html                        /docs/integrations/request-context/tor-exit-nodes
-
-/docs/integrations/vpn-providers                              /docs/integrations/request-context/vpn-providers
-/docs/integrations/vpn-providers.html                         /docs/integrations/request-context/vpn-providers
-
-/docs/integrations/apple                                      /docs/integrations/user-identity/apple
-/docs/integrations/apple.html                                 /docs/integrations/user-identity/apple
-
-/docs/integrations/auth0                                      /docs/integrations/user-identity/auth0
-/docs/integrations/auth0.html                                 /docs/integrations/user-identity/auth0
-
-/docs/integrations/azure                                      /docs/integrations/user-identity/azure
-/docs/integrations/azure.html                                 /docs/integrations/user-identity/azure
-
-/docs/integrations/cognito                                    /docs/integrations/user-identity/cognito
-/docs/integrations/cognito.html                               /docs/integrations/user-identity/cognito
-
-/docs/integrations/github                                     /docs/integrations/user-identity/github
-/docs/integrations/github.html                                /docs/integrations/user-identity/github
-
-/docs/integrations/gitlab                                     /docs/integrations/user-identity/gitlab
-/docs/integrations/gitlab.html                                /docs/integrations/user-identity/gitlab
-
-/docs/integrations/google                                     /docs/integrations/user-identity/google
-/docs/integrations/google.html                                /docs/integrations/user-identity/google
-
-/docs/integrations/index                                      /docs/integrations/user-identity/identity-providers
-/docs/integrations/index.html                                 /docs/integrations/user-identity/identity-providers
-
-/docs/integrations/okta                                       /docs/integrations/user-identity/okta
-/docs/integrations/okta.html                                  /docs/integrations/user-identity/okta
-
-/docs/integrations/one-login                                  /docs/integrations/user-identity/one-login
-/docs/integrations/one-login.html                             /docs/integrations/user-identity/one-login
-
-/docs/integrations/ping                                       /docs/integrations/user-identity/ping
-/docs/integrations/ping.html                                  /docs/integrations/user-identity/ping
-
-/docs/integrations/bamboohr                                  /docs/integrations/user-standing/bamboohr
-/docs/integrations/bamboohr.html                             /docs/integrations/user-standing/bamboohr
-
-/docs/capabilities/directory-sync                             /docs/integrations/user-standing/directory-sync
-/docs/capabilities/directory-sync.html                        /docs/integrations/user-standing/directory-sync
-
-/docs/integrations/zenefits                                  /docs/integrations/user-standing/zenefits
-/docs/integrations/zenefits.html                             /docs/integrations/user-standing/zenefits
-
-/docs/capabilities/certificates-and-tls                      /docs/internals/certificates-and-tls
-/docs/capabilities/certificates-and-tls.html                 /docs/internals/certificates-and-tls
-
-/docs/manage/clusters                                        /docs/internals/clusters
-/docs/manage/clusters.html                                   /docs/internals/clusters
-
-/docs/capabilities/high-availability                          /docs/internals/configuration
-/docs/capabilities/high-availability.html                     /docs/internals/configuration
-
-/docs/capabilities/enterprise-api                             /docs/internals/management-api-enterprise
-/docs/capabilities/enterprise-api.html                        /docs/internals/management-api-enterprise
-
-/docs/deploy/cloud/api-guide                                  /docs/internals/management-api-zero
-/docs/deploy/cloud/api-guide.html                             /docs/internals/management-api-zero
-
-/docs/capabilities/metrics                                    /docs/internals/metrics
-/docs/capabilities/metrics.html                               /docs/internals/metrics
-
-/docs/manage/mutual-auth                                      /docs/internals/mutual-auth
-/docs/manage/mutual-auth.html                                 /docs/internals/mutual-auth
-
-/docs/capabilities/ppl                                        /docs/internals/ppl
-/docs/capabilities/ppl.html                                   /docs/internals/ppl
-
-/docs/capabilities/programmatic-access                        /docs/internals/programmatic-access
-/docs/capabilities/programmatic-access.html                   /docs/internals/programmatic-access
-
-/docs/manage/troubleshooting                                  /docs/internals/troubleshooting
-/docs/manage/troubleshooting.html                             /docs/internals/troubleshooting
+# Additional fixes for pages that 404 after reorg
+/docs/quickstart /docs/get-started/quickstart
+/docs/capabilities/tcp /docs/capabilities/non-http
+/docs/capabilities/tcp/examples/* /docs/capabilities/non-http/examples/:splat
+/docs/capabilities/device-identity /docs/integrations/device-context/device-identity
+/docs/capabilities/mtls-clients /docs/internals/mutual-auth
+/docs/capabilities/mtls-services /docs/internals/mutual-auth
+/docs/capabilities/hosted-authenticate-service /docs/capabilities/authentication
+/docs/capabilities/self-hosted-authenticate-service /docs/capabilities/authentication

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,123 +1,75 @@
 # Netlify Redirects
 # https://docs.netlify.com/routing/redirects/
 
-###############################
-# Domain-level & legacy doc references
-###############################
-
-# Root domain => new docs
+# Domain-level references
 http://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
 https://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
 
-###############################
 # Root => /docs
-###############################
 / /docs
 
-###############################
 # Releases & Versions
-###############################
 /docs/releases /docs/versions
 /docs/releases/changelog /docs/deploy/upgrading
 /docs/releases/upgrading /docs/deploy/upgrading
-
-# Consolidate old "changelog" => /docs/deploy/upgrading
 /docs/changelog /docs/deploy/upgrading
 /docs/changelog.html /docs/deploy/upgrading
 /docs/CHANGELOG /docs/deploy/upgrading
 /docs/CHANGELOG.html /docs/deploy/upgrading
 
-###############################
 # Old debug => new Troubleshooting
-###############################
 /docs/reference/debug /docs/internals/troubleshooting
 
-###############################
-# Guide references => new pages
-###############################
+# Guides => new pages
 /guide/ /docs/get-started/quickstart
 /guide/kubernetes.html /docs/deploy/k8s
 /guide/kubernetes /docs/deploy/k8s
 /docs/deploy/k8s/ /docs/deploy/k8s/quickstart
-
-# Synology
 /guide/synology /docs/guides/synology
 /guide/synology.html /docs/guides/synology
 /docs/quick-start/synology.html /docs/guides/synology
-
-# JWT verification => "getting-users-identity"
 /docs/guides/jwt-verification /docs/capabilities/getting-users-identity
 /docs/guides/jwt-verification.html /docs/capabilities/getting-users-identity
-
-# Catch-all for /guides
 /guides/* /docs/guides/:splat
-
-# Additional direct re-routes
 /docs/guides/tcp /docs/capabilities/non-http
 /guides/vs-code-server.html /docs/guides/code-server
 /docs/guides/vs-code-server.html /docs/guides/code-server
 /guides/local-oidc.html /docs/guides/local-oidc
 /docs/guides/local-oidc /docs/integrations/user-identity/oidc
 
-###############################
 # Programmatic access
-###############################
 /docs/reference/programmatic-access.html /docs/capabilities/programmatic-access
 
-###############################
 # Enterprise => /docs/deploy/enterprise
-###############################
 /enterprise /docs/deploy/enterprise
 /docs/enterprise /docs/deploy/enterprise
-
-# Old service-accounts => new capabilities
 /enterprise/service-accounts /docs/capabilities/service-accounts
 /enterprise/service-accounts.html /docs/capabilities/service-accounts
-
-# Old Prometheus references => new "configure-metrics"
 /enterprise/prometheus /docs/deploy/enterprise/configure-metrics
 /enterprise/prometheus.html /docs/deploy/enterprise/configure-metrics
-
-# Old "concepts" => "authentication"
 /docs/enterprise/concepts.html /docs/capabilities/authentication
 /docs/enterprise/concepts /docs/capabilities/authentication
-
-# Old "about" => enterprise root
 /docs/enterprise/about /docs/deploy/enterprise
-
-# Old "reports" => "audit-logs"
 /docs/capabilities/reports /docs/capabilities/audit-logs
-
-# Enterprise quickstart
 /docs/enterprise/install/quickstart /docs/deploy/enterprise/quickstart
 /docs/enterprise/install/quickstart.html /docs/deploy/enterprise/quickstart
 /docs/enterprise/install /docs/deploy/enterprise/quickstart
 /enterprise/install/ /docs/deploy/enterprise/quickstart
-
-# Old enterprise changelog => new /docs/versions
 /docs/enterprise/changelog /docs/versions
 /docs/enterprise/changelog.html /docs/versions
-
-# Catch-all for enterprise subpaths
 /enterprise/* /docs/deploy/enterprise/:splat
 
-###############################
 # Clients
-###############################
 /docs/deploy/pomerium-cli /docs/deploy/clients
 /docs/deploy/pomerium-desktop /docs/deploy/clients
 /docs/deploy/clients /docs/deploy/clients
 /docs/deploy/clients/* /docs/deploy/clients
 
-###############################
 # Zero references
-###############################
 /docs/zero/cluster-status /docs/troubleshooting/cluster-status
 /docs/zero/upgrading /docs/deploy/upgrading
 
-###############################
-# Old "quickstart" => /get-started/quickstart
-###############################
+# Old quickstart => /get-started/quickstart
 /docs/quick-start /docs/get-started/quickstart
 /docs/quickstart /docs/get-started/quickstart
 /docs/install /docs/get-started/quickstart
@@ -132,23 +84,19 @@ https://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
 /docs/install/binary.html /docs/deploy/core
 /docs/quick-start/binary /docs/deploy/core
 /docs/quick-start/binary.html /docs/deploy/core
-
-# Helm references
-/docs/quick-start/helm.html /docs/deploy/k8s/helm
-/docs/deploy/k8s/helm /docs/guides/helm
-/docs/enterprise/install/helm /docs/guides/helm
-/docs/install/helm /docs/guides/helm
-/docs/install/helm.html /docs/guides/helm
-/docs/deploy/k8s/helm.html /docs/guides/helm
-
-# From-source => /docs/deploy/core
 /docs/quick-start/from-source.html /docs/deploy/core
 /docs/install/from-source /docs/deploy/core
 /docs/install/from-source.html /docs/deploy/core
 
-###############################
+# Helm => /docs/deploy/k8s/install (no /docs/guides/helm in current sitemap)
+/docs/quick-start/helm.html /docs/deploy/k8s/install
+/docs/deploy/k8s/helm /docs/deploy/k8s/install
+/docs/enterprise/install/helm /docs/deploy/k8s/install
+/docs/install/helm /docs/deploy/k8s/install
+/docs/install/helm.html /docs/deploy/k8s/install
+/docs/deploy/k8s/helm.html /docs/deploy/k8s/install
+
 # TCP & Non-HTTP
-###############################
 /docs/tcp /docs/capabilities/non-http
 /docs/tcp/client /docs/capabilities/non-http/client
 /docs/tcp/client.html /docs/capabilities/non-http/client
@@ -157,14 +105,10 @@ https://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
 /docs/tcp/examples/* /docs/capabilities/non-http/examples/:splat
 /docs/tcp/* /docs/capabilities/non-http/examples/:splat
 
-###############################
-# /examples/
-###############################
+# /examples
 /examples/js-sdk/express-server /docs/capabilities/getting-users-identity
 
-###############################
 # K8s references
-###############################
 /docs/topics/kubernetes-integration.html /docs/deploy/k8s
 /docs/deploying/k8s/install /docs/deploy/k8s/install
 /docs/quick-start/kubernetes.html /docs/deploy/k8s/quickstart
@@ -173,17 +117,13 @@ https://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
 /docs/topics/ingress /docs/deploy/k8s/ingress
 /kubernetes/ /docs/deploy/k8s/quickstart
 
-###############################
 # Troubleshooting & FAQ
-###############################
 /docs/FAQ.html /docs/internals/troubleshooting
 /docs/faq /docs/internals/troubleshooting
 /docs/internals/troubleshooting /docs/internals/troubleshooting
 /docs/internals/troubleshooting.html /docs/internals/troubleshooting
 
-###############################
 # Architecture / background / upgrading
-###############################
 /docs/architecture.html /docs/internals/architecture
 /docs/architecture /docs/internals/architecture
 /docs/background /docs/internals/zero-trust
@@ -191,17 +131,13 @@ https://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
 /docs/upgrading.html /docs/deploy/upgrading
 /docs/upgrading /docs/deploy/upgrading
 
-###############################
 # Newly renamed pages
-###############################
 /_generate-recovery-token /docs/admonitions/_generate-recovery-token
 /_generate-recovery-token.html /docs/admonitions/_generate-recovery-token
 /_install-mkcert /docs/admonitions/_install-mkcert
 /_install-mkcert.html /docs/admonitions/_install-mkcert
-
 /docs/manage/custom-domains /docs/capabilities/custom-domains
 /docs/manage/custom-domains.html /docs/capabilities/custom-domains
-
 /docs/get-started/fundamentals/advanced-policies /docs/get-started/fundamentals/core/advanced-policies
 /docs/get-started/fundamentals/advanced-policies.html /docs/get-started/fundamentals/core/advanced-policies
 /docs/get-started/fundamentals/advanced-routes /docs/get-started/fundamentals/core/advanced-routes
@@ -236,11 +172,8 @@ https://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
 /docs/get-started/fundamentals/zero-single-sign-on.html /docs/get-started/fundamentals/zero/zero-single-sign-on
 /docs/get-started/fundamentals/zero-tcp-routes /docs/get-started/fundamentals/zero/zero-tcp-routes
 /docs/get-started/fundamentals/zero-tcp-routes.html /docs/get-started/fundamentals/zero/zero-tcp-routes
-
 /docs/integrations/integrations /docs/capabilities/integrations
 /docs/integrations/integrations.html /docs/capabilities/integrations
-
-# Fleets, geoip, ip-ranges => new "request-context" or "device-context"
 /docs/integrations/fleetdm /docs/integrations/device-context/fleetdm
 /docs/integrations/fleetdm.html /docs/integrations/device-context/fleetdm
 /docs/integrations/geoip /docs/integrations/request-context/geoip
@@ -251,8 +184,6 @@ https://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
 /docs/integrations/tor-exit-nodes.html /docs/integrations/request-context/tor-exit-nodes
 /docs/integrations/vpn-providers /docs/integrations/request-context/vpn-providers
 /docs/integrations/vpn-providers.html /docs/integrations/request-context/vpn-providers
-
-# OIDC, Okta, Ping, etc. => new "user-identity"
 /docs/integrations/apple /docs/integrations/user-identity/apple
 /docs/integrations/apple.html /docs/integrations/user-identity/apple
 /docs/integrations/auth0 /docs/integrations/user-identity/auth0
@@ -275,16 +206,12 @@ https://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
 /docs/integrations/one-login.html /docs/integrations/user-identity/one-login
 /docs/integrations/ping /docs/integrations/user-identity/ping
 /docs/integrations/ping.html /docs/integrations/user-identity/ping
-
-# BambooHR, directory-sync => user-standing
 /docs/integrations/bamboohr /docs/integrations/user-standing/bamboohr
 /docs/integrations/bamboohr.html /docs/integrations/user-standing/bamboohr
 /docs/capabilities/directory-sync /docs/integrations/user-standing/directory-sync
 /docs/capabilities/directory-sync.html /docs/integrations/user-standing/directory-sync
 /docs/integrations/zenefits /docs/integrations/user-standing/zenefits
 /docs/integrations/zenefits.html /docs/integrations/user-standing/zenefits
-
-# TLS, clusters, mutual-auth => new "internals"
 /docs/capabilities/certificates-and-tls /docs/internals/certificates-and-tls
 /docs/capabilities/certificates-and-tls.html /docs/internals/certificates-and-tls
 /docs/manage/clusters /docs/internals/clusters
@@ -297,17 +224,11 @@ https://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
 /docs/deploy/cloud/api-guide.html /docs/internals/management-api-zero
 /docs/manage/mutual-auth /docs/internals/mutual-auth
 /docs/manage/mutual-auth.html /docs/internals/mutual-auth
-
-# "metrics" => internals or enterprise config
 /docs/capabilities/metrics /docs/internals/metrics
 /docs/capabilities/metrics.html /docs/internals/metrics
-
-# PPL, programmatic
 /docs/capabilities/ppl /docs/internals/ppl
 /docs/capabilities/ppl.html /docs/internals/ppl
 /docs/capabilities/programmatic-access /docs/internals/programmatic-access
 /docs/capabilities/programmatic-access.html /docs/internals/programmatic-access
-
-# Troubleshooting
 /docs/manage/troubleshooting /docs/internals/troubleshooting
 /docs/manage/troubleshooting.html /docs/internals/troubleshooting


### PR DESCRIPTION
- Added redirects for old capabilities pages (hosted-authenticate-service, mtls-clients, etc.).
- Updated Helm references to point to /docs/deploy/k8s/install.
- Removed outdated references (pre 0.20) and consolidated rules to avoid 404s.
- Grouped rules logically by doc category for easier maintenance.

Follow-up to [#1726](https://github.com/pomerium/documentation/pull/1726)