### PR TITLE
fix ToC formatting on Connections page

### DIFF
--- a/content/docs/internals/connection.mdx
+++ b/content/docs/internals/connection.mdx
@@ -18,11 +18,11 @@ The primary focus of this document is the management of transport layer connecti
 
 TCP and UDP traffic is tunneled over HTTP, so let's focus on the HTTP connection lifecycle.
 
-### 1. **Downstream connection and TLS termination**
+### 1. Downstream connection and TLS termination
 
 - A client, usually a web browser, [Pomerium CLI](/docs/deploy/clients), or [Pomerium Desktop App](/docs/deploy/clients), initiates a connection to Pomerium. This connection can be HTTP/1.1, HTTP/2, or HTTP/3.
 
-:::tip **Note**
+:::tip Note
 
 HTTP/2 and HTTP/1.1 are allowed by default, with most modern browsers defaulting to HTTP/2.
 
@@ -36,25 +36,25 @@ In rare circumstances, you may need to force HTTP/1.1 using the [`codec_type`](/
 - Optionally, [client-side mTLS](/docs/internals/certificates-and-tls) can be enabled for downstream connections to enforce the use and validation of client certificates.
 - Pomerium enforces some [minimum TLS requirements](/docs/internals/security#downstream-tls) for best practice, which are non-configurable.
 
-### 2. **Request initiation**
+### 2. Request initiation
 
 After TLS handshakes are complete, the downstream client sends an HTTP request. The proxy parses this request, matches it against the configured routes, and determines the upstream service to which the request should be forwarded.
 
-### 3. **Request authorization**
+### 3. Request authorization
 
 The request is authorized according to the policies applied to the Pomerium route before it is forwarded to the upstream service. For more details, see [request lifecycle](/docs/internals/architecture#the-lifecycle-of-a-request).
 
-### 4. **Upstream connection and request forwarding**
+### 4. Upstream connection and request forwarding
 
 - **[Load Balancing](/docs/capabilities/routing#load-balancer)**: Pomerium utilizes its load balancing algorithms to select the optimal upstream service instance to process the request. This selection is made from a list of healthy service instances, which is maintained by service discovery and health checking subsystems. The algorithm used for load balancing can be configured and includes options such as Round Robin, Least Request, Random, and more. See [Load Balancing Policy options](/docs/reference/routes/load-balancing#load-balancing-policy-options) and [Load Balancing Policy Config](/docs/reference/routes/load-balancing-policy-config) for more information.
 - **[Health Checks](/docs/reference/routes/load-balancing#health-checks)**: Health checks are key to maintaining the list of viable service instances for load balancing. Pomerium can be set up to routinely check the health of each upstream service instance using methods like HTTP calls, TCP connections, or custom health checks. If an instance fails the health check, it is deemed unhealthy and removed from the list of available instances for load balancing. This ensures that traffic is not directed to instances incapable of handling it.
 - **Connection & Request Forwarding**: Upon selecting a healthy upstream service instance, Pomerium establishes a connection with this instance (if one does not already exist) and forwards the client's request to it. Connection pooling is employed to improve efficiency by reusing existing connections where possible. This behavior can vary depending on whether the connection is HTTP/1.1 (where each connection can be reused but only manages one request at a time) or HTTP/2 (which supports multiple concurrent requests over a single connection).
 
-### 5. **Response forwarding**
+### 5. Response forwarding
 
 The upstream service processes the request and sends a response back to Pomerium, which subsequently forwards the response to the client.
 
-### 6. **Connection termination**
+### 6. Connection termination
 
 The connections between the client, Pomerium, and the upstream service are maintained for future requests and are terminated in accordance with the [Timeouts](#timeouts).
 


### PR DESCRIPTION
I happened to notice the formatting on the [Connections](https://www.pomerium.com/docs/internals/connection) page table of contents is different than other pages:
![Screenshot 2025-05-14 at 5 32 35 PM](https://github.com/user-attachments/assets/1cfbacfa-80dc-46de-8842-b93918181c3b)
