### PR TITLE
Use docker images without an explict domain 

### DIFF
--- a/content/docs/deploy/clients/clients.mdx
+++ b/content/docs/deploy/clients/clients.mdx
@@ -112,7 +112,7 @@ brew install pomerium-cli
 <TabItem value="docker" label="Docker">
 
 ```bash
-docker run pomerium.com/pomerium/cli:latest --version
+docker run pomerium/cli:latest --version
 ```
 
 </TabItem>

--- a/content/docs/deploy/cloud/install.mdx
+++ b/content/docs/deploy/cloud/install.mdx
@@ -82,7 +82,7 @@ services:
         aliases:
           - verify.<CLUSTER_STARTER_SUBDOMAIN>.pomerium.app
   verify:
-    image: pomerium.com/pomerium/verify:latest
+    image: pomerium/verify:latest
     networks:
       main:
         aliases:

--- a/content/docs/get-started/fundamentals/core/advanced-policies.md
+++ b/content/docs/get-started/fundamentals/core/advanced-policies.md
@@ -167,13 +167,13 @@ Docker Compose:
 ```yaml
 services:
   pomerium:
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:
       - 443:443
   verify:
-    image: pomerium.com/pomerium/verify:latest
+    image: pomerium/verify:latest
     expose:
       - 8000
     environment:

--- a/content/docs/get-started/fundamentals/core/advanced-routes.md
+++ b/content/docs/get-started/fundamentals/core/advanced-routes.md
@@ -442,13 +442,13 @@ Docker Compose
 ```yaml
 services:
   pomerium:
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:
       - 443:443
   verify:
-    image: pomerium.com/pomerium/verify:latest
+    image: pomerium/verify:latest
     expose:
       - 8000
     environment:

--- a/content/docs/get-started/fundamentals/core/build-policies.md
+++ b/content/docs/get-started/fundamentals/core/build-policies.md
@@ -246,13 +246,13 @@ Docker Compose:
 ```yaml
 services:
   pomerium:
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:
       - 443:443
   verify:
-    image: pomerium.com/pomerium/verify:latest
+    image: pomerium/verify:latest
     expose:
       - 8000
   grafana:

--- a/content/docs/get-started/fundamentals/core/build-routes.md
+++ b/content/docs/get-started/fundamentals/core/build-routes.md
@@ -70,6 +70,12 @@ In your `docker-compose.yaml` file, add Grafana as a service:
 ```yaml title="docker-compose.yaml"
 services:
   pomerium:
+    image: pomerium/pomerium:latest
+    volumes:
+      - ./config.yaml:/pomerium/config.yaml:ro
+    ports:
+      - 443:443
+  verify:
     image: pomerium/verify:latest
     expose:
       - 8000

--- a/content/docs/get-started/fundamentals/core/build-routes.md
+++ b/content/docs/get-started/fundamentals/core/build-routes.md
@@ -70,13 +70,7 @@ In your `docker-compose.yaml` file, add Grafana as a service:
 ```yaml title="docker-compose.yaml"
 services:
   pomerium:
-    image: pomerium.com/pomerium/pomerium:latest
-    volumes:
-      - ./config.yaml:/pomerium/config.yaml:ro
-    ports:
-      - 443:443
-  verify:
-    image: pomerium.com/pomerium/verify:latest
+    image: pomerium/verify:latest
     expose:
       - 8000
   grafana:
@@ -183,13 +177,13 @@ Docker Compose:
 ```yaml
 services:
   pomerium:
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:
       - 443:443
   verify:
-    image: pomerium.com/pomerium/verify:latest
+    image: pomerium/verify:latest
     expose:
       - 8000
   grafana:

--- a/content/docs/get-started/fundamentals/core/get-started.md
+++ b/content/docs/get-started/fundamentals/core/get-started.md
@@ -109,13 +109,13 @@ Add the following configuration settings to `docker-compose.yaml`:
 ```yaml title="docker-compose.yaml"
 services:
   pomerium:
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:
       - 443:443
   verify:
-    image: pomerium.com/pomerium/verify:latest
+    image: pomerium/verify:latest
     expose:
       - 8000
 ```
@@ -182,13 +182,13 @@ Docker Compose:
 ```yaml
 services:
   pomerium:
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:
       - 443:443
   verify:
-    image: pomerium.com/pomerium/verify:latest
+    image: pomerium/verify:latest
     expose:
       - 8000
 ```

