### PR TITLE
fix: add title for Zero Quickstart to frontmatter

### DIFF
--- a/content/docs/get-started/quickstart.mdx
+++ b/content/docs/get-started/quickstart.mdx
@@ -1,6 +1,5 @@
 ---
-# cSpell:ignore thisisunsafe, genkey, noout
-
+title: 'Pomerium Zero Quickstart'
 lang: en-US
 sidebar_label: Quickstart
 pagination_prev: null
@@ -23,8 +22,6 @@ keywords:
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-
-# Pomerium Zero Quickstart
 
 The Zero Quickstart shows you how to install and run Pomerium Zero in a Docker container.
 


### PR DESCRIPTION
This PR adds a title property to the frontmatter of the Zero Quick Start page.

Fixes #1924

**Before**

```
# Pomerium Documentation

This file contains information about Pomerium's public documentation to help LLMs understand and reference our documentation.

Pomerium is an identity and context-aware access proxy that provides secure access to applications and services.

## Getting Started

- [cSpell:ignore thisisunsafe, genkey, noout](content/docs/get-started/quickstart.md): Learn how to install and run Pomerium Zero in a Docker container.
```

**After**

```
# Pomerium Documentation

This file contains information about Pomerium's public documentation to help LLMs understand and reference our documentation.

Pomerium is an identity and context-aware access proxy that provides secure access to applications and services.

## Getting Started

- [Pomerium Zero Quickstart](content/docs/get-started/quickstart.md): Learn how to install and run Pomerium Zero in a Docker container.
````