### PR TITLE
Add documentation for source_ip criteria

### DIFF
--- a/content/docs/internals/ppl.mdx
+++ b/content/docs/internals/ppl.mdx
@@ -156,6 +156,7 @@ Entries marked with `*` denote criteria that are only available in the [Enterpri
 | \* `groups` | [String List Matcher] | Returns true if a user's group ID matches the supplied value **exactly**. `groups` data is only available after a successful directory sync. See [Identity Providers](/docs/integrations/user-identity/identity-providers) for vendor-specific directory sync steps. |
 | `http_method` | [String Matcher] | Returns true if the HTTP method matches the given value. |
 | `http_path` | [String Matcher] | Returns true if the HTTP path matches the given value. |
+| `source_ip` | [String Matcher] | Returns true if the source IP address matches the given value. |
 | `invalid_client_certificate` | Anything. Typically `true`. | Returns true if the incoming request does not have a trusted client certificate. By default, a `deny` rule using this criterion is added to all Pomerium policies when [downstream mTLS] is configured (but this default can be changed using the [Enforcement Mode](/docs/reference/downstream-mtls-settings#enforcement-mode) setting.) |
 | `pomerium_routes` | Anything. Typically `true`. | Returns true if the incoming request is for the special `.pomerium` routes. A default `allow` rule using this criterion is added to all Pomerium policies. |
 | \* `record` | variable | Allows policies to be extended using data from [external data sources](/docs/capabilities/integrations). See [Record Matcher](#record-matcher) for more information. |


### PR DESCRIPTION
Related PR: https://github.com/pomerium/pomerium/pull/5772.

The related PR implements the `source_ip` criteria in PPL, allow user to write policies using client IP address.