--- a/content/docs/get-started/fundamentals/core/jwt-verification.md
+++ b/content/docs/get-started/fundamentals/core/jwt-verification.md
@@ -208,7 +208,7 @@ In your Docker Compose file, add the following environment variable to your Veri
 
 ```yaml title="docker-compose"
 verify:
-  image: pomerium.com/pomerium/verify:latest
+  image: pomerium/verify:latest
   expose:
     - 8000
   environment:
@@ -338,13 +338,13 @@ Docker Compose
 ```yaml
 services:
   pomerium:
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:
       - 443:443
   verify:
-    image: pomerium.com/pomerium/verify:latest
+    image: pomerium/verify:latest
     expose:
       - 8000
     environment:

--- a/content/docs/get-started/fundamentals/core/tcp-routes.md
+++ b/content/docs/get-started/fundamentals/core/tcp-routes.md
@@ -116,7 +116,7 @@ In your Docker Compose file, bind mount your wildcard certificates as a volume i
 ```yaml title="docker-compose.yaml"
 services:
   pomerium:
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     volumes:
       # Mount your wildcard certificates:
       - ./_wildcard.localhost.pomerium.io-key.pem:/pomerium/key.pem:ro

--- a/content/docs/get-started/fundamentals/zero/zero-advanced-routes.mdx
+++ b/content/docs/get-started/fundamentals/zero/zero-advanced-routes.mdx
@@ -356,7 +356,7 @@ services:
           - verify.<CLUSTER_SUBDOMAIN>.pomerium.app
           - authenticate.<CLUSTER_SUBDOMAIN>.pomerium.app
   verify:
-    image: pomerium.com/pomerium/verify:latest
+    image: pomerium/verify:latest
     networks:
       main:
         aliases:

--- a/content/docs/get-started/fundamentals/zero/zero-build-routes.mdx
+++ b/content/docs/get-started/fundamentals/zero/zero-build-routes.mdx
@@ -98,7 +98,7 @@ At this point, your Docker Compose file should look like this:
 ```yaml title="docker-compose.yaml"
 services:
   pomerium:
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     ports:
       - 443:443
     restart: always
@@ -112,7 +112,7 @@ services:
         aliases:
           - verify.<YOUR_CLUSTER_SUBDOMAIN>.pomerium.app
   verify:
-    image: pomerium.com/pomerium/verify:latest
+    image: pomerium/verify:latest
     networks:
       main:
         aliases:

--- a/content/docs/get-started/fundamentals/zero/zero-single-sign-on.mdx
+++ b/content/docs/get-started/fundamentals/zero/zero-single-sign-on.mdx
@@ -199,7 +199,7 @@ At this point, your Docker Compose file should look like this:
 ```yaml title="docker-compose.yaml"
 services:
   pomerium:
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     ports:
       - 443:443
     restart: always
@@ -214,7 +214,7 @@ services:
           - verify.<CLUSTER_SUBDOMAIN>.pomerium.app
           - authenticate.<CLUSTER_SUBDOMAIN>.pomerium.app
   verify:
-    image: pomerium.com/pomerium/verify:latest
+    image: pomerium/verify:latest
     networks:
       main:
         aliases:

--- a/content/docs/get-started/quickstart.mdx
+++ b/content/docs/get-started/quickstart.mdx
@@ -66,7 +66,7 @@ services:
         aliases:
           - verify.<CLUSTER_STARTER_SUBDOMAIN>.pomerium.app
   verify:
-    image: pomerium.com/pomerium/verify:latest
+    image: pomerium/verify:latest
     networks:
       main:
         aliases:

--- a/content/docs/guides/gitlab.mdx
+++ b/content/docs/guides/gitlab.mdx
@@ -212,7 +212,7 @@ Integrations that use unique subdomains will require their own certificates and 
     ...
 
       pomerium:
-        image: pomerium.com/pomerium/pomerium:latest
+        image: pomerium/pomerium:latest
         container_name: pomerium
         volumes:
           - ./srv/pomerium/config.yaml:/pomerium/config.yaml:ro

--- a/content/docs/guides/guacamole.md
+++ b/content/docs/guides/guacamole.md
@@ -122,7 +122,7 @@ In your Docker Compose file, replace `nginx` with Pomerium Core:
 
    ```yaml showLineNumbers
    pomerium:
