### PR TITLE
remove broken link to GitHub packages

### DIFF
--- a/content/docs/deploy/core.mdx
+++ b/content/docs/deploy/core.mdx
@@ -91,7 +91,7 @@ apt-get update && apt-get install pomerium
 
 ## Docker Images
 
-We also provide container images on [Docker Hub](https://hub.docker.com/r/pomerium/pomerium) and [GitHub Packages](https://github.com/pomerium/pomerium/pkgs/container/pomerium). Common tags:
+We also provide container images on [Docker Hub](https://hub.docker.com/r/pomerium/pomerium). Common tags:
 
 - **`:latest`** → The most recent stable release
 - **`:vX.Y.Z`** → A specific release


### PR DESCRIPTION
Related issue:
https://linear.app/pomerium/issue/ENG-2232/remove-github-packages-link-from-core-docs