### PR TITLE
fix cluster-status redirect

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -67,7 +67,7 @@ https://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
 
 # Zero references
 /docs/zero/cluster-status /docs/internals/clusters
-/docs/troubleshooting/cluster-status /docs/internals/clusters#cluster-status--troubleshooting
+/docs/troubleshooting/cluster-status /docs/internals/clusters
 /docs/zero/upgrading /docs/deploy/upgrading
 
 # Old quickstart => /get-started/quickstart


### PR DESCRIPTION
Related issue:
https://linear.app/pomerium/issue/ENG-1983/zerodocs-fix-troubleshootingcluster-status-links