### PR TITLE
OPE-117 add _headers to not index

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,2 @@
+/*
+  X-Robots-Tag: noindex

--- a/cspell.json
+++ b/cspell.json
@@ -230,6 +230,7 @@
     "docusaurus.config.js",
     "package.json",
     "sidebars.js",
-    "static/_redirects"
+    "static/_redirects",
+    "_headers"
   ]
 }


### PR DESCRIPTION
This adds a default header that marks docs as not to be indexed.   With a follow up, we'll want to make sure we add process to make sure the current current docs are allowed to be indexed. 

From the preview deployment a curl shows we have the desired header 
<img width="619" alt="Screenshot 2025-03-24 at 8 28 27 PM" src="https://github.com/user-attachments/assets/942c79df-a178-47c2-901d-0119111c7c42" />
