### PR TITLE
docs(zero): clarify databroker storage type auto-inference

### DIFF
--- a/content/docs/reference/databroker.mdx
+++ b/content/docs/reference/databroker.mdx
@@ -51,6 +51,17 @@ DATABROKER_STORAGE_TYPE=postgres
 `databroker_storage_type` is a bootstrap configuration setting and is not configurable in the Console.
 
 </TabItem>
+<TabItem value="Zero" label="Zero">
+
+In Pomerium Zero, the storage type is **automatically inferred** from the connection string format and does not need to be configured separately:
+
+- `file:///path/to/directory` → file backend
+- `postgres://...` or `postgresql://...` → Postgres backend
+- Empty/unset → in-memory (default)
+
+See [Databroker Storage Connection String](#databroker-storage-connection-string) below for configuration details.
+
+</TabItem>
 <TabItem value="Kubernetes" label="Kubernetes">
 
 See Kubernetes [Storage reference](/docs/deploy/k8s/reference#storage) for more information.
@@ -83,6 +94,21 @@ DATABROKER_STORAGE_CONNECTION_STRING=file:///var/pomerium/databroker
 <TabItem value="Enterprise" label="Enterprise">
 
 `databroker_storage_connection_string` is a bootstrap configuration setting and is not configurable in the Console.
+
+</TabItem>
+<TabItem value="Zero" label="Zero">
+
+In Pomerium Zero, configure the connection string in the **Settings → General** section of the Zero console. The storage type is automatically inferred from the connection string:
+
+```
+file:///var/lib/pomerium
+```
+
+:::note
+
+When using the file backend, ensure the specified directory exists and has appropriate permissions. The in-memory backend (when the field is left empty) does not persist data across restarts.
+
+:::
 
 </TabItem>
 <TabItem value="Kubernetes" label="Kubernetes">
@@ -131,6 +157,29 @@ DATABROKER_STORAGE_CONNECTION_STRING_FILE=/run/secrets/db_connection_string
 <TabItem value="Enterprise" label="Enterprise">
 
 `databroker_storage_connection_string` is a bootstrap configuration setting and is not configurable in the Console.
+
+</TabItem>
+<TabItem value="Zero" label="Zero">
+
+In Pomerium Zero, configure the connection string in the **Settings → General** section of the Zero console. The storage type is automatically inferred from the connection string format:
+
+```
+postgres://user:password@host:5432/database?sslmode=require
+```
+
+or
+
+```
+postgresql://user:password@host:5432/database?sslmode=require
+```
+
+Both `postgres://` and `postgresql://` schemes are supported and automatically detected as Postgres storage.
+
+:::tip
+
+For production deployments, use a managed Postgres service or ensure your database has proper backups configured. Unlike the in-memory backend, Postgres provides persistent, replicated storage suitable for multi-replica deployments.
+
+:::
 
 </TabItem>
 <TabItem value="Kubernetes" label="Kubernetes">

--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -271,7 +271,7 @@
     "type": "URL"
   },
   "data-broker-storage-connection-string": {
-    "description": "Sets the connection string for the Databroker storage backend.",
+    "description": "Sets the connection string for the Databroker storage backend. The storage type (memory, file, or Postgres) is automatically inferred from the connection string format: 'file:///' URIs use the file backend, 'postgres://' or 'postgresql://' URIs use the Postgres backend, and empty/unset defaults to in-memory storage (not persisted across restarts).",
     "id": "data-broker-storage-connection-string",
     "path": "/databroker#databroker-storage-connection-string",
     "services": [],


### PR DESCRIPTION
## Summary

Clarifies that Pomerium Zero automatically infers the databroker storage backend type from the connection string format, eliminating the need for a separate storage type configuration.

- Adds "Zero" tab to Databroker Storage Type section explaining auto-inference behavior
- Adds "Zero" tab to Databroker Storage Connection String section with file backend example
- Adds "Zero" tab to PostgreSQL connection string section with postgres examples
- Updates reference.json description to mention auto-inference

### Storage type inference:

| Connection String | Inferred Backend |
|-------------------|------------------|
| `file:///path/to/dir` | File backend |
| `postgres://...` or `postgresql://...` | PostgreSQL backend |
| Empty/unset | In-memory (default) |

## Test plan

- [x] Built docs locally
- [x] Verified new Zero tabs render correctly in deploy preview
- [x] Review deploy preview: https://deploy-preview-2028--pomerium-docs.netlify.app/docs/reference/databroker

Closes ENG-3098

> 🤖 **Note:** This PR was partially authored with AI assistance, based on internal docs / blog posts we wrote since.