### PR TITLE
add example time_of_day formats

### DIFF
--- a/content/docs/internals/ppl.mdx
+++ b/content/docs/internals/ppl.mdx
@@ -455,6 +455,16 @@ allow:
         before: 4:30PM
 ```
 
+Values for `after` and `before` should match one of these formats:
+
+- "3:04 PM"
+- "3:04PM"
+- "3 PM"
+- "3PM"
+- "15:04:05.999999999"
+- "15:04:05"
+- "15:04"
+
 ## Rego
 
 :::caution Rego Usage Requires Extreme Care


### PR DESCRIPTION
Document the supported time formats for the `time_of_day` criterion.

Related issue:
https://linear.app/pomerium/issue/ENG-1868/terraform-provider-the-time-in-the-policy-is-not-displayed-in-the