### PR TITLE
enterprise k8s install: fix ingress file name

### DIFF
--- a/content/docs/deploy/enterprise/install.mdx
+++ b/content/docs/deploy/enterprise/install.mdx
@@ -197,7 +197,7 @@ See [Environment Variables] for Config and Secret keys description.
 
 Create [Ingress] for Console.
 
-<CodeBlock language="jsx" title="ingress.yaml">
+<CodeBlock language="jsx" title="ingress-console.yaml">
   {Ingress}
 </CodeBlock>
 


### PR DESCRIPTION
Currently there is a mismatch between the kustomization.yaml file and the code block title for the Ingress resource. Update the code block title to match the kustomization.yaml file.