### PR TITLE
docs: Native SSH docs update

### DIFF
--- a/content/docs/capabilities/native-ssh-access.mdx
+++ b/content/docs/capabilities/native-ssh-access.mdx
@@ -200,12 +200,16 @@ Restart SSH daemon:
 # Ubuntu/Debian
 sudo systemctl restart ssh
 
-# RHEL/CentOS/Amazon Linux/Fedora
+# Other Linux distributions
 sudo systemctl restart sshd
 
 # Check service status
-sudo systemctl status ssh   # Ubuntu/Debian
-sudo systemctl status sshd  # RHEL/CentOS/Amazon Linux
+
+# Ubuntu/Debian
+sudo systemctl status ssh
+
+# Other Linux distributions
+sudo systemctl status sshd
 ```
 
 ## Connecting to SSH Routes

--- a/content/docs/capabilities/native-ssh-access.mdx
+++ b/content/docs/capabilities/native-ssh-access.mdx
@@ -227,7 +227,7 @@ Pomerium SSH routes use the syntax `user@route@pomerium`, where:
 1. Run your SSH command, e.g. `ssh user@route@pomerium-server`
 2. You should see a device code prompt or be redirected to authenticate
 3. Complete authentication in your browser
-4. Return to terminal and the connection completes successfully
+4. Return to terminal and the connection completes successfully, as long as you meet the configured Pomerium policy requirements for this route.
 
 <iframe
   width="100%"

--- a/content/docs/capabilities/native-ssh-access.mdx
+++ b/content/docs/capabilities/native-ssh-access.mdx
@@ -218,7 +218,27 @@ Pomerium SSH routes use the syntax `user@route@pomerium`, where:
 - `route` is the Pomerium route name (the name given after `ssh://` - for example, `from: ssh://route1` is "route1")
 - `pomerium` is the address of the Pomerium server. This can be a DNS name or an IP address.
 
-On first connection, you will be prompted to log in with OAuth in your browser. Subsequent connections within the session timeout will use cached credentials.
+### First Connection
+
+1. Run your SSH command, e.g. `ssh user@route@pomerium-server`
+2. You should see a device code prompt or be redirected to authenticate
+3. Complete authentication in your browser
+4. Return to terminal and the connection completes successfully
+
+<iframe
+  width="100%"
+  height="415"
+  src="https://www.youtube.com/embed/jfUG5dZ5wcU"
+  title="Native SSH Access with Pomerium"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  allowfullscreen></iframe>
+
+**If you don't see an OAuth prompt:** Check that your identity provider supports Device Code flow.
+
+### Subsequent Connections
+
+- Uses cached credentials within session timeout
+- No browser prompt needed
 
 :::info
 

--- a/content/docs/capabilities/native-ssh-access.mdx
+++ b/content/docs/capabilities/native-ssh-access.mdx
@@ -197,7 +197,15 @@ OpenSSH does not enforce file ownership or permissions on the TrustedUserCAKeys 
 Restart SSH daemon:
 
 ```bash
+# Ubuntu/Debian
+sudo systemctl restart ssh
+
+# RHEL/CentOS/Amazon Linux/Fedora
 sudo systemctl restart sshd
+
+# Check service status
+sudo systemctl status ssh   # Ubuntu/Debian
+sudo systemctl status sshd  # RHEL/CentOS/Amazon Linux
 ```
 
 ## Connecting to SSH Routes

--- a/content/docs/capabilities/native-ssh-access.mdx
+++ b/content/docs/capabilities/native-ssh-access.mdx
@@ -218,6 +218,10 @@ In version 0.30.0, SSH access only supports the Device Code OAuth flow. This res
 
 :::
 
+### Why Device Code?
+
+SSH clients don’t support browser redirects or interactive web authentication, which is required by standard OAuth flows like Authorization Code. The Device Code flow enables secure login by allowing you to authenticate via your browser, then return to the SSH session—bridging the gap between CLI tools and web-based identity providers.
+
 ## Using the Internal CLI
 
 ![Internal CLI Syntax](./img/ssh/syntax-cli.svg)

--- a/content/docs/capabilities/native-ssh-access.mdx
+++ b/content/docs/capabilities/native-ssh-access.mdx
@@ -241,8 +241,9 @@ Pomerium SSH routes use the syntax `user@route@pomerium`, where:
 
 ### Subsequent Connections
 
-- Uses cached credentials within session timeout
-- No browser prompt needed
+- Run the same SSH command with your route and Pomerium server target; you will not see the device code prompt or browser authentication.
+- Uses cached credentials within session timeout (defaults to 14 hours; see [cookie expiration](https://docs.pomerium.com/docs/reference/cookies#cookie-expiration))
+- Pomerium policy is still enforced for each connection, but this happens non-interactively unless your session has expired or policy requirements have changed.
 
 :::info
 


### PR DESCRIPTION
This pull request updates the documentation for native SSH access with Pomerium, adding clarity to the SSH daemon restart process and enhancing the explanation of the authentication flow. The changes also introduce a new section explaining the Device Code OAuth flow and its importance.

### Updates to SSH daemon restart instructions:

* Added specific commands for restarting the SSH service on Ubuntu/Debian (`sudo systemctl restart ssh`) and RHEL/CentOS/Amazon Linux/Fedora (`sudo systemctl restart sshd`).
* Included commands to check the service status for both distributions (`sudo systemctl status ssh` and `sudo systemctl status sshd`).

### Enhancements to authentication flow documentation:

* Introduced a "First Connection" section with step-by-step instructions for authenticating via OAuth, including a YouTube video embed for visual guidance.
* Added a "Subsequent Connections" section explaining the use of cached credentials within the session timeout, eliminating the need for repeated browser prompts.
* Created a "Why Device Code?" section to explain the rationale behind using the Device Code flow for SSH clients, highlighting its compatibility with CLI tools and web-based identity providers.

Changes available for viewing at:
- https://deploy-preview-1930--pomerium-docs.netlify.app/docs/capabilities/native-ssh-access
- llms.txt: https://deploy-preview-1930--pomerium-docs.netlify.app/content/docs/capabilities/native-ssh-access.md

Closes #1929