### PR TITLE
ppl: add not_in string matcher

### DIFF
--- a/content/docs/capabilities/mcp.mdx
+++ b/content/docs/capabilities/mcp.mdx
@@ -528,6 +528,7 @@ The `mcp_tool` criterion is designed specifically for MCP routes and allows poli
 | `ends_with` | Tool name ends with the specified suffix | `mcp_tool: { ends_with: "_query" }` |
 | `contains` | Tool name contains the specified substring | `mcp_tool: { contains: "read" }` |
 | `in` | Tool name matches one of the provided values | `mcp_tool: { in: ["list_tables", "describe_table"] }` |
+| `not_in` | Tool name does not match any of the provided values (useful to enforce allowlists under `deny`) | `mcp_tool: { not_in: ["query", "list_tables"] }` |
 
 #### Evaluation semantics
 
@@ -575,6 +576,20 @@ policy:
 Note:
 
 - `mcp_tool` currently works best for deny-based block lists (exact names, prefixes, etc.).
+
+To flip this around and implement an allowlist, you can deny any tool name not in the approved set using the `not_in` operator:
+
+```yaml
+policy:
+  allow:
+    and:
+      - domain:
+          is: company.com
+  deny:
+    and:
+      - mcp_tool:
+          not_in: ['query', 'list_tables']
+```
 
 ### Example
 

--- a/content/docs/internals/ppl.mdx
+++ b/content/docs/internals/ppl.mdx
@@ -401,6 +401,7 @@ A string matcher is an object with operators as keys. It supports the following 
 - `contains`: Returns true if the string contains the specified substring
 - `ends_with`: Returns true if the string ends with the specified suffix
 - `in`: Returns true if the string is present in the provided array of strings
+- `not_in`: Returns true if the string is not present in the provided array of strings
 - `is`: Returns true if the string exactly matches the specified value
 - `starts_with`: Returns true if the string starts with the specified prefix
 
@@ -434,6 +435,15 @@ allow:
 ```
 
 A string matcher can also be used with an array, a string, a number or a boolean, in which case it is the same as the `is` operator.
+
+To enforce an allowlist by denying any value not in a known-safe set, use `not_in` under a `deny` rule. For example, to only allow specific tool names (see MCP policies):
+
+```yaml
+deny:
+  and:
+    - mcp_tool:
+        not_in: ['query', 'list_tables']
+```
 
 ### String List Matcher
 


### PR DESCRIPTION
Ref: https://linear.app/pomerium/issue/ENG-2960/pplmcp-tool-only-return-true-for-the-underlying-matcher

