### PR TITLE
docs: add SSH tunneling reference with description and path

### DIFF
--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -1651,7 +1651,7 @@
     "title": "SSH Host Keys"
   },
   "ssh-tunneling": {
-    "description": "Makes a route an SSH tunnel. Users see this as HTTPS traffic from the outside, but this the 'To' route will be handled as an SSH reverse tunnel.",
+    "description": "When enabled, this route must be served by one or more SSH reverse tunnel connections. Pomerium will not initiate a direct connection to the 'To' URL.",
     "id": "ssh-tunneling",
     "path": "/../capabilities/non-http/examples/ssh",
     "title": "SSH Tunneling"


### PR DESCRIPTION
Add a help docs section for SSH tunneling.

Relates to [ENG-3404](https://linear.app/pomerium/issue/ENG-3404/zero-improve-ux-clarity-around-reverse-tunnel-setting)