### PR TITLE
add a missing ingress annotation link

### DIFF
--- a/content/docs/deploy/k8s/ingress.md
+++ b/content/docs/deploy/k8s/ingress.md
@@ -672,6 +672,7 @@ For more information on the Pomerium Ingress Controller or the Kubernetes concep
 [`ingress.pomerium.io/timeout`]: /docs/reference/routes/timeouts#route-timeout
 [`ingress.pomerium.io/tls_upstream_server_name`]: /docs/reference/routes/tls#tls-upstream-server-name
 [`ingress.pomerium.io/tls_downstream_server_name`]: /docs/reference/routes/tls-downstream-server-name
+[`ingress.pomerium.io/tls_server_name`]: /docs/reference/routes/tls#tls-upstream-server-name
 [`ingress.pomerium.io/tls_skip_verify`]: /docs/reference/routes/tls#tls-skip-verification
 [`tls_custom_ca_secret`]: /docs/reference/routes/tls#tls-custom-certificate-authority
 [client-certificate-authority]: /docs/reference/certificates


### PR DESCRIPTION
Add a missing link target in the "Pomerium-Standard Annotations" list on the Ingress Configuration page. It looks like this setting was renamed in https://github.com/pomerium/pomerium/pull/3243 (from `tls_server_name` to `tls_upstream_server_name`) but the Ingress annotation was never updated to match.

Related issue: https://linear.app/pomerium/issue/ENG-2333/ingress-controller-outdated-tls-server-name-annotation