### PR TITLE
ENG-3012: Remove mermaid theme overrides

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -228,9 +228,6 @@ const config = {
         'hcl',
       ],
     },
-    mermaid: {
-      theme: {light: 'default', dark: 'default'},
-    },
   },
   stylesheets: [
     'https://fonts.googleapis.com/icon?family=Material+Icons',


### PR DESCRIPTION
An alternative would be to set dark mode to dark theme, but light and dark default to those values, so this configuration can be removed.

Fixes #2012 