### PR TITLE
docs: remove old version links (v0.18-v0.29) from version selector

### DIFF
--- a/src/components/docVersions.json
+++ b/src/components/docVersions.json
@@ -1,54 +1,14 @@
 {
-  "vNext": {
-    "id": "vNext",
-    "link": "https://main.docs.pomerium.com/docs"
+  "0.30.0": {
+    "id": "v0.30.x",
+    "link": "https://0-30-0.docs.pomerium.com/docs"
   },
   "0.31.0": {
     "id": "v0.31.x",
     "link": "https://0-31-0.docs.pomerium.com/docs"
   },
-  "0.30.0": {
-    "id": "v0.30.x",
-    "link": "https://0-30-0.docs.pomerium.com/docs"
-  },
-  "0.29.0": {
-    "id": "v0.29.x",
-    "link": "https://0-29-0.docs.pomerium.com/docs"
-  },
-  "0.28.0": {
-    "id": "v0.28.x",
-    "link": "https://0-28-0.docs.pomerium.com/docs"
-  },
-  "0.27.0": {
-    "id": "v0.27.x",
-    "link": "https://0-27-0.docs.pomerium.com/docs"
-  },
-  "0.26.0": {
-    "id": "v0.26.x",
-    "link": "https://0-26-0.docs.pomerium.com/docs"
-  },
-  "0.25.0": {
-    "id": "v0.25.x",
-    "link": "https://0-25-0.docs.pomerium.com/docs"
-  },
-  "0.24.0": {
-    "id": "v0.24.x",
-    "link": "https://0-24-0.docs.pomerium.com/docs"
-  },
-  "0.23.0": {
-    "id": "v0.23.x",
-    "link": "https://0-23-0.docs.pomerium.com/docs"
-  },
-  "0.22.0": {
-    "id": "v0.22.x",
-    "link": "https://0-22-0.docs.pomerium.com/docs"
-  },
-  "0.21.0": {
-    "id": "v0.21.x",
-    "link": "https://0-21-0.docs.pomerium.com/docs"
-  },
-  "0.20.0": {
-    "id": "v0.20.x",
-    "link": "https://0-20-0.docs.pomerium.com/docs"
+  "vNext": {
+    "id": "vNext",
+    "link": "https://main.docs.pomerium.com/docs"
   }
 }

--- a/static/_redirects
+++ b/static/_redirects
@@ -229,8 +229,9 @@ https://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
 /docs/guides/cors /docs/internals/troubleshooting#cross-origin-configuration
 /docs/guides/jwt-verification-with-envoy /docs/capabilities/getting-users-identity
 /docs/guides/kubernetes.html /docs/deploy/k8s/quickstart
-/docs/guides/nginx https://0-20-0.docs.pomerium.com/docs/guides/nginx 301!
-/docs/guides/nginx.html https://0-20-0.docs.pomerium.com/docs/guides/nginx 301!
+# nginx guide was deprecated - redirect to guides index
+/docs/guides/nginx /docs/guides 301!
+/docs/guides/nginx.html /docs/guides 301!
 /docs/guides/securing-tcp /docs/capabilities/non-http/tcp
 /docs/guides/upstream-mtls.html /docs/capabilities/mtls-services
 /docs/identity-providers /docs/integrations/user-identity/identity-providers
@@ -304,7 +305,8 @@ https://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
 /docs/reference/branding/logo-url /docs/reference/branding#logo-url
 /docs/reference/cookie-secure /docs/reference/cookies
 /docs/reference/downstream-mtls /docs/reference/downstream-mtls-settings
-/docs/reference/forward-auth https://0-20-0.docs.pomerium.com/docs/reference/forward-auth 301!
+# forward-auth was deprecated - redirect to reference index
+/docs/reference/forward-auth /docs/reference 301!
 /docs/reference/grpc-address /docs/reference/grpc#grpc-address
 /docs/reference/grpc-insecure /docs/reference/grpc#grpc-insecure
 /docs/reference/metrics-basic-authentication /docs/deploy/enterprise/configure-metrics


### PR DESCRIPTION
## Summary

- Update `docVersions.json` to only show v0.30, v0.31, and vNext
- Update `_redirects` to point deprecated pages (nginx guide, forward-auth) to current docs instead of old `0-20-0.docs.pomerium.com` subdomain

## Problem

LLMs and Google Search are surfacing outdated v0.20 documentation. This PR removes links to old versioned docs from the UI and stops redirecting to old subdomains.

## Related

- Infrastructure PR: https://github.com/pomerium/infrastructure/pull/366 (DNS + LB changes for 301 redirects)

## Test plan

- [ ] Version dropdown shows only v0.30, v0.31, vNext
- [ ] `/docs/guides/nginx` redirects to `/docs/guides` (not external subdomain)
- [ ] `/docs/reference/forward-auth` redirects to `/docs/reference` (not external subdomain)

Refs: ENG-3474