### PR TITLE
docs: fix 20+ broken internal anchor links

### DIFF
--- a/content/docs/capabilities/getting-users-identity.mdx
+++ b/content/docs/capabilities/getting-users-identity.mdx
@@ -102,7 +102,7 @@ Pick the key matching the `kid` claim in the JWT header to verify its signature.
 
 ## Four Approaches to JWT Validation
 
-### 1. Manual Verification
+### 1. Manual Verification {#manual-verification}
 
 Useful for learning or debugging:
 

--- a/content/docs/capabilities/mcp.mdx
+++ b/content/docs/capabilities/mcp.mdx
@@ -23,7 +23,6 @@ Pomerium provides secure access to Model Context Protocol (MCP) servers, enablin
 - [Security Considerations](#security-considerations) - Access control and token security
 - [Observability](#observability) - Logging and monitoring MCP activities
 - [Policy-Based Tool Access Control](#policy-based-tool-access-control) - Fine-grained tool permissions
-- [Best Practices](#best-practices)
 - [Demo and Examples](#demo-and-examples)
 
 ## Overview
@@ -611,7 +610,7 @@ policy:
           starts_with: 'admin_'
 ```
 
-For more advanced policy patterns, see the [PPL documentation](/docs/internals/ppl#examples).
+For more advanced policy patterns, see the [PPL documentation](/docs/internals/ppl).
 
 ### Understanding Authorization Results
 

--- a/content/docs/capabilities/non-http/_cli-client-certificates.mdx
+++ b/content/docs/capabilities/non-http/_cli-client-certificates.mdx
@@ -34,4 +34,4 @@ Or, to filter for a certificate whose Subject contains the Organizational Unit N
   {`pomerium-cli ${props.protocol} --client-cert-from-store --client-cert-subject "OU=My Department" route.corp.example.com:1234`}
 </CodeBlock>
 
-See the [reference page](/docs/capabilities/non-http#certificate-name-filters) for more details about the certificate name filter syntax.
+See the [reference page](/docs/deploy/clients#certificate-name-filters) for more details about the certificate name filter syntax.

--- a/content/docs/capabilities/non-http/examples/git.mdx
+++ b/content/docs/capabilities/non-http/examples/git.mdx
@@ -18,7 +18,7 @@ When hosting a self-hosted Git server like [GitLab](/docs/guides/gitlab) behind 
 :::
 
 :::tip
-This example assumes you've already [created a TCP route](/docs/capabilities/non-http#configure-tcp-routes) for this service.
+This example assumes you've already [created a TCP route](/docs/capabilities/non-http/tcp#configure-tcp-routes) for this service.
 :::
 
  ## Basic Connection

--- a/content/docs/capabilities/non-http/examples/ms-sql.mdx
+++ b/content/docs/capabilities/non-http/examples/ms-sql.mdx
@@ -20,7 +20,7 @@ This document explains how to connect to a Microsoft SQL database through an enc
 :::
 
 :::tip
-This example assumes you've already [created a TCP route](/docs/capabilities/non-http#configure-tcp-routes) for this service.
+This example assumes you've already [created a TCP route](/docs/capabilities/non-http/tcp#configure-tcp-routes) for this service.
 :::
 
 

--- a/content/docs/capabilities/non-http/examples/mysql.mdx
+++ b/content/docs/capabilities/non-http/examples/mysql.mdx
@@ -18,7 +18,7 @@ This document explains how to connect to a MySQL or MariaDB database through an 
 :::
 
 :::tip
-This example assumes you've already [created a TCP route](/docs/capabilities/non-http#configure-tcp-routes) for this service.
+This example assumes you've already [created a TCP route](/docs/capabilities/non-http/tcp#configure-tcp-routes) for this service.
 :::
 
  ## Basic Connection

--- a/content/docs/capabilities/non-http/examples/rdp.mdx
+++ b/content/docs/capabilities/non-http/examples/rdp.mdx
@@ -19,7 +19,7 @@ Remote Desktop Protocol (**RDP**) is a standard for using a desktop computer rem
 :::
 
 :::tip
-This example assumes you've already [created a TCP route](/docs/capabilities/non-http#configure-tcp-routes) for this service.
+This example assumes you've already [created a TCP route](/docs/capabilities/non-http/tcp#configure-tcp-routes) for this service.
 :::
 
 ## Basic Connection

--- a/content/docs/capabilities/non-http/examples/redis.mdx
+++ b/content/docs/capabilities/non-http/examples/redis.mdx
@@ -18,7 +18,7 @@ Redis is a popular in-memory data structure store. It can be run locally or conf
 :::
 
 :::tip
-This example assumes you've already [created a TCP route](/docs/capabilities/non-http#configure-tcp-routes) for this service.
+This example assumes you've already [created a TCP route](/docs/capabilities/non-http/tcp#configure-tcp-routes) for this service.
 :::
 
 ## Basic Connection

--- a/content/docs/capabilities/non-http/examples/ssh.mdx
+++ b/content/docs/capabilities/non-http/examples/ssh.mdx
@@ -29,7 +29,7 @@ By tunneling SSH connections through your Pomerium service:
 :::
 
 :::tip
-This example assumes you've already [created a TCP route](/docs/capabilities/non-http#configure-tcp-routes) for this service.
+This example assumes you've already [created a TCP route](/docs/capabilities/non-http/tcp#configure-tcp-routes) for this service.
 :::
 
  ## Basic Connection

--- a/content/docs/deploy/clients/clients.mdx
+++ b/content/docs/deploy/clients/clients.mdx
@@ -380,7 +380,7 @@ Then, add a connection by filling in the fields defined below:
 
 - **Pomerium URL**: The Pomerium Proxy service address. This is required if the **Destination URL** can't be resolved from DNS or a local `hosts` entry, or if the Proxy service uses a non-standard port.
 - **Disable TLS Verification**: Allows untrusted certificates from the Pomerium gateway
-- **Client Certificates**: For routes that enforce [mTLS](/docs/internals/mutual-auth), you can **set a client certificate manually** or automatically [**search the OS certificate store**](/docs/capabilities/non-http#client-certificates) for a trusted certificate (note: macOS and Windows only).
+- **Client Certificates**: For routes that enforce [mTLS](/docs/internals/mutual-auth), you can **set a client certificate manually** or automatically [**search the OS certificate store**](/docs/capabilities/non-http/tcp#client-certificates) for a trusted certificate (note: macOS and Windows only).
 
 ![Reviewing the Advanced Settings in the Pomerium Desktop client](./img/desktop/advanced-settings.png)
 

--- a/content/docs/deploy/enterprise/enterprise.md
+++ b/content/docs/deploy/enterprise/enterprise.md
@@ -87,11 +87,11 @@ In the **External Data** dashboard, you can import, view, and manage [external d
 | TCP Support | ![Pomerium checkmark](./img/pomerium-checkmark.svg) | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
 | Enterprise Console | <ClearIcon /> | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
 | [Enterprise API](/docs/internals/management-api-enterprise) | <ClearIcon /> | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
-| [Session Management](/docs/internals/metrics#sessions) | <ClearIcon /> | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
+| [Session Management](/docs/internals/metrics) | <ClearIcon /> | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
 | [Namespaces](/docs/internals/namespacing) | <ClearIcon /> | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
 | [Directory Sync](/docs/integrations/user-standing/directory-sync) | <ClearIcon /> | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
 | [User Impersonation](/docs/capabilities/impersonation) | <ClearIcon /> | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
-| [Deployment History](/docs/internals/metrics#changesets-and-deployments) | <ClearIcon /> | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
+| [Deployment History](/docs/internals/metrics) | <ClearIcon /> | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
 | [Device Identity](/docs/integrations/device-context/device-identity) | <ClearIcon /> | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
 | [Custom Branding](/docs/capabilities/branding) | <ClearIcon /> | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
 | [Service Accounts](/docs/capabilities/service-accounts) | <ClearIcon /> | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |

--- a/content/docs/deploy/k8s/configure.md
+++ b/content/docs/deploy/k8s/configure.md
@@ -50,7 +50,7 @@ Integration with your Identity Provider is configured using [`identityProvider`]
 
 Each Pomerium installation has a special route that unauthenticated users are redirected to that handles sign-in via your Identity Provider. It is configured via the [`authenticate`](/docs/deploy/k8s/reference#authenticate) parameter of the [CRD](./reference#authenticate).
 
-The authenticate endpoint DNS address should resolve to an external IP address assigned by your Kubernetes Load Balancer to the `pomerium-proxy` service. If you use `external-dns`, that may be [done automatically](#external-dns).
+The authenticate endpoint DNS address should resolve to an external IP address assigned by your Kubernetes Load Balancer to the `pomerium-proxy` service. If you use [external-dns](https://github.com/kubernetes-sigs/external-dns), DNS records can be managed automatically.
 
 :::note
 

--- a/content/docs/deploy/k8s/ingress.md
+++ b/content/docs/deploy/k8s/ingress.md
@@ -89,7 +89,7 @@ The default installation adds `pomerium` [IngressClass](https://kubernetes.io/do
 
 It is also possible to [set Pomerium to be a default ingress controller](/docs/deploy/k8s/install#set-pomerium-as-default-ingressclass) cluster-wide.
 
-### Set Ingress annotations
+### Set Ingress annotations {#set-ingress-annotations}
 
 Most configuration keys in non-Kubernetes deployments can be specified as annotation in an Ingress Resource definition. The format is `ingress.pomerium.io/${OPTION_NAME}`.
 
@@ -476,7 +476,7 @@ Additional TLS certificates may be supplied by creating a Kubernetes secret(s) i
 
 - [`ingress.pomerium.io/tls_client_secret`](/docs/reference/routes/tls#tls-client-certificate)
 - [`ingress.pomerium.io/tls_custom_ca_secret`](/docs/reference/routes/tls#tls-custom-certificate-authority)
-- [`ingress.pomerium.io/tls_downstream_client_ca_secret`](#supported-annotations)
+- [`ingress.pomerium.io/tls_downstream_client_ca_secret`](#set-ingress-annotations)
 
 Please note that the referenced `tls_client_secret` must be a [TLS Kubernetes secret](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets). `tls_custom_ca_secret` and `tls_downstream_client_ca_secret` referenced Secrets must contain `ca.crt` key containing a .PEM encoded (base64-encoded DER format) public certificate.
 

--- a/content/docs/deploy/k8s/quickstart.mdx
+++ b/content/docs/deploy/k8s/quickstart.mdx
@@ -188,7 +188,7 @@ See the [**Verify examples**](https://github.com/pomerium/verify/blob/main/examp
                      number: 8000
    ```
 
-   Note that in **Line 8**, we include the [annotation](/docs/deploy/k8s/ingress#supported-annotations) `ingress.pomerium.io/pass_identity_headers`, which provides a [JWT](/docs/internals/glossary#json-web-token) to the Verify service.
+   Note that in **Line 8**, we include the [annotation](/docs/deploy/k8s/ingress#set-ingress-annotations) `ingress.pomerium.io/pass_identity_headers`, which provides a [JWT](/docs/internals/glossary#json-web-token-jwt) to the Verify service.
 
    Deploy the service with `kubectl apply -f verify-ingress.yaml`, and visit the path in your browser:
 

--- a/content/docs/guides/cockpit.md
+++ b/content/docs/guides/cockpit.md
@@ -20,7 +20,7 @@ description: Learn how to secure Cockpit, a web GUI for Linux servers, behind Po
 
 ## Before You Begin
 
-This guide assumes you already have Pomerium installed and connected to your [IdP](/docs/internals/glossary#identity-provider). If not, follow the instructions in the following articles before continuing:
+This guide assumes you already have Pomerium installed and connected to your [IdP](/docs/internals/glossary#identity-provider-idp). If not, follow the instructions in the following articles before continuing:
 
 - Install Pomerium
   - [Binaries](/docs/deploy/core) if installing Pomerium as a system-level service.

--- a/content/docs/guides/istio.mdx
+++ b/content/docs/guides/istio.mdx
@@ -316,8 +316,8 @@ To demonstrate complete authorization validation through to the upstream service
 
    Apply the policies with `kubectl apply -f` to complete the configuration.
 
-[authn]: /docs/internals/glossary.md#authentication
-[authz]: /docs/internals/glossary.md#authorization
+[authn]: /docs/internals/glossary.md#authentication-authn
+[authz]: /docs/internals/glossary.md#authorization-authz
 [istio]: https://istio.io/latest/
 [istio]: https://github.com/istio/istio
 [certmanager]: https://github.com/jetstack/cert-manager

--- a/content/docs/integrations/device-context/webauthn.mdx
+++ b/content/docs/integrations/device-context/webauthn.mdx
@@ -39,7 +39,7 @@ Device identity links a cryptographically unique ID to each device, letting you 
 
 ## Device Identity with Pomerium
 
-As of [Pomerium v0.16.0](/docs/deploy/upgrading.mdx#policy-for-device-identity) and higher, you can require [WebAuthn](https://www.w3.org/TR/webauthn-2) for device identity checks. This means:
+As of [Pomerium v0.16.0](/docs/deploy/upgrading) and higher, you can require [WebAuthn](https://www.w3.org/TR/webauthn-2) for device identity checks. This means:
 
 - Users can register their devices as a [trusted execution environment](/docs/integrations/device-context/device-identity#authenticated-device-types).
 - Admins can configure policy restricting route access to _only_ devices that have been authenticated through WebAuthn.

--- a/content/docs/integrations/user-identity/okta.mdx
+++ b/content/docs/integrations/user-identity/okta.mdx
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 
 Okta is a popular identity provider used by businesses of all sizes. Integrating Pomerium with Okta allows you to use the identity Okta provides to apply context-driven policies from Pomerium to your infrastructure.
 
-This page covers configuring Okta to communicate with Pomerium as an [IdP](/docs/internals/glossary#identity-provider). It assumes you have already [installed Pomerium][pomerium-install] before you begin.
+This page covers configuring Okta to communicate with Pomerium as an [IdP](/docs/internals/glossary#identity-provider-idp). It assumes you have already [installed Pomerium][pomerium-install] before you begin.
 
 :::caution
 


### PR DESCRIPTION
## Summary

- Fix glossary anchor suffix mismatches (IdP, JWT, AuthN, AuthZ abbreviations)
- Update non-HTTP documentation paths after restructuring
- Remove links to deleted sections, point to parent pages instead
- Add missing explicit anchor IDs to referenced headings

## Test plan

- [x] `yarn format` passes
- [x] `yarn build` passes (remaining warnings are pre-existing)
- [x] Manually tested all changed links with Playwright
- [x] Reviewed `_redirects` - no changes needed

Fixes: ENG-3428, ENG-3429, ENG-3430, ENG-3431