### PR TITLE
fix missing bearer

### DIFF
--- a/content/docs/reference/bearer-token-format.mdx
+++ b/content/docs/reference/bearer-token-format.mdx
@@ -57,7 +57,7 @@ BEARER_TOKEN_FORMAT=idp_access_token
 The `az` CLI can be used to get an access-token:
 
 ```bash
-curl -H "Authorization: $(az account get-access-token --query accessToken --output tsv)" https://example.localhost.pomerium.io
+curl -H "Authorization: Bearer $(az account get-access-token --query accessToken --output tsv)" https://example.localhost.pomerium.io
 ```
 
 ### Options


### PR DESCRIPTION
It should be `Authorization: Bearer TOKEN` not `Authorization: TOKEN`.