-     image: pomerium.com/pomerium/pomerium:latest
+     image: pomerium/pomerium:latest
      # highlight-start
      # Mount your config file
      volumes:

--- a/content/docs/guides/hedgedoc.md
+++ b/content/docs/guides/hedgedoc.md
@@ -97,7 +97,7 @@ In your `docker-compose.yaml` file, add the following services:
 ```yaml
 services:
   pomerium:
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     volumes:
       # Mount your certificates
       - ./_wildcard.localhost.pomerium.io.pem:/pomerium/cert.pem:ro

--- a/content/docs/guides/tiddlywiki.mdx
+++ b/content/docs/guides/tiddlywiki.mdx
@@ -86,7 +86,7 @@ Add the following code in your `docker-compose.yaml` file:
 ```yaml title="docker-compose.yaml"
 services:
   pomerium:
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:

--- a/content/docs/integrations/user-identity/keycloak.mdx
+++ b/content/docs/integrations/user-identity/keycloak.mdx
@@ -50,14 +50,14 @@ services:
           - keycloak.localhost.pomerium.io
 
   pomerium:
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:
       - 443:443
 
   verify:
-    image: pomerium.com/pomerium/verify:latest
+    image: pomerium/verify:latest
     environment:
       JWKS_ENDPOINT: https://pomerium/.well-known/pomerium/jwks.json
 ```

--- a/content/docs/internals/configuration.mdx
+++ b/content/docs/internals/configuration.mdx
@@ -213,7 +213,7 @@ networks:
 services:
   pomerium-proxy:
     hostname: pomerium-proxy
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     networks:
       main: {}
     volumes:
@@ -231,7 +231,7 @@ services:
       - CERTIFICATE_AUTHORITY_FILE=/run/secrets/ca.pem
   pomerium-authorize:
     hostname: pomerium-authorize
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     networks:
       main: {}
     volumes:
@@ -243,7 +243,7 @@ services:
       - CERTIFICATE_AUTHORITY_FILE=/run/secrets/ca.pem
   pomerium-authenticate:
     hostname: pomerium-authenticate
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml
     secrets:
@@ -262,7 +262,7 @@ services:
           - authenticate.localhost.pomerium.io
   pomerium-databroker:
     hostname: pomerium-databroker
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     networks:
       main: {}
     volumes:

--- a/content/examples/docker/autocert.docker-compose.yml
+++ b/content/examples/docker/autocert.docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   pomerium:
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     environment:
       # Generate new secret keys. e.g. `head -c32 /dev/urandom | base64`
       - COOKIE_SECRET=V2JBZk0zWGtsL29UcFUvWjVDWWQ2UHExNXJ0b2VhcDI=
@@ -12,6 +12,6 @@ services:
 
   # https://verify.corp.beyondperimeter.com --> Pomerium --> http://verify
   verify:
-    image: pomerium.com/pomerium/verify:latest
+    image: pomerium/verify:latest
     expose:
       - 80

--- a/content/examples/docker/basic.docker-compose.yml.md
+++ b/content/examples/docker/basic.docker-compose.yml.md
@@ -1,7 +1,7 @@
 ```yaml
 services:
   pomerium:
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     volumes:
       ## Mount your config file: https://www.pomerium.com/docs/reference/
       - ./config.yaml:/pomerium/config.yaml:ro
@@ -9,7 +9,7 @@ services:
       - 443:443
   ## https://verify.localhost.pomerium.io --> Pomerium --> http://verify
   verify:
-    image: pomerium.com/pomerium/verify:latest
+    image: pomerium/verify:latest
     expose:
       - 8000
 ```

--- a/content/examples/docker/nginx.docker-compose.yml
+++ b/content/examples/docker/nginx.docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - /var/run/docker.sock:/tmp/docker.sock:ro
 
   pomerium-authenticate:
-    image: pomerium.com/pomerium/pomerium:latest # or `build: .` to build from source
+    image: pomerium/pomerium:latest # or `build: .` to build from source
     restart: always
     environment:
       - SERVICES=authenticate
@@ -59,7 +59,7 @@ services:
       - 443
 
   pomerium-authorize:
-    image: pomerium.com/pomerium/pomerium:latest # or `build: .` to build from source
+    image: pomerium/pomerium:latest # or `build: .` to build from source
     restart: always
     environment:
       - SERVICES=authorize
@@ -76,7 +76,7 @@ services:
       - 443
 
   pomerium-databroker:
-    image: pomerium.com/pomerium/pomerium:latest # or `build: .` to build from source
+    image: pomerium/pomerium:latest # or `build: .` to build from source
     restart: always
     environment:
       - SERVICES=databroker
@@ -93,7 +93,7 @@ services:
 
   # https://verify.corp.beyondperimeter.com
   verify:
-    image: pomerium.com/pomerium/verify:latest
+    image: pomerium/verify:latest
     expose:
       - 80
   # https://hello.corp.beyondperimeter.com

--- a/content/examples/enterprise/hosted-auth-docker.yaml.md
+++ b/content/examples/enterprise/hosted-auth-docker.yaml.md
@@ -1,7 +1,7 @@
 ```yaml title="docker-compose.yaml"
 services:
   pomerium:
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:
@@ -57,7 +57,7 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
   verify:
