### PR TITLE
update bearer token format limitations

### DIFF
--- a/content/docs/capabilities/authentication.mdx
+++ b/content/docs/capabilities/authentication.mdx
@@ -54,7 +54,7 @@ By configuring your applications to route requests to Pomerium's Proxy service, 
 
 ## Direct IdP Token Authentication
 
-Pomerium also supports authenticating users using an Identity Provider’s access token directly, without a full OAuth browser redirect flow. If a user or service has already obtained a valid access token from Microsoft Entra ID, they can present it to Pomerium to gain access, rather than going through the usual login redirect. Pomerium will validate the token with the IdP and create a session for the associated user.
+Pomerium also supports authenticating users using an Identity Provider’s access token directly, without a full OAuth browser redirect flow. If a user or service has already obtained a valid access token or identity token, they can present it to Pomerium to gain access, rather than going through the usual login redirect. Pomerium will validate the token with the IdP and create a session for the associated user.
 
 ### Benefits
 
@@ -65,8 +65,6 @@ Pomerium also supports authenticating users using an Identity Provider’s acces
 **Secure Validation:** Pomerium verifies the token’s signature and claims with the IdP (ensuring it’s not expired, issued for the correct client, etc.) before trusting it. Only tokens from configured, trusted IdPs are accepted.
 
 ### Limitations
-
-Microsoft Entra ID is supported, but future Pomerium updates may expand direct token support to other providers.
 
 Direct IdP token authentication is an opt-in capability that can be enabled through [Pomerium configuration](/docs/reference/bearer-token-format). This enhancement makes Pomerium even more flexible in hybrid environments where not all clients are web browsers.
 

--- a/content/docs/reference/bearer-token-format.mdx
+++ b/content/docs/reference/bearer-token-format.mdx
@@ -29,7 +29,7 @@ Authorization: Bearer Token
 
 Pomerium's `default` behavior is to pass bearer tokens to upstream applications without interpreting them. Pomerium also supports creating sessions from tokens issued by an identity provider without needing to initiate an interactive login. If the `idp_access_token` option is used, then the bearer token will be interpreted as an IdP-issued access token. If the `idp_identity_token` option is used, then the bearer token will be interpreted as an IdP-issued identity token.
 
-Currently only [Microsoft Entra](../integrations/user-identity/azure) is supported with this option.
+Since v0.30 access and identity tokens are supported by all IdPs, except Apple does not support access tokens, and GitHub does not support identity tokens.
 
 This option can also be configured at the route-level.
 


### PR DESCRIPTION
Update the documentation about bearer token formats. All IdPs are now supported, not just Microsoft Entra.