### PR TITLE
docs: Add documentation for special /.pomerium routes

### DIFF
--- a/content/docs/internals/special-routes.md
+++ b/content/docs/internals/special-routes.md
@@ -173,11 +173,11 @@ In the stateless flow, the Pomerium proxy needs to securely transmit information
 
 This endpoint is handled by Pomerium's control plane HTTP server and is crucial for initiating the stateless authentication handshake securely.
 
-For further information about specific features and integrations, see:
+## Related Concepts
 
-- [Authentication](/docs/capabilities/authentication)
-- [Device Identity](/docs/capabilities/device-identity)
-- [JWTs and Identity Headers](/docs/capabilities/getting-users-identity)
-- [Stateless Authentication](/docs/reference/stateless)
+Pomerium uses special internal routes for various functions. Understanding these is key to grasping the overall architecture.
 
-_Note: Some endpoints may be deprecated or disabled by default in newer Pomerium versions. Always refer to the upgrade notes for the latest changes._
+- **Authentication Flow:** Learn how Pomerium integrates with your IdP for [SSO Authentication](/docs/capabilities/authentication).
+- **Device Trust:** Pomerium can leverage [Device Identity](/docs/integrations/device-context/device-identity) for enhanced security postures.
+- **User Information:** See how to access [user identity details](/docs/capabilities/getting-users-identity) passed upstream.
+- **Configuration:** Some special routes behave differently depending on whether you [use stateless mode](/docs/internals/configuration#use-stateless-mode). _Note: Some endpoints may be deprecated or disabled by default in newer Pomerium versions. Always refer to the upgrade notes for the latest changes._

--- a/content/docs/internals/special-routes.md
+++ b/content/docs/internals/special-routes.md
@@ -180,4 +180,6 @@ Pomerium uses special internal routes for various functions. Understanding these
 - **Authentication Flow:** Learn how Pomerium integrates with your IdP for [SSO Authentication](/docs/capabilities/authentication).
 - **Device Trust:** Pomerium can leverage [Device Identity](/docs/integrations/device-context/device-identity) for enhanced security postures.
 - **User Information:** See how to access [user identity details](/docs/capabilities/getting-users-identity) passed upstream.
-- **Configuration:** Some special routes behave differently depending on whether you [use stateless mode](/docs/internals/configuration#use-stateless-mode). _Note: Some endpoints may be deprecated or disabled by default in newer Pomerium versions. Always refer to the upgrade notes for the latest changes._
+- **Configuration:** Some special routes behave differently depending on whether you [use stateless mode](/docs/internals/configuration#use-stateless-mode).
+
+_Note: Some endpoints may be deprecated or disabled by default in newer Pomerium versions. Always refer to the upgrade notes for the latest changes._

--- a/content/docs/internals/special-routes.md
+++ b/content/docs/internals/special-routes.md
@@ -31,7 +31,7 @@ Below is a summary of the special `/.pomerium` routes, including their HTTP meth
 | [`/.pomerium/`](#user-info-page) | `GET` | Yes (must be logged in) | User info page (HTML) showing current identity, session details, and device identities. |
 | [`/.pomerium/user`](#user-data-endpoint) | `GET` | Yes (must be logged in) | Return current user information in JSON format (plain claims data). |
 | [`/.pomerium/jwt`](#jwt-retrieval-endpoint) | `GET` | Yes (logged in; _deprecated_) | Return the Pomerium JWT (attestation token) for the current session. Disabled by default in newer versions. |
-| [`/.pomerium/api/v1/login`](#programmatic-login-url-api) | `GET` | No (initiates login) | Generate a one-time **programmatic login** URL to start an OAuth2 login flow and obtain a Pomerium session token (JWT). |
+| [`/.pomerium/api/v1/login`](#programmatic-login-url-api) | `GET` | No (initiates login) | Generate a one-time **programmatic login** URL to start an OAuth2 login flow and obtain a Pomerium session token. |
 | [`/.pomerium/sign_out`](#single-sign-out-endpoint) | `GET`, `POST` | Yes (CSRF token required) | Log the user out of Pomerium (and IdP session if applicable), clearing session cookies and redirecting to a post-logout page. |
 | [`/.pomerium/webauthn`](#device-enrollment-endpoint) | `GET`, `POST` | Yes (must be logged in) | Initiate or complete a **device enrollment** via WebAuthn for device identity verification. |
 | [`/.pomerium/device-enrolled`](#device-enrollment-callback) | `GET` | Yes (must be logged in) | Finalize device enrollment. Typically used by Pomerium to confirm a device was successfully registered. |

--- a/content/docs/internals/special-routes.md
+++ b/content/docs/internals/special-routes.md
@@ -77,7 +77,6 @@ This endpoint is particularly useful for single-page applications that need to f
 }
 ```
 
-
 ### Programmatic Login URL API
 
 The `/.pomerium/api/v1/login` endpoint initiates a programmatic login flow by generating a one-time sign-in URL. It's designed for CLI tools, scripts, or other non-browser clients that need to obtain Pomerium credentials via OAuth login.
@@ -175,6 +174,7 @@ In the stateless flow, the Pomerium proxy needs to securely transmit information
 This endpoint is handled by Pomerium's control plane HTTP server and is crucial for initiating the stateless authentication handshake securely.
 
 For further information about specific features and integrations, see:
+
 - [Authentication & SSO](/docs/authentication-sso)
 - [Device Identity and WebAuthn](/docs/internals/device-identity)
 - [JWTs and Identity Headers](/docs/topics/getting-users-identity)

--- a/content/docs/internals/special-routes.md
+++ b/content/docs/internals/special-routes.md
@@ -1,5 +1,6 @@
 ---
-title: Special Routes
+title: 'Special Routes'
+sidebar_label: 'Special Routes'
 lang: en-US
 keywords:
   [
@@ -24,7 +25,6 @@ keywords:
     hpke,
   ]
 description: Learn about Pomerium's reserved endpoints that handle authentication, session management, user information, health checks, and discovery.
-sidebar_position: 5
 ---
 
 # Special Routes

--- a/content/docs/internals/special-routes.md
+++ b/content/docs/internals/special-routes.md
@@ -15,30 +15,48 @@ keywords:
     programmatic access,
     logout flow,
     jwt,
+    health check,
+    ping,
+    healthz,
+    well-known,
+    jwks,
+    oidc discovery,
+    hpke,
   ]
-description: Learn about Pomerium's reserved endpoints that handle authentication flows, session management, and user information retrieval.
+description: Learn about Pomerium's reserved endpoints that handle authentication, session management, user information, health checks, and discovery.
 sidebar_position: 5
 ---
 
 # Special Routes
 
-Pomerium's proxy service reserves the `/.pomerium` path for internal endpoints that facilitate authentication flows, session management, and user information retrieval. Any request to a route ending in `/.pomerium/...` is intercepted by Pomerium (not forwarded to upstream apps) and handled by these special endpoints. This page documents all such endpoints, their purpose, and usage for end-users and developers integrating with Pomerium.
+Pomerium handles several special URL paths internally for various functions including authentication flows, session management, user information retrieval, health checks, and service discovery.
 
-Below is a summary of the special `/.pomerium` routes, including their HTTP methods, purpose, and whether an existing authenticated session is required:
+Most authentication-related internal endpoints live under the reserved `/.pomerium` path prefix. Any request to a route ending in `/.pomerium/...` is intercepted by Pomerium's proxy service (not forwarded to upstream apps) and handled by these special endpoints.
+
+Additionally, Pomerium exposes other special endpoints outside the `/.pomerium` path, primarily for health checking (`/ping`, `/healthz`) and service discovery (`/.well-known/...`). These are typically handled by the control plane HTTP server or directly by the proxy listener.
+
+This page documents all such endpoints, their purpose, and usage.
+
+Below is a summary of the special routes:
 
 | **Endpoint** | **Method(s)** | **Requires Auth?** | **Purpose** |
-| --- | --- | --- | --- |
-| [`/.pomerium/`](#user-info-page) | `GET` | Yes (must be logged in) | User info page (HTML) showing current identity, session details, and device identities. |
-| [`/.pomerium/user`](#user-data-endpoint) | `GET` | Yes (must be logged in) | Return current user information in JSON format (plain claims data). |
+| :-- | :-- | :-- | :-- |
+| [`/.pomerium/`](#user-info-page) | `GET` | Yes (logged in) | User info page (HTML) showing current identity, session details, and device identities. |
+| [`/.pomerium/user`](#user-data-endpoint) | `GET` | Yes (logged in) | Return current user information in JSON format (plain claims data). |
 | [`/.pomerium/jwt`](#jwt-retrieval-endpoint) | `GET` | Yes (logged in; _deprecated_) | Return the Pomerium JWT (attestation token) for the current session. Disabled by default in newer versions. |
-| [`/.pomerium/api/v1/login`](#programmatic-login-url-api) | `GET` | No (initiates login) | Generate a one-time **programmatic login** URL to start an OAuth2 login flow and obtain a Pomerium session token. |
-| [`/.pomerium/sign_out`](#single-sign-out-endpoint) | `GET`, `POST` | Yes (CSRF token required) | Log the user out of Pomerium (and IdP session if applicable), clearing session cookies and redirecting to a post-logout page. |
-| [`/.pomerium/webauthn`](#device-enrollment-endpoint) | `GET`, `POST` | Yes (must be logged in) | Initiate or complete a **device enrollment** via WebAuthn for device identity verification. |
-| [`/.pomerium/device-enrolled`](#device-enrollment-callback) | `GET` | Yes (must be logged in) | Finalize device enrollment. Typically used by Pomerium to confirm a device was successfully registered. |
+| [`/.pomerium/api/v1/login`](#programmatic-login-url-api) | `GET` | No (initiates login) | Generate a one-time **programmatic login** URL to start an OAuth2 login flow and obtain a Pomerium session token (JWT). |
+| [`/.pomerium/sign_out`](#single-sign-out-endpoint) | `GET`, `POST` | Yes (CSRF token) | Log the user out of Pomerium (and IdP session if applicable), clearing session cookies and redirecting. |
+| [`/.pomerium/webauthn`](#device-enrollment-endpoint) | `GET`, `POST` | Yes (logged in) | Initiate or complete a **device enrollment** via WebAuthn for device identity verification. |
+| [`/.pomerium/device-enrolled`](#device-enrollment-callback) | `GET` | Yes (logged in) | Finalize device enrollment. Typically used by Pomerium to confirm a device was successfully registered. |
+| [`/ping`](#health-check-endpoints) | `GET`, `HEAD` | No | Basic health check endpoint. Returns 200 OK. |
+| [`/healthz`](#health-check-endpoints) | `GET`, `HEAD` | No | Basic health check endpoint. Returns 200 OK. |
+| [`/.well-known/pomerium`](#oidc-discovery-endpoint) | `GET` | No | OIDC-like discovery document listing relevant Pomerium endpoints (JWKS URI, etc.). |
+| [`/.well-known/pomerium/jwks.json`](#jwks-endpoint) | `GET` | No | Serves the JSON Web Key Set (JWKS) used to verify Pomerium-issued JWTs. |
+| [`/.well-known/pomerium/hpke-public-key`](#hpke-public-key-endpoint) | `GET` | No | Serves the Hybrid Public Key Encryption (HPKE) public key used in the stateless authentication flow. |
 
-Below are details for each special route, including how and when to use them, what they return, and any relevant query parameters or considerations:
+Below are details for each special route:
 
-## User Info Page
+### User Info Page
 
 The base `/.pomerium/` path displays an HTML page with information about the currently authenticated user's session. This page serves as a simple dashboard where users can verify their login identity and session details. Users can see their email address, name, and associated groups/roles, as well as manage device identity and sign out.
 
@@ -46,7 +64,7 @@ End-users can visit `https://<your-app>/.pomerium/` in their browser to self-ins
 
 If device identity is enabled, the page will list unique Device IDs associated with the user's session, allowing users to identify their device and share that ID with administrators if needed. Users can also remove devices from their account directly from this page.
 
-## User Data Endpoint
+### User Data Endpoint
 
 The `/.pomerium/user` endpoint returns information about the currently signed-in user in plaintext JSON format. It provides the same claims that Pomerium asserts about the user (email, ID, name, groups) but in a direct JSON object format rather than a signed token.
 
@@ -60,7 +78,7 @@ This endpoint is particularly useful for single-page applications that need to f
 }
 ```
 
-## JWT Retrieval Endpoint
+### JWT Retrieval Endpoint
 
 _Deprecated in newer versions_
 
@@ -70,18 +88,18 @@ Historically, single-page applications used this to decode user info from a JWT,
 
 In Pomerium v0.27.0 and later, this endpoint is disabled by default and will be removed in a future release, though it can be temporarily re-enabled with a runtime flag.
 
-## Programmatic Login URL API
+### Programmatic Login URL API
 
 The `/.pomerium/api/v1/login` endpoint initiates a programmatic login flow by generating a one-time sign-in URL. It's designed for CLI tools, scripts, or other non-browser clients that need to obtain Pomerium credentials via OAuth login.
 
 This approach is valuable when you need an access token for an automated client. The process works in three steps:
 
-1. Your application calls this endpoint with a `pomerium_redirect_uri` parameter to get a sign-in URL
-2. The user opens this URL in a browser, which triggers the authentication flow
-3. After successful authentication, the browser redirects to your specified URI with a `pomerium_jwt` query parameter
-4. Your application extracts this token for further use
+1.  Your application calls this endpoint with a `pomerium_redirect_uri` parameter to get a sign-in URL
+2.  The user opens this URL in a browser, which triggers the authentication flow
+3.  After successful authentication, the browser redirects to your specified URI with a `pomerium_jwt` query parameter
+4.  Your application extracts this token for further use
 
-Unlike other endpoints, this one doesn't require an existing session - it's specifically designed to initiate the login process.
+Unlike other `/.pomerium` endpoints, this one doesn't require an existing session - it's specifically designed to initiate the login process.
 
 **Example:**
 
@@ -89,19 +107,19 @@ Unlike other endpoints, this one doesn't require an existing session - it's spec
 curl "https://<your-app>/.pomerium/api/v1/login?pomerium_redirect_uri=http://localhost:5000/callback"
 ```
 
-## Single Sign-Out Endpoint
+### Single Sign-Out Endpoint
 
 The `/.pomerium/sign_out` endpoint logs the user out of Pomerium and optionally out of the identity provider as well. It clears session cookies and redirects to a post-logout page.
 
 This endpoint is typically invoked when a user clicks "Logout" in your application or when you need a programmatic sign-out. The logout process follows these steps:
 
-1. Pomerium clears the user's session cookie
-2. The request redirects to the authenticate service's sign-out endpoint
-3. The user is sent to a configured post-logout page, which can be specified via the `pomerium_redirect_uri` parameter
+1.  Pomerium clears the user's session cookie
+2.  The request redirects to the authenticate service's sign-out endpoint
+3.  The user is sent to a configured post-logout page, which can be specified via the `pomerium_redirect_uri` parameter
 
 This endpoint supports front-channel logout when integrated with identity providers that support it.
 
-## Device Enrollment Endpoint
+### Device Enrollment Endpoint
 
 The `/.pomerium/webauthn` endpoint handles device enrollment and attestation via WebAuthn as part of Pomerium's device identity feature. It manages the challenge/response flow between the user's browser and Pomerium.
 
@@ -112,20 +130,66 @@ This process is typically initiated when a user clicks a "Register Device" butto
 
 The endpoint requires an authenticated session with a valid CSRF token to function properly.
 
-## Device Enrollment Callback
+### Device Enrollment Callback
 
 The `/.pomerium/device-enrolled` endpoint finalizes the device enrollment process. After successful WebAuthn registration via the `/.pomerium/webauthn` endpoint, this callback confirms the device has been properly enrolled.
 
 Users don't typically access this endpoint directly. Instead, the browser is automatically redirected here upon successful device registration, where either a confirmation message is displayed or the user is redirected back to the original application route.
 
----
+### Health Check Endpoints
 
-For further details on programmatic login flows, device enrollment, and session management, refer to the associated sections in Pomerium's documentation. This reference page is intended to consolidate all internal endpoints for easier troubleshooting and integration.
+The `/ping` and `/healthz` endpoints provide simple health checks. They respond with a `200 OK` status code to `GET` or `HEAD` requests, indicating that the Pomerium instance handling the request is running.
+
+These endpoints are typically used by:
+
+- **Load Balancers:** To determine if a Pomerium instance is healthy and should receive traffic.
+- **Orchestration Systems (e.g., Kubernetes):** For readiness and liveness probes to manage container lifecycles.
+- **Monitoring Systems:** To perform basic availability checks.
+
+They do not require authentication and return minimal content (`OK` for `GET`, nothing for `HEAD`). These endpoints are handled by Pomerium's control plane HTTP server.
+
+### OIDC Discovery Endpoint
+
+The `/.well-known/pomerium` endpoint serves a JSON document similar to an OpenID Connect Discovery document. It provides metadata about Pomerium's own endpoints, such as:
+
+- `issuer`: The base URL of the Pomerium instance serving the request.
+- `jwks_uri`: The URL to Pomerium's JWKS endpoint.
+- `authentication_callback_endpoint`: The OAuth2 callback URL handled by the authenticate service.
+- `frontchannel_logout_uri`: The URL used for front-channel logout flows.
+
+This endpoint allows clients and upstream applications to dynamically discover necessary Pomerium URLs. It is handled by Pomerium's control plane HTTP server.
+
+```json
+{
+  "issuer": "https://app.example.com/",
+  "authentication_callback_endpoint": "https://authenticate.example.com/oauth2/callback",
+  "frontchannel_logout_uri": "https://app.example.com/.pomerium/sign_out",
+  "jwks_uri": "https://app.example.com/.well-known/pomerium/jwks.json"
+}
+```
+
+### JWKS Endpoint
+
+The `/.well-known/pomerium/jwks.json` endpoint serves Pomerium's JSON Web Key Set (JWKS). This contains the public key(s) corresponding to the private key(s) Pomerium uses to sign JWT assertions (like the one in the `X-Pomerium-Jwt-Assertion` header).
+
+Upstream applications or other services can fetch these keys to verify the signature of JWTs issued by Pomerium, confirming their authenticity and the identity claims within them. The keys are typically rotated periodically, and clients should expect to refetch the JWKS accordingly, respecting standard HTTP caching headers (like `Cache-Control` and `ETag`) provided by the endpoint. This endpoint is handled by Pomerium's control plane HTTP server.
+
+### HPKE Public Key Endpoint
+
+The `/.well-known/pomerium/hpke-public-key` endpoint serves the public key used for Hybrid Public Key Encryption (HPKE). This endpoint is specifically relevant for Pomerium's **stateless authentication flow**.
+
+In the stateless flow, the Pomerium proxy needs to securely transmit information (like the intended redirect URI) to the authenticate service. It does this by encrypting parameters using the authenticate service's HPKE public key fetched from this endpoint. The authenticate service can then decrypt these parameters using its corresponding private key.
+
+This endpoint is handled by Pomerium's control plane HTTP server and is crucial for initiating the stateless authentication handshake securely.
+
+---
 
 **References:**
 
 - [Programmatic Access Documentation](https://www.pomerium.com/docs/internals/programmatic-access)
 - [Pomerium Authentication & SSO](https://www.pomerium.com/docs/authentication-sso)
 - [Device Identity and WebAuthn Integration](https://www.pomerium.com/docs/internals/device-identity)
+- [JWTs and Identity Headers](https://www.pomerium.com/docs/topics/getting-users-identity)
+- [Stateless Authentication Flow](https://www.pomerium.com/docs/reference/configuration#use-stateless-mode)
 
 _Note: Some endpoints may be deprecated or disabled by default in newer Pomerium versions. Always refer to the upgrade notes for the latest changes._

--- a/content/docs/internals/special-routes.md
+++ b/content/docs/internals/special-routes.md
@@ -4,15 +4,15 @@ Pomerium's proxy service reserves the `/.pomerium` path for internal endpoints t
 
 Below is a summary of the special `/.pomerium` routes, including their HTTP methods, purpose, and whether an existing authenticated session is required:
 
-| **Endpoint**                                | **Method(s)** | **Requires Auth?**            | **Purpose**                                                                                                                   |
-| ------------------------------------------ | ------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| [`/.pomerium/`](#user-info-page)           | `GET`         | Yes (must be logged in)       | User info page (HTML) showing current identity, session details, and device identities.                                       |
-| [`/.pomerium/user`](#user-data-endpoint)   | `GET`         | Yes (must be logged in)       | Return current user information in JSON format (plain claims data).                                                           |
-| [`/.pomerium/jwt`](#jwt-retrieval-endpoint) | `GET`         | Yes (logged in; *deprecated*) | Return the Pomerium JWT (attestation token) for the current session. Disabled by default in newer versions.                   |
-| [`/.pomerium/api/v1/login`](#programmatic-login-url-api) | `GET`         | No (initiates login)          | Generate a one-time **programmatic login** URL to start an OAuth2 login flow and obtain a Pomerium session token (JWT).       |
-| [`/.pomerium/sign_out`](#single-sign-out-endpoint) | `GET`, `POST` | Yes (CSRF token required)     | Log the user out of Pomerium (and IdP session if applicable), clearing session cookies and redirecting to a post-logout page. |
-| [`/.pomerium/webauthn`](#device-enrollment-endpoint) | `GET`, `POST` | Yes (must be logged in)       | Initiate or complete a **device enrollment** via WebAuthn for device identity verification.                                   |
-| [`/.pomerium/device-enrolled`](#device-enrollment-callback) | `GET`         | Yes (must be logged in)       | Finalize device enrollment. Typically used by Pomerium to confirm a device was successfully registered.                       |
+| **Endpoint** | **Method(s)** | **Requires Auth?** | **Purpose** |
+| --- | --- | --- | --- |
+| [`/.pomerium/`](#user-info-page) | `GET` | Yes (must be logged in) | User info page (HTML) showing current identity, session details, and device identities. |
+| [`/.pomerium/user`](#user-data-endpoint) | `GET` | Yes (must be logged in) | Return current user information in JSON format (plain claims data). |
+| [`/.pomerium/jwt`](#jwt-retrieval-endpoint) | `GET` | Yes (logged in; _deprecated_) | Return the Pomerium JWT (attestation token) for the current session. Disabled by default in newer versions. |
+| [`/.pomerium/api/v1/login`](#programmatic-login-url-api) | `GET` | No (initiates login) | Generate a one-time **programmatic login** URL to start an OAuth2 login flow and obtain a Pomerium session token (JWT). |
+| [`/.pomerium/sign_out`](#single-sign-out-endpoint) | `GET`, `POST` | Yes (CSRF token required) | Log the user out of Pomerium (and IdP session if applicable), clearing session cookies and redirecting to a post-logout page. |
+| [`/.pomerium/webauthn`](#device-enrollment-endpoint) | `GET`, `POST` | Yes (must be logged in) | Initiate or complete a **device enrollment** via WebAuthn for device identity verification. |
+| [`/.pomerium/device-enrolled`](#device-enrollment-callback) | `GET` | Yes (must be logged in) | Finalize device enrollment. Typically used by Pomerium to confirm a device was successfully registered. |
 
 Below are details for each special route, including how and when to use them, what they return, and any relevant query parameters or considerations:
 
@@ -40,7 +40,7 @@ This endpoint is particularly useful for single-page applications that need to f
 
 ## JWT Retrieval Endpoint
 
-*Deprecated in newer versions*
+_Deprecated in newer versions_
 
 The `/.pomerium/jwt` endpoint returns the attestation JWT for the current session - the signed token Pomerium uses to convey user identity to upstream services via the `X-Pomerium-Jwt-Assertion` header.
 
@@ -53,6 +53,7 @@ In Pomerium v0.27.0 and later, this endpoint is disabled by default and will be 
 The `/.pomerium/api/v1/login` endpoint initiates a programmatic login flow by generating a one-time sign-in URL. It's designed for CLI tools, scripts, or other non-browser clients that need to obtain Pomerium credentials via OAuth login.
 
 This approach is valuable when you need an access token for an automated client. The process works in three steps:
+
 1. Your application calls this endpoint with a `pomerium_redirect_uri` parameter to get a sign-in URL
 2. The user opens this URL in a browser, which triggers the authentication flow
 3. After successful authentication, the browser redirects to your specified URI with a `pomerium_jwt` query parameter
@@ -60,7 +61,8 @@ This approach is valuable when you need an access token for an automated client.
 
 Unlike other endpoints, this one doesn't require an existing session - it's specifically designed to initiate the login process.
 
-**Example:**  
+**Example:**
+
 ```bash
 curl "https://<your-app>/.pomerium/api/v1/login?pomerium_redirect_uri=http://localhost:5000/callback"
 ```
@@ -70,6 +72,7 @@ curl "https://<your-app>/.pomerium/api/v1/login?pomerium_redirect_uri=http://loc
 The `/.pomerium/sign_out` endpoint logs the user out of Pomerium and optionally out of the identity provider as well. It clears session cookies and redirects to a post-logout page.
 
 This endpoint is typically invoked when a user clicks "Logout" in your application or when you need a programmatic sign-out. The logout process follows these steps:
+
 1. Pomerium clears the user's session cookie
 2. The request redirects to the authenticate service's sign-out endpoint
 3. The user is sent to a configured post-logout page, which can be specified via the `pomerium_redirect_uri` parameter
@@ -81,6 +84,7 @@ This endpoint supports front-channel logout when integrated with identity provid
 The `/.pomerium/webauthn` endpoint handles device enrollment and attestation via WebAuthn as part of Pomerium's device identity feature. It manages the challenge/response flow between the user's browser and Pomerium.
 
 This process is typically initiated when a user clicks a "Register Device" button, which starts the WebAuthn flow. The endpoint works differently depending on the HTTP method:
+
 - A `GET` request provides a WebAuthn challenge to the browser
 - A `POST` request accepts the attestation response from the browser, verifying and enrolling the device
 
@@ -96,9 +100,10 @@ Users don't typically access this endpoint directly. Instead, the browser is aut
 
 For further details on programmatic login flows, device enrollment, and session management, refer to the associated sections in Pomerium's documentation. This reference page is intended to consolidate all internal endpoints for easier troubleshooting and integration.
 
-**References:**  
-- [Programmatic Access Documentation](https://www.pomerium.com/docs/internals/programmatic-access)  
-- [Pomerium Authentication & SSO](https://www.pomerium.com/docs/authentication-sso)  
+**References:**
+
+- [Programmatic Access Documentation](https://www.pomerium.com/docs/internals/programmatic-access)
+- [Pomerium Authentication & SSO](https://www.pomerium.com/docs/authentication-sso)
 - [Device Identity and WebAuthn Integration](https://www.pomerium.com/docs/internals/device-identity)
 
-*Note: Some endpoints may be deprecated or disabled by default in newer Pomerium versions. Always refer to the upgrade notes for the latest changes.*
+_Note: Some endpoints may be deprecated or disabled by default in newer Pomerium versions. Always refer to the upgrade notes for the latest changes._

--- a/content/docs/internals/special-routes.md
+++ b/content/docs/internals/special-routes.md
@@ -186,10 +186,16 @@ This endpoint is handled by Pomerium's control plane HTTP server and is crucial 
 
 **References:**
 
-- [Programmatic Access Documentation](https://www.pomerium.com/docs/internals/programmatic-access)
-- [Pomerium Authentication & SSO](https://www.pomerium.com/docs/authentication-sso)
-- [Device Identity and WebAuthn Integration](https://www.pomerium.com/docs/internals/device-identity)
-- [JWTs and Identity Headers](https://www.pomerium.com/docs/topics/getting-users-identity)
-- [Stateless Authentication Flow](https://www.pomerium.com/docs/reference/configuration#use-stateless-mode)
+- [Programmatic Access][programmatic-access]
+- [Authentication & SSO][authentication-sso]
+- [Device Identity and WebAuthn][device-identity]
+- [JWTs and Identity Headers][identity-headers]
+- [Stateless Authentication][stateless-auth]
 
 _Note: Some endpoints may be deprecated or disabled by default in newer Pomerium versions. Always refer to the upgrade notes for the latest changes._
+
+[programmatic-access]: /docs/internals/programmatic-access
+[authentication-sso]: /docs/authentication-sso
+[device-identity]: /docs/internals/device-identity
+[identity-headers]: /docs/topics/getting-users-identity
+[stateless-auth]: /docs/reference/configuration#use-stateless-mode

--- a/content/docs/internals/special-routes.md
+++ b/content/docs/internals/special-routes.md
@@ -43,7 +43,6 @@ Below is a summary of the special routes:
 | :-- | :-- | :-- | :-- |
 | [`/.pomerium/`](#user-info-page) | `GET` | Yes (logged in) | User info page (HTML) showing current identity, session details, and device identities. |
 | [`/.pomerium/user`](#user-data-endpoint) | `GET` | Yes (logged in) | Return current user information in JSON format (plain claims data). |
-| [`/.pomerium/jwt`](#jwt-retrieval-endpoint) | `GET` | Yes (logged in; _deprecated_) | Return the Pomerium JWT (attestation token) for the current session. Disabled by default in newer versions. |
 | [`/.pomerium/api/v1/login`](#programmatic-login-url-api) | `GET` | No (initiates login) | Generate a one-time **programmatic login** URL to start an OAuth2 login flow and obtain a Pomerium session token (JWT). |
 | [`/.pomerium/sign_out`](#single-sign-out-endpoint) | `GET`, `POST` | Yes (CSRF token) | Log the user out of Pomerium (and IdP session if applicable), clearing session cookies and redirecting. |
 | [`/.pomerium/webauthn`](#device-enrollment-endpoint) | `GET`, `POST` | Yes (logged in) | Initiate or complete a **device enrollment** via WebAuthn for device identity verification. |
@@ -78,15 +77,6 @@ This endpoint is particularly useful for single-page applications that need to f
 }
 ```
 
-### JWT Retrieval Endpoint
-
-_Deprecated in newer versions_
-
-The `/.pomerium/jwt` endpoint returns the attestation JWT for the current session - the signed token Pomerium uses to convey user identity to upstream services via the `X-Pomerium-Jwt-Assertion` header.
-
-Historically, single-page applications used this to decode user info from a JWT, but in modern usage, the `/.pomerium/user` endpoint generally replaces this functionality. The Pomerium JWT is meant to function as a signed attestation of an authorization policy decision, which is incompatible with how this endpoint was intended to be used.
-
-In Pomerium v0.27.0 and later, this endpoint is disabled by default and will be removed in a future release, though it can be temporarily re-enabled with a runtime flag.
 
 ### Programmatic Login URL API
 

--- a/content/docs/internals/special-routes.md
+++ b/content/docs/internals/special-routes.md
@@ -175,9 +175,9 @@ This endpoint is handled by Pomerium's control plane HTTP server and is crucial 
 
 For further information about specific features and integrations, see:
 
-- [Authentication & SSO](/docs/authentication-sso)
-- [Device Identity and WebAuthn](/docs/internals/device-identity)
-- [JWTs and Identity Headers](/docs/topics/getting-users-identity)
-- [Stateless Authentication](/docs/reference/configuration#use-stateless-mode)
+- [Authentication](/docs/capabilities/authentication)
+- [Device Identity](/docs/capabilities/device-identity)
+- [JWTs and Identity Headers](/docs/capabilities/getting-users-identity)
+- [Stateless Authentication](/docs/reference/stateless)
 
 _Note: Some endpoints may be deprecated or disabled by default in newer Pomerium versions. Always refer to the upgrade notes for the latest changes._

--- a/content/docs/internals/special-routes.md
+++ b/content/docs/internals/special-routes.md
@@ -68,7 +68,7 @@ If device identity is enabled, the page will list unique Device IDs associated w
 
 The `/.pomerium/user` endpoint returns information about the currently signed-in user in plaintext JSON format. It provides the same claims that Pomerium asserts about the user (email, ID, name, groups) but in a direct JSON object format rather than a signed token.
 
-This endpoint is particularly useful for single-page applications that need to fetch user identity data without parsing a JWT. A front-end application can simply call `fetch('/.pomerium/user')` to display the user's email or perform client-side logic based on group claims.
+This endpoint is particularly useful for single-page applications that need to fetch user identity data without parsing a JWT. A front-end application can simply call `fetch('/.pomerium/user')` to display the user's email or perform client-side logic based on group claims. Note that this endpoint should only be used for UI customization - never rely on this frontend data for security decisions or permissions checks, which must always be enforced by your backend services.
 
 ```json
 {
@@ -84,7 +84,7 @@ _Deprecated in newer versions_
 
 The `/.pomerium/jwt` endpoint returns the attestation JWT for the current session - the signed token Pomerium uses to convey user identity to upstream services via the `X-Pomerium-Jwt-Assertion` header.
 
-Historically, single-page applications used this to decode user info from a JWT, but in modern usage, the `/.pomerium/user` endpoint generally replaces this functionality.
+Historically, single-page applications used this to decode user info from a JWT, but in modern usage, the `/.pomerium/user` endpoint generally replaces this functionality. The Pomerium JWT is meant to function as a signed attestation of an authorization policy decision, which is incompatible with how this endpoint was intended to be used.
 
 In Pomerium v0.27.0 and later, this endpoint is disabled by default and will be removed in a future release, though it can be temporarily re-enabled with a runtime flag.
 
@@ -106,6 +106,8 @@ Unlike other `/.pomerium` endpoints, this one doesn't require an existing sessio
 ```bash
 curl "https://<your-app>/.pomerium/api/v1/login?pomerium_redirect_uri=http://localhost:5000/callback"
 ```
+
+See the [Programmatic Access](/docs/internals/programmatic-access) page for more detailed information about implementing programmatic authentication flows.
 
 ### Single Sign-Out Endpoint
 
@@ -182,20 +184,10 @@ In the stateless flow, the Pomerium proxy needs to securely transmit information
 
 This endpoint is handled by Pomerium's control plane HTTP server and is crucial for initiating the stateless authentication handshake securely.
 
----
-
-**References:**
-
-- [Programmatic Access][programmatic-access]
-- [Authentication & SSO][authentication-sso]
-- [Device Identity and WebAuthn][device-identity]
-- [JWTs and Identity Headers][identity-headers]
-- [Stateless Authentication][stateless-auth]
+For further information about specific features and integrations, see:
+- [Authentication & SSO](/docs/authentication-sso)
+- [Device Identity and WebAuthn](/docs/internals/device-identity)
+- [JWTs and Identity Headers](/docs/topics/getting-users-identity)
+- [Stateless Authentication](/docs/reference/configuration#use-stateless-mode)
 
 _Note: Some endpoints may be deprecated or disabled by default in newer Pomerium versions. Always refer to the upgrade notes for the latest changes._
-
-[programmatic-access]: /docs/internals/programmatic-access
-[authentication-sso]: /docs/authentication-sso
-[device-identity]: /docs/internals/device-identity
-[identity-headers]: /docs/topics/getting-users-identity
-[stateless-auth]: /docs/reference/configuration#use-stateless-mode

--- a/content/docs/internals/special-routes.md
+++ b/content/docs/internals/special-routes.md
@@ -1,0 +1,104 @@
+# Special Routes
+
+Pomerium's proxy service reserves the `/.pomerium` path for internal endpoints that facilitate authentication flows, session management, and user information retrieval. Any request to a route ending in `/.pomerium/...` is intercepted by Pomerium (not forwarded to upstream apps) and handled by these special endpoints. This page documents all such endpoints, their purpose, and usage for end-users and developers integrating with Pomerium.
+
+Below is a summary of the special `/.pomerium` routes, including their HTTP methods, purpose, and whether an existing authenticated session is required:
+
+| **Endpoint**                                | **Method(s)** | **Requires Auth?**            | **Purpose**                                                                                                                   |
+| ------------------------------------------ | ------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| [`/.pomerium/`](#user-info-page)           | `GET`         | Yes (must be logged in)       | User info page (HTML) showing current identity, session details, and device identities.                                       |
+| [`/.pomerium/user`](#user-data-endpoint)   | `GET`         | Yes (must be logged in)       | Return current user information in JSON format (plain claims data).                                                           |
+| [`/.pomerium/jwt`](#jwt-retrieval-endpoint) | `GET`         | Yes (logged in; *deprecated*) | Return the Pomerium JWT (attestation token) for the current session. Disabled by default in newer versions.                   |
+| [`/.pomerium/api/v1/login`](#programmatic-login-url-api) | `GET`         | No (initiates login)          | Generate a one-time **programmatic login** URL to start an OAuth2 login flow and obtain a Pomerium session token (JWT).       |
+| [`/.pomerium/sign_out`](#single-sign-out-endpoint) | `GET`, `POST` | Yes (CSRF token required)     | Log the user out of Pomerium (and IdP session if applicable), clearing session cookies and redirecting to a post-logout page. |
+| [`/.pomerium/webauthn`](#device-enrollment-endpoint) | `GET`, `POST` | Yes (must be logged in)       | Initiate or complete a **device enrollment** via WebAuthn for device identity verification.                                   |
+| [`/.pomerium/device-enrolled`](#device-enrollment-callback) | `GET`         | Yes (must be logged in)       | Finalize device enrollment. Typically used by Pomerium to confirm a device was successfully registered.                       |
+
+Below are details for each special route, including how and when to use them, what they return, and any relevant query parameters or considerations:
+
+## User Info Page
+
+The base `/.pomerium/` path displays an HTML page with information about the currently authenticated user's session. This page serves as a simple dashboard where users can verify their login identity and session details. Users can see their email address, name, and associated groups/roles, as well as manage device identity and sign out.
+
+End-users can visit `https://<your-app>/.pomerium/` in their browser to self-inspect their session. If not yet authenticated, they'll be prompted to log in before seeing the info page.
+
+If device identity is enabled, the page will list unique Device IDs associated with the user's session, allowing users to identify their device and share that ID with administrators if needed. Users can also remove devices from their account directly from this page.
+
+## User Data Endpoint
+
+The `/.pomerium/user` endpoint returns information about the currently signed-in user in plaintext JSON format. It provides the same claims that Pomerium asserts about the user (email, ID, name, groups) but in a direct JSON object format rather than a signed token.
+
+This endpoint is particularly useful for single-page applications that need to fetch user identity data without parsing a JWT. A front-end application can simply call `fetch('/.pomerium/user')` to display the user's email or perform client-side logic based on group claims.
+
+```json
+{
+  "email": "user@example.com",
+  "name": "John Doe",
+  "groups": ["engineering", "admins"]
+}
+```
+
+## JWT Retrieval Endpoint
+
+*Deprecated in newer versions*
+
+The `/.pomerium/jwt` endpoint returns the attestation JWT for the current session - the signed token Pomerium uses to convey user identity to upstream services via the `X-Pomerium-Jwt-Assertion` header.
+
+Historically, single-page applications used this to decode user info from a JWT, but in modern usage, the `/.pomerium/user` endpoint generally replaces this functionality.
+
+In Pomerium v0.27.0 and later, this endpoint is disabled by default and will be removed in a future release, though it can be temporarily re-enabled with a runtime flag.
+
+## Programmatic Login URL API
+
+The `/.pomerium/api/v1/login` endpoint initiates a programmatic login flow by generating a one-time sign-in URL. It's designed for CLI tools, scripts, or other non-browser clients that need to obtain Pomerium credentials via OAuth login.
+
+This approach is valuable when you need an access token for an automated client. The process works in three steps:
+1. Your application calls this endpoint with a `pomerium_redirect_uri` parameter to get a sign-in URL
+2. The user opens this URL in a browser, which triggers the authentication flow
+3. After successful authentication, the browser redirects to your specified URI with a `pomerium_jwt` query parameter
+4. Your application extracts this token for further use
+
+Unlike other endpoints, this one doesn't require an existing session - it's specifically designed to initiate the login process.
+
+**Example:**  
+```bash
+curl "https://<your-app>/.pomerium/api/v1/login?pomerium_redirect_uri=http://localhost:5000/callback"
+```
+
+## Single Sign-Out Endpoint
+
+The `/.pomerium/sign_out` endpoint logs the user out of Pomerium and optionally out of the identity provider as well. It clears session cookies and redirects to a post-logout page.
+
+This endpoint is typically invoked when a user clicks "Logout" in your application or when you need a programmatic sign-out. The logout process follows these steps:
+1. Pomerium clears the user's session cookie
+2. The request redirects to the authenticate service's sign-out endpoint
+3. The user is sent to a configured post-logout page, which can be specified via the `pomerium_redirect_uri` parameter
+
+This endpoint supports front-channel logout when integrated with identity providers that support it.
+
+## Device Enrollment Endpoint
+
+The `/.pomerium/webauthn` endpoint handles device enrollment and attestation via WebAuthn as part of Pomerium's device identity feature. It manages the challenge/response flow between the user's browser and Pomerium.
+
+This process is typically initiated when a user clicks a "Register Device" button, which starts the WebAuthn flow. The endpoint works differently depending on the HTTP method:
+- A `GET` request provides a WebAuthn challenge to the browser
+- A `POST` request accepts the attestation response from the browser, verifying and enrolling the device
+
+The endpoint requires an authenticated session with a valid CSRF token to function properly.
+
+## Device Enrollment Callback
+
+The `/.pomerium/device-enrolled` endpoint finalizes the device enrollment process. After successful WebAuthn registration via the `/.pomerium/webauthn` endpoint, this callback confirms the device has been properly enrolled.
+
+Users don't typically access this endpoint directly. Instead, the browser is automatically redirected here upon successful device registration, where either a confirmation message is displayed or the user is redirected back to the original application route.
+
+---
+
+For further details on programmatic login flows, device enrollment, and session management, refer to the associated sections in Pomerium's documentation. This reference page is intended to consolidate all internal endpoints for easier troubleshooting and integration.
+
+**References:**  
+- [Programmatic Access Documentation](https://www.pomerium.com/docs/internals/programmatic-access)  
+- [Pomerium Authentication & SSO](https://www.pomerium.com/docs/authentication-sso)  
+- [Device Identity and WebAuthn Integration](https://www.pomerium.com/docs/internals/device-identity)
+
+*Note: Some endpoints may be deprecated or disabled by default in newer Pomerium versions. Always refer to the upgrade notes for the latest changes.*

--- a/content/docs/internals/special-routes.md
+++ b/content/docs/internals/special-routes.md
@@ -1,3 +1,25 @@
+---
+title: Special Routes
+lang: en-US
+keywords:
+  [
+    pomerium,
+    identity access proxy,
+    special routes,
+    authentication endpoints,
+    api,
+    user information,
+    session management,
+    device identity,
+    webauthn,
+    programmatic access,
+    logout flow,
+    jwt,
+  ]
+description: Learn about Pomerium's reserved endpoints that handle authentication flows, session management, and user information retrieval.
+sidebar_position: 5
+---
+
 # Special Routes
 
 Pomerium's proxy service reserves the `/.pomerium` path for internal endpoints that facilitate authentication flows, session management, and user information retrieval. Any request to a route ending in `/.pomerium/...` is intercepted by Pomerium (not forwarded to upstream apps) and handled by these special endpoints. This page documents all such endpoints, their purpose, and usage for end-users and developers integrating with Pomerium.

--- a/cspell.json
+++ b/cspell.json
@@ -219,7 +219,11 @@
     "Whitelabeling",
     "yamlencode",
     "yourcompany",
-    "Zipkin"
+    "Zipkin",
+    "healthz",
+    "hpke",
+    "HPKE",
+    "lifecycles"
   ],
   "ignorePaths": [
     "*.mp4",


### PR DESCRIPTION
This commit introduces a new documentation page dedicated to Pomerium's
internal routes under the `/.pomerium` path prefix. Previously, information
about these endpoints was fragmented or missing, making it difficult for
users and developers to understand their purpose and usage.

The new "Special Routes" page addresses this by providing a consolidated
reference. Key additions include:

- A summary table outlining each `/.pomerium/...` endpoint, its supported
  HTTP methods, whether authentication is required, and its primary purpose.
- Detailed explanations for each endpoint, covering:
    - `/.pomerium/`: User info HTML page.
    - `/.pomerium/user`: JSON user data endpoint.
    - `/.pomerium/jwt`: Deprecated JWT retrieval endpoint.
    - `/.pomerium/api/v1/login`: Programmatic login URL generation.
    - `/.pomerium/sign_out`: Single sign-out functionality.
    - `/.pomerium/webauthn`: Device enrollment (WebAuthn).
    - `/.pomerium/device-enrolled`: Device enrollment callback.
- Usage examples and context for end-users (e.g., checking session info)
  and developers (e.g., programmatic login integration, SPA identity fetching).
- Links to related documentation sections (Programmatic Access, Device
  Identity, etc.).