### PR TITLE
Add a list of prerequisites before building Core from source

### DIFF
--- a/content/docs/deploy/core.mdx
+++ b/content/docs/deploy/core.mdx
@@ -121,6 +121,17 @@ If you plan to run on port 443 in a rootless environment, you may need extra [ca
 
 If you prefer building from source:
 
+### Prerequisites
+
+In order to run `make`, you need the following:
+
+1. [NPM](https://github.com/npm/cli)
+2. [Yarn](https://classic.yarnpkg.com/en/docs/install)
+3. [Docker](https://www.docker.com/) (optional)
+4. [Go](https://go.dev/dl/) -- currently Go 1.24 is the maximum supported Go version.
+
+### Building
+
 1. **Clone the Repository**
    ```bash
    git clone https://github.com/pomerium/pomerium.git $HOME/pomerium


### PR DESCRIPTION
Listing some tools I needed to install before I could build Pomerium Core. I debated mentioning `brew` but decided against, as that is Mac specific. The rest of these tools should apply to any (reasonable) OS. 