### PR TITLE
redirects: update troubleshooting

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -66,7 +66,8 @@ https://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
 /docs/deploy/clients/* /docs/deploy/clients
 
 # Zero references
-/docs/zero/cluster-status /docs/troubleshooting/cluster-status
+/docs/zero/cluster-status /docs/internals/troubleshooting
+/docs/troubleshooting/cluster-status /docs/internals/troubleshooting
 /docs/zero/upgrading /docs/deploy/upgrading
 
 # Old quickstart => /get-started/quickstart
@@ -120,8 +121,8 @@ https://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
 # Troubleshooting & FAQ
 /docs/FAQ.html /docs/internals/troubleshooting
 /docs/faq /docs/internals/troubleshooting
-/docs/internals/troubleshooting /docs/internals/troubleshooting
-/docs/internals/troubleshooting.html /docs/internals/troubleshooting
+/docs/troubleshooting /docs/internals/troubleshooting
+/docs/troubleshooting.html /docs/internals/troubleshooting
 
 # Architecture / background / upgrading
 /docs/architecture.html /docs/internals/architecture
@@ -289,7 +290,6 @@ https://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
 /docs/topics/ppl /docs/internals/ppl
 /docs/topics/production-deployment.html /docs/deploy/upgrading
 /docs/topics/programmatic-access.html /docs/internals/programmatic-access
-/docs/troubleshooting /docs/internals/troubleshooting
 /docs/zero/billing /docs/deploy/cloud/billing
 /docs/zero/import /docs/deploy/cloud/import
 /recipes/ad-guard /docs/guides/ad-guard


### PR DESCRIPTION
Update redirects for troubleshooting page. Add a cluster-status redirect for Pomerium Zero status page help links.

Related issue:
https://linear.app/pomerium/issue/ENG-1983/zerodocs-fix-troubleshootingcluster-status-links