### PR TITLE
add redirect

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -329,6 +329,9 @@ https://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
 /docs/reference/policy/* /docs/internals/ppl 301!
 /docs/reference/policy/allowed-groups /docs/internals/ppl 301!
 
-# Versioned guides category (404 issue #525)  
+# Versioned guides category (404 issue #525)
 # Handle versioned domains like 0-20-0.docs.pomerium.com
 /category/guides /docs/guides 301!
+
+# Envoy bootstrap options
+/docs/reference/envoy-bootstrap-options /docs/reference/envoy-admin-interface


### PR DESCRIPTION
Add redirect for https://www.pomerium.com/docs/reference/envoy-bootstrap-options which no longer exists.