### PR TITLE
chore: update versions for Pomerium v0.30.0 release

### DIFF
--- a/content/docs/deploy/cloud/install.mdx
+++ b/content/docs/deploy/cloud/install.mdx
@@ -129,7 +129,7 @@ To update Pomerium with Helm, run the following command:
 ```bash
 helm upgrade pomerium-zero oci://docker.io/pomerium/pomerium-zero \
   --namespace pomerium-zero \
-  --version 0.29.0
+  --version 0.30.0
 ```
 
 </TabItem>
@@ -144,7 +144,7 @@ In v0.27, we updated the Kubernetes installation manifest to use a Deployment in
 To update Pomerium in Kubernetes, run the following command:
 
 ```bash
-$ kubectl apply -k github.com/pomerium/pomerium/k8s/zero\?ref=v0.29.0
+$ kubectl apply -k github.com/pomerium/pomerium/k8s/zero\?ref=v0.30.0
 ```
 
 </TabItem>

--- a/content/docs/deploy/enterprise/configure-terraform.md
+++ b/content/docs/deploy/enterprise/configure-terraform.md
@@ -31,7 +31,7 @@ terraform {
   required_providers {
     pomerium = {
       source  = "pomerium/pomerium"
-      version = "~> 0.29.0"
+      version = "~> 0.30.0"
     }
   }
 }

--- a/content/docs/deploy/k8s/gateway-api.mdx
+++ b/content/docs/deploy/k8s/gateway-api.mdx
@@ -69,7 +69,7 @@ To install the Pomerium Ingress Controller with support for Gateway API:
 1. Then install the Pomerium Ingress Controller using the `gateway-api` kustomization:
 
    ```sh
-   kubectl apply -k github.com/pomerium/ingress-controller/config/gateway-api\?ref=v0.29.0
+   kubectl apply -k github.com/pomerium/ingress-controller/config/gateway-api\?ref=v0.30.0
    ```
 
    This installs and configures the Ingress Controller, and adds a [GatewayClass](https://gateway-api.sigs.k8s.io/concepts/api-overview/#gatewayclass) named `pomerium-gateway` for use with the Gateway API.

--- a/content/docs/deploy/k8s/install.md
+++ b/content/docs/deploy/k8s/install.md
@@ -18,7 +18,7 @@ Use Pomerium as a first-class secure-by-default Ingress Controller. The Pomerium
 ## Deploy
 
 ```console
-kubectl apply -k github.com/pomerium/ingress-controller/config/default\?ref=v0.29.0
+kubectl apply -k github.com/pomerium/ingress-controller/config/default\?ref=v0.30.0
 ```
 
 The Pomerium Ingress Controller is now installed into your cluster.
@@ -150,7 +150,7 @@ Make sure to always restrict access to the envoy admin interface ingress.
 
 ```yaml title="kustomization.yaml"
 resources:
-  - github.com/pomerium/ingress-controller/config/default?ref=v0.29.0
+  - github.com/pomerium/ingress-controller/config/default?ref=v0.30.0
   - admin-service.yaml
   - admin-ingress.yaml
 patches:

--- a/content/docs/deploy/k8s/quickstart.mdx
+++ b/content/docs/deploy/k8s/quickstart.mdx
@@ -56,7 +56,7 @@ mkcert "*.localhost.pomerium.io"
 1. Install Pomerium to your cluster:
 
 ```sh
-kubectl apply -k github.com/pomerium/ingress-controller/config/default\?ref=v0.29.0
+kubectl apply -k github.com/pomerium/ingress-controller/config/default\?ref=v0.30.0
 ```
 
 This will create all the components of Pomerium in the `pomerium` namespace, as well as a bootstrap secret:

--- a/content/examples/enterprise/hosted-auth-docker.yaml.md
+++ b/content/examples/enterprise/hosted-auth-docker.yaml.md
@@ -19,7 +19,7 @@ services:
         condition: service_healthy
       pomerium:
         condition: service_started
-    image: docker.cloudsmith.io/pomerium/enterprise/pomerium-console:v0.29.0
+    image: docker.cloudsmith.io/pomerium/enterprise/pomerium-console:v0.30.1
     command:
       - 'serve'
       - '--config'

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -56,8 +56,7 @@ const config = {
           },
           versions: {
             current: {
-              label: 'vNext (upcoming release)',
-              badge: true,
+              label: 'v0.30 (latest)'
             },
           },
         },
@@ -138,7 +137,11 @@ const config = {
           dropdownItemsAfter: [
             {
               to: 'https://0-29-0.docs.pomerium.com/docs',
-              label: 'v0.29 (latest)',
+              label: 'v0.29',
+            },
+            {
+              to: 'https://0-28-0.docs.pomerium.com/docs',
+              label: 'v0.28',
             },
             {
               type: 'html',

--- a/k8s/console/deployment/image.yaml
+++ b/k8s/console/deployment/image.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: pomerium-console
-          image: docker.cloudsmith.io/pomerium/enterprise/pomerium-console:v0.29.0
+          image: docker.cloudsmith.io/pomerium/enterprise/pomerium-console:v0.30.1
           imagePullPolicy: IfNotPresent
       imagePullSecrets:
         - name: pomerium-enterprise-docker

--- a/k8s/core/kustomization.yaml
+++ b/k8s/core/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: pomerium
 resources:
-  - github.com/pomerium/ingress-controller/config/default?ref=v0.29.0
+  - github.com/pomerium/ingress-controller/config/default?ref=v0.30.0
   - service.yaml
 patches:
   - patch: |-

--- a/src/components/docVersions.json
+++ b/src/components/docVersions.json
@@ -3,6 +3,10 @@
     "id": "vNext",
     "link": "https://main.docs.pomerium.com/docs"
   },
+  "0.30.0": {
+    "id": "v0.30.x",
+    "link": "https://0-30-0.docs.pomerium.com/docs"
+  },
   "0.29.0": {
     "id": "v0.29.x",
     "link": "https://0-29-0.docs.pomerium.com/docs"


### PR DESCRIPTION
Also stage 0.30 branch as production ready. Next step is to branch 0-30-0 from this and then adjust the robots config and reset main to pre-release.