### PR TITLE
fix version dropdown

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -136,8 +136,12 @@ const config = {
           dropdownActiveClassDisabled: true,
           dropdownItemsAfter: [
             {
-              to: 'https://0-28-0.docs.pomerium.com/docs',
-              label: 'v0.28 (latest)',
+              to: 'https://0-27-0.docs.pomerium.com/docs',
+              label: 'v0.27',
+            },
+            {
+              to: 'https://0-26-0.docs.pomerium.com/docs',
+              label: 'v0.26',
             },
             {
               type: 'html',


### PR DESCRIPTION
Update the version dropdown so it contains v0.28, v0.27, and v0.26.

Related issue:
https://linear.app/pomerium/issue/ENG-1994/docs-live-site-version-dropdown-contains-two-v028-links