### PR TITLE
llms.txt: omit partials

### DIFF
--- a/plugins/llms-txt-plugin.js
+++ b/plugins/llms-txt-plugin.js
@@ -122,7 +122,8 @@ async function scanDocumentationFiles(contentDir) {
           await scanDirectory(fullPath, relativePath);
         } else if (
           entry.isFile() &&
-          (entry.name.endsWith('.mdx') || entry.name.endsWith('.md'))
+          (entry.name.endsWith('.mdx') || entry.name.endsWith('.md')) &&
+          !entry.name.startsWith('_')
         ) {
           // Create a route-like object from the file
           const urlPath =


### PR DESCRIPTION
Do not generate links for partials (files beginning with an underscore).

Related issue:
- https://github.com/pomerium/documentation/issues/1933