### PR TITLE
add source_ip PPL criteria

### DIFF
--- a/content/docs/internals/ppl.mdx
+++ b/content/docs/internals/ppl.mdx
@@ -160,6 +160,7 @@ Entries marked with `*` denote criteria that are only available in the [Enterpri
 | `pomerium_routes` | Anything. Typically `true`. | Returns true if the incoming request is for the special `.pomerium` routes. A default `allow` rule using this criterion is added to all Pomerium policies. |
 | \* `record` | variable | Allows policies to be extended using data from [external data sources](/docs/capabilities/integrations). See [Record Matcher](#record-matcher) for more information. |
 | `reject` | Anything. Typically `true`. | Always returns false. The opposite of `accept`. |
+| `source_ip` | String or list of strings, each containing an IP address or CIDR range. | Returns true if the incoming request was from an IP address matching any element of the list. |
 | \* `time_of_day` | [Time of Day Matcher] | Returns true if the time of the request (for the current day) matches the constraints. |
 | `user` | [String Matcher] | Returns `true` if the logged-in user's ID matches the supplied value. (The actual value of the user ID claim depends on how the identity provider sets this value.) |
 


### PR DESCRIPTION
Add the new `source_ip` PPL criteria to the table on the Pomerium Policy Language page.