### PR TITLE
add ssh to the 'From' URL reference

### DIFF
--- a/content/docs/reference/routes/from.mdx
+++ b/content/docs/reference/routes/from.mdx
@@ -68,7 +68,7 @@ You can revert to the previous behavior by setting the [`match_any_incoming_port
 
 | **YAML**/**JSON** setting | **Type** | **Schemes** | **Usage** |
 | :-- | :-- | :-- | :-- |
-| `from` | `URL` | `https`, `tcp+https`, `udp+https` | **required** |
+| `from` | `URL` | `https`, `tcp+https`, `udp+https`, `ssh` | **required** |
 
 ### Examples
 

--- a/content/docs/reference/routes/from.mdx
+++ b/content/docs/reference/routes/from.mdx
@@ -21,9 +21,11 @@ The **From** URL is the externally accessible URL for a proxied HTTP request.
 
 Specifying `tcp+https` or `udp+https` for the scheme enables [TCP proxying](/docs/capabilities/non-http/) or [UDP proxying](/docs/capabilities/non-http/udp) (available since v0.29) support for the route. You may map more than one port through the same hostname by specifying a different `:port` in the URL.
 
+Specifying `ssh` for the scheme enables [native SSH proxying](/docs/capabilities/native-ssh-access).
+
 ## How to Configure
 
-The from URL must contain a **scheme** and **hostname**. It can't contain a path. When defining a From URL, you must use `https`, `tcp+https` or `udp+https`. Pomerium only supports secure schemes.
+The from URL must contain a **scheme** and **hostname**. It can't contain a path. When defining a From URL, you must use `https`, `tcp+https`, `udp+https`, or `ssh`. Pomerium only supports secure schemes.
 
 ### Port Matching Behavior
 


### PR DESCRIPTION
Update the list of supported URL schemes on the From URL reference page.

Related to https://linear.app/pomerium/issue/ENG-2040/document-native-ssh-access.