### PR TITLE
add doc for host-upstream

### DIFF
--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -633,6 +633,14 @@
     "title": "Host Rewrite Header",
     "type": "string"
   },
+  "host-upstream": {
+    "description": "Sets the Host header of an upstream request according to the host specified in the To URL for the route.",
+    "id": "host-upstream",
+    "path": "/routes/headers#host-rewrite",
+    "services": ["proxy"],
+    "title": "Host to Upstream",
+    "type": "boolean"
+  },
   "http-health-check-codec-client-type": {
     "description": "Specifies which application protocol to use. Optional.",
     "id": "http-health-check-codec-client-type",


### PR DESCRIPTION
Add a doc for the default host header behavior.

No AI was used for this PR.