### PR TITLE
Fix Terraform HCL code formatting

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -221,6 +221,7 @@ const config = {
         'nginx',
         'rego',
         'shell-session',
+        'hcl',
       ],
     },
     mermaid: {


### PR DESCRIPTION
By default, Prism does not support HCL, but with a config option, HCL syntax highlighting can be enabled.

This will add a splash of color to https://docs.pomerium.com/docs/deploy/enterprise/configure-terraform and any more hcl code snippets.