-    image: pomerium.com/pomerium/verify:latest
+    image: pomerium/verify:latest
     expose:
       - 8000
     restart: always

--- a/content/examples/guacamole/guacamole.docker-compose.md
+++ b/content/examples/guacamole/guacamole.docker-compose.md
@@ -57,7 +57,7 @@ services:
 
   # pomerium
   pomerium:
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:

--- a/content/examples/jenkins/jenkins-docker-compose.md
+++ b/content/examples/jenkins/jenkins-docker-compose.md
@@ -3,7 +3,7 @@ networks:
  main: {}
 services:
  pomerium:
-   image: pomerium.com/pomerium/pomerium:latest
+   image: pomerium/pomerium:latest
    volumes:
      - ./config.yaml:/pomerium/config.yaml:ro
    ports:
@@ -15,7 +15,7 @@ services:
  verify:
    networks:
      main: {}
-   image: pomerium.com/pomerium/verify:latest
+   image: pomerium/verify:latest
    expose:
      - 8000
  jenkins:

--- a/content/examples/nginx/docker-compose.yaml.md
+++ b/content/examples/nginx/docker-compose.yaml.md
@@ -18,11 +18,11 @@ services:
       - ./proxy.conf:/etc/nginx/proxy.conf
 
   verify:
-    image: pomerium.com/pomerium/verify:latest
+    image: pomerium/verify:latest
     expose:
       - 80
   pomerium:
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     expose:

--- a/content/examples/tcp/docker-compose.yaml.md
+++ b/content/examples/tcp/docker-compose.yaml.md
@@ -1,7 +1,7 @@
 ```yaml title="docker-compose.md"
 services:
   pomerium:
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     volumes:
       # Uncomment to mount certificates (optional)
       # - ./_wildcard.localhost.pomerium.io.pem:/pomerium/cert.pem:ro

--- a/content/examples/tiddlywiki/docker-compose.yaml.md
+++ b/content/examples/tiddlywiki/docker-compose.yaml.md
@@ -1,7 +1,7 @@
 ```yaml title="docker-compose.yaml"
 services:
   pomerium:
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     volumes:
       # Use a volume to store ACME certificates
       - ./config.yaml:/pomerium/config.yaml:ro

--- a/content/examples/tooljet/console-compose.yaml.md
+++ b/content/examples/tooljet/console-compose.yaml.md
@@ -3,7 +3,7 @@ networks:
   main: {}
 services:
   pomerium:
-    image: pomerium.com/pomerium/pomerium:v0.21.1
+    image: pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:
@@ -68,7 +68,7 @@ services:
   verify:
     networks:
       main: {}
-    image: pomerium.com/pomerium/verify:latest
+    image: pomerium/verify:latest
     expose:
       - 8000
     restart: always

--- a/content/examples/tooljet/docker-compose.yaml.md
+++ b/content/examples/tooljet/docker-compose.yaml.md
@@ -3,7 +3,7 @@ networks:
   main: {}
 services:
   pomerium:
-    image: pomerium.com/pomerium/pomerium:latest
+    image: pomerium/pomerium:latest
     volumes:
       ## Mount your config file: https://www.pomerium.com/docs/reference/
       - ./config.yaml:/pomerium/config.yaml:ro
@@ -18,7 +18,7 @@ services:
   verify:
     networks:
       main: {}
-    image: pomerium.com/pomerium/verify:latest
+    image: pomerium/verify:latest
     expose:
       - 8000
   tooljet:


### PR DESCRIPTION
This updates pomerium.com/pomerium/* and cr.pomerium.com/* images to use their pomerium/* counterparts.  