### PR TITLE
update service mode summary

### DIFF
--- a/content/docs/reference/service-mode.mdx
+++ b/content/docs/reference/service-mode.mdx
@@ -18,7 +18,9 @@ import TabItem from '@theme/TabItem';
 
 ## Summary
 
-**Service Mode** sets which service(s) to run. If testing, you may want to set to `all` and run Pomerium in [all-in-one mode](/docs/internals/configuration#all-in-one-vs-split-service-mode). In production, you'll likely want to spin up several instances of each service mode for [high availability](/docs/internals/configuration).
+**Service Mode** sets which service(s) to run. When set to `all` (the default), Pomerium runs in [all-in-one mode](/docs/internals/configuration#all-in-one-vs-split-service-mode).
+
+To instead run in [split service mode](/docs/internals/configuration#discrete-services), you will need to deploy multiple instances of Pomerium: at least one replica of each of the four services.
 
 ## How to configure
 


### PR DESCRIPTION
Rephrase the summary for the Service Mode reference page, to avoid implying that all-in-one mode is only for testing.