### PR TITLE
fix: remove YAML frontmatter from md files for cleaner llms.txt

### DIFF
--- a/content/docs/get-started/quickstart.mdx
+++ b/content/docs/get-started/quickstart.mdx
@@ -23,6 +23,8 @@ keywords:
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+# Pomerium Zero Quickstart
+
 The Zero Quickstart shows you how to install and run Pomerium Zero in a Docker container.
 
 ## Before you start

--- a/plugins/llms-txt-plugin.js
+++ b/plugins/llms-txt-plugin.js
@@ -13,6 +13,9 @@ const visit = require('unist-util-visit').visit;
  * - Strips any remaining standalone ::: lines
  */
 function preCleanDocusaurusMDX(raw) {
+  // Remove YAML frontmatter at the very top (--- ... ---)
+  raw = raw.replace(/^---[\s\S]*?---\s*(\n|$)/, '');
+
   // Remove all Docusaurus import lines
   raw = raw.replace(/^\s*import\s.*from\s+['"][^'"]+['"];?\s*$/gm, '');
 
@@ -74,9 +77,10 @@ async function cleanMarkdownForLLM(rawContent) {
 
   const result = await processor.process(rawContent);
 
-  // Remove any accidental lingering frontmatter at the start
+  // Remove any accidental lingering frontmatter at the start (robust)
   let cleaned = result.value
-    .replace(/^---[\s\S]*?---+\s*/m, '') // Remove frontmatter with any number of dashes
+    .replace(/^---[\t ]*\n[\s\S]*?\n---[\t ]*(\n|$)/, '') // Remove YAML frontmatter at very top
+    .replace(/^---[\s\S]*?---+\s*/m, '') // Remove frontmatter with any number of dashes (fallback)
     .replace(/^(?:-{3,}|\*{3,}|_{3,})\s*\n+/gm, '') // Remove HRs at file start
     .trim();
 

--- a/plugins/llms-txt-plugin.js
+++ b/plugins/llms-txt-plugin.js
@@ -77,15 +77,8 @@ async function cleanMarkdownForLLM(rawContent) {
 
   const result = await processor.process(rawContent);
 
-  // Remove any accidental lingering frontmatter at the start (robust)
-  let cleaned = result.value
-    .replace(/^---[\t ]*\n[\s\S]*?\n---[\t ]*(\n|$)/, '') // Remove YAML frontmatter at very top
-    .replace(/^---[\s\S]*?---+\s*/m, '') // Remove frontmatter with any number of dashes (fallback)
-    .replace(/^(?:-{3,}|\*{3,}|_{3,})\s*\n+/gm, '') // Remove HRs at file start
-    .trim();
-
   // Optionally trim excessive blank lines
-  return cleaned.replace(/\n{3,}/g, '\n\n');
+  return result.value.replace(/\n{3,}/g, '\n\n');
 }
 
 /**


### PR DESCRIPTION
llms.txt is correctly referencing markdown content now, but the frontmatter of the markdown files in build artifacts was retained. This can cause issues with LLMs reading the markdown files (see recommended format https://llmstxt.org/#format). As well, the what I thought was a redundant title is not, since we're stripping the frontmatter, unlike when the actual pages render, so the quickstart title is back.

An example in the deploy of frontmatter stripped, but feel free to check out other files referenced in https://deploy-preview-1931--pomerium-docs.netlify.app/llms.txt:

- https://deploy-preview-1931--pomerium-docs.netlify.app/content/docs/get-started/quickstart.md

Relates to #1924