### PR TITLE
telemetry: fix alert definitions

### DIFF
--- a/content/examples/prometheus/console-alerts.yml
+++ b/content/examples/prometheus/console-alerts.yml
@@ -1,8 +1,8 @@
 groups:
   - name: pomerium-console-core-connectivity
     rules:
-      - alert: ConsoleGRPCClientErrors
-        expr: rate(pomerium_rpc_client_requests_per_rpc_bucket{rpc_grpc_status_code!="0"}[5m]) > 0.1
+      - alert: ConsoleCoreGRPCClientErrors
+        expr: rate(pomerium_rpc_client_requests_per_rpc_count{rpc_grpc_status_code!~"^(0|1|5|6)$"}[5m]) > 0.1
         for: 2m
         labels:
           severity: warning
@@ -66,7 +66,7 @@ groups:
   - name: pomerium-console-external-data-sources
     rules:
       - alert: ExternalDataSourceTaskFailures
-        expr: increase(pomerium_console_datasource_task_calls_failures_total[5m]) > 0
+        expr: increase(pomerium_console_datasource_task_failures_total[5m]) > 0
         for: 1m
         labels:
           severity: warning

--- a/content/examples/prometheus/envoy-alerts.yml
+++ b/content/examples/prometheus/envoy-alerts.yml
@@ -78,8 +78,8 @@ groups:
       - alert: PomeriumHighGRPCErrorRate
         expr: |
           (
-            rate(pomerium_grpc_client_requests_total{grpc_client_status!="OK"}[5m]) / 
-            clamp_min(rate(pomerium_grpc_client_requests_total[5m]), 1)
+            rate(pomerium_rpc_client_requests_per_rpc_count{rpc_grpc_status_code!~"^(0|1|5|6)$"}[5m]) /
+            clamp_min(rate(pomerium_rpc_client_requests_per_rpc_count[5m]), 1)
           ) > 0.05
         for: 2m
         labels:

--- a/content/examples/prometheus/pomerium-alerts.yml
+++ b/content/examples/prometheus/pomerium-alerts.yml
@@ -136,7 +136,7 @@ groups:
             4. Verify autocert storage permissions
 
       - alert: PomeriumIdentityManagerSessionRefreshFailures
-        expr: rate(pomerium_identity_manager_session_refresh_errors[5m]) > 0.1
+        expr: rate(pomerium_identity_manager_last_session_refresh_errors[5m]) > 0.1
         for: 5m
         labels:
           severity: warning

--- a/content/examples/prometheus/prometheus.yml
+++ b/content/examples/prometheus/prometheus.yml
@@ -1,5 +1,6 @@
 global:
   scrape_interval: 30s
+  metric_name_validation_scheme: legacy
 
 rule_files:
   - "upstream-alerts.yml"
@@ -14,3 +15,4 @@ scrape_configs:
   - job_name: 'pomerium-console'
     static_configs:
       - targets: ['localhost:9092']
+

--- a/content/examples/prometheus/upstream-alerts.yml
+++ b/content/examples/prometheus/upstream-alerts.yml
@@ -5,8 +5,8 @@ groups:
         expr: |
           (
             sum(rate(envoy_http_ext_authz_denied[5m])) / 
-            clamp_min(sum(rate(envoy_http_ext_authz_total[5m])), 1)
-          ) > 0.01
+            clamp_min(sum(rate(envoy_http_ext_authz_ok[5m])), 1)
+          ) > 0.05
         for: 5m
         labels:
           severity: critical


### PR DESCRIPTION
https://linear.app/pomerium/issue/ENG-2709/telemetry-some-alert-queries-reference-metric-names-that-do-not-exist

