### PR TITLE
add bootstrap_service_account and cache_dir options

### DIFF
--- a/content/docs/deploy/enterprise/configure.mdx
+++ b/content/docs/deploy/enterprise/configure.mdx
@@ -35,6 +35,8 @@ All values are case sensitive unless otherwise noted.
 | <a className="entRef-anchor" id="audience">#</a><a href='#audience'>AUDIENCE</a> | A list of audiences for verifying the signing key. | `[]` |
 | <a className="entRef-anchor" id="authenticate-service-url">#</a><a href='#authenticate-service-url'>AUTHENTICATE_SERVICE_URL</a> | (deprecated) Authenticate service URL is not required in the Console configuration. For Device Enrollment, use the [external route URL](/docs/reference/routes/from). | none |
 | <a className="entRef-anchor" id="bind-addr">#</a><a href='#bind-addr'>BIND_ADDR</a> | The address the Pomerium Console will listen on. | `:8701` |
+| <a className="entRef-anchor" id="bootstrap-service-account">#</a><a href="#bootstrap-service-account">BOOTSTRAP_SERVICE_ACCOUNT</a> | Enable the bootstrap service account. | `false` |
+| <a className="entRef-anchor" id="cache-dir">#</a><a href="#cache-dir">CACHE_DIR</a> | Directory to use for caching. | Cache only in memory. |
 | <a className="entRef-anchor" id="customer-id">#</a><a href='#customer-id'>CUSTOMER_ID</a> | The customer ID | none |
 | <a className="entRef-anchor" id="database-encryption-key">#</a><a href='#database-encryption-key'>DATABASE_ENCRYPTION_KEY</a> | The base64-encoded encryption key for encrypting sensitive data in the database. | none |
 | <a className="entRef-anchor" id="database-encryption-key-file">#</a><a href='#database-encryption-key-file'>DATABASE_ENCRYPTION_KEY_FILE</a> | Loads base64-encoded `database-encryption-key` secret from a file. | none |
@@ -79,6 +81,8 @@ All values are case sensitive unless otherwise noted.
 | <a className="entRef-anchor" id="audience">#</a><a href='#audience'>audience</a> | A list of audiences for verifying the signing key. | `[]` |
 | <a className="entRef-anchor" id="authenticate-service-url">#</a><a href='#authenticate-service-url'>authenticate_service_url</a> | (deprecated) Authenticate service URL is not required in the Console configuration. For Device Enrollment, use the [external route URL](/docs/reference/routes/from). | none |
 | <a className="entRef-anchor" id="bind-addr">#</a><a href='#bind-addr'>bind_addr</a> | The address the Pomerium Console will listen on. | `:8701` |
+| <a className="entRef-anchor" id="bootstrap-service-account">#</a><a href="#bootstrap-service-account">bootstrap_service_account</a> | Enable the bootstrap service account. | `false` |
+| <a className="entRef-anchor" id="cache-dir">#</a><a href="#cache-dir">cache_dir</a> | Directory to use for caching. | Cache only in memory. |
 | <a className="entRef-anchor" id="customer-id">#</a><a href='#customer-id'>customer_id</a> | The customer ID | none |
 | <a className="entRef-anchor" id="database-encryption-key">#</a><a href='#database-encryption-key'>database_encryption_key</a> | The base64-encoded encryption key for encrypting sensitive data in the database. | none |
 | <a className="entRef-anchor" id="database-encryption-key-file">#</a><a href='#database-encryption-key-file'>database_encryption_key_file</a> | Loads base64-encoded `database-encryption-key` secret from a file. | none |


### PR DESCRIPTION
For [ENG-2463](https://linear.app/pomerium/issue/ENG-2463/documentation-add-enterprise-cache-dir)