### PR TITLE
docs: update enterprise install refs to 0.31

### DIFF
--- a/content/docs/deploy/enterprise/install.mdx
+++ b/content/docs/deploy/enterprise/install.mdx
@@ -149,13 +149,13 @@ The assumption is that Pomerium is installed into the `pomerium` namespace, and 
 The below command will expose the Pomerium Core Databroker gRPC interface.
 
 ```console
-kubectl apply -k github.com/pomerium/documentation/k8s/core\?ref=0-27-0
+kubectl apply -k github.com/pomerium/documentation/k8s/core\?ref=0-31-0
 ```
 
 ## Deploy Enterprise Console
 
 ```console
-kubectl apply -k github.com/pomerium/documentation/k8s/console\?ref=0-27-0
+kubectl apply -k github.com/pomerium/documentation/k8s/console\?ref=0-31-0
 ```
 
 The Enterprise Console need be configured before it becomes fully operational.


### PR DESCRIPTION
## Summary
- bump kustomize install refs for core and console to 0-31-0