### PR TITLE
alerts: force regular names

### DIFF
--- a/content/examples/prometheus/prometheus.yml
+++ b/content/examples/prometheus/prometheus.yml
@@ -1,5 +1,6 @@
 global:
   scrape_interval: 30s
+  metric_name_validation_scheme: legacy
 
 rule_files:
   - "upstream-alerts.yml"
@@ -14,3 +15,4 @@ scrape_configs:
   - job_name: 'pomerium-console'
     static_configs:
       - targets: ['localhost:9092']
+


### PR DESCRIPTION
when configuring Prometheus, ensure it does not reformat metric names into new UTF8 format with dots.

See https://linear.app/pomerium/issue/ENG-2726/prometheus-metrics-names-altered-after-scrape

