### PR TITLE
Fix version tag references that were missed

### DIFF
--- a/content/docs/deploy/k8s/install.md
+++ b/content/docs/deploy/k8s/install.md
@@ -18,7 +18,7 @@ Use Pomerium as a first-class secure-by-default Ingress Controller. The Pomerium
 ## Deploy
 
 ```console
-kubectl apply -k github.com/pomerium/ingress-controller/config/default\?ref=v0.27.2
+kubectl apply -k github.com/pomerium/ingress-controller/config/default\?ref=v0.29.0
 ```
 
 The Pomerium Ingress Controller is now installed into your cluster.
@@ -150,7 +150,7 @@ Make sure to always restrict access to the envoy admin interface ingress.
 
 ```yaml title="kustomization.yaml"
 resources:
-  - github.com/pomerium/ingress-controller/config/default?ref=v0.27.2
+  - github.com/pomerium/ingress-controller/config/default?ref=v0.29.0
   - admin-service.yaml
   - admin-ingress.yaml
 patches:

--- a/content/docs/deploy/k8s/quickstart.mdx
+++ b/content/docs/deploy/k8s/quickstart.mdx
@@ -56,7 +56,7 @@ mkcert "*.localhost.pomerium.io"
 1. Install Pomerium to your cluster:
 
 ```sh
-kubectl apply -k github.com/pomerium/ingress-controller/config/default\?ref=v0.27.2
+kubectl apply -k github.com/pomerium/ingress-controller/config/default\?ref=v0.29.0
 ```
 
 This will create all the components of Pomerium in the `pomerium` namespace, as well as a bootstrap secret:

--- a/content/examples/enterprise/hosted-auth-docker.yaml.md
+++ b/content/examples/enterprise/hosted-auth-docker.yaml.md
@@ -19,7 +19,7 @@ services:
         condition: service_healthy
       pomerium:
         condition: service_started
-    image: docker.cloudsmith.io/pomerium/enterprise/pomerium-console:v0.27.2
+    image: docker.cloudsmith.io/pomerium/enterprise/pomerium-console:v0.29.0
     command:
       - 'serve'
       - '--config'

--- a/k8s/console/deployment/image.yaml
+++ b/k8s/console/deployment/image.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: pomerium-console
-          image: docker.cloudsmith.io/pomerium/enterprise/pomerium-console:v0.27.3
+          image: docker.cloudsmith.io/pomerium/enterprise/pomerium-console:v0.29.0
           imagePullPolicy: IfNotPresent
       imagePullSecrets:
         - name: pomerium-enterprise-docker

--- a/k8s/core/kustomization.yaml
+++ b/k8s/core/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: pomerium
 resources:
-  - github.com/pomerium/ingress-controller/config/default?ref=v0.27.2
+  - github.com/pomerium/ingress-controller/config/default?ref=v0.29.0
   - service.yaml
 patches:
   - patch: |-


### PR DESCRIPTION
These weren't updated with the 0.28 release, so they were missed again when we moved 0.28 references to 0.29.