### PR TITLE
request headers apply to upstream requests

### DIFF
--- a/content/docs/reference/routes/headers.mdx
+++ b/content/docs/reference/routes/headers.mdx
@@ -263,7 +263,7 @@ set_request_headers:
 
 ## Remove Request Headers {#remove-request-headers}
 
-**Remove Request Headers** allows you to remove given request headers. This can be useful if you want to prevent privacy information from being passed to downstream applications.
+**Remove Request Headers** allows you to remove given request headers. This can be useful if you want to prevent privacy information from being passed to upstream applications.
 
 ### How to Configure {#how-to-configure-remove-request-headers}
 


### PR DESCRIPTION
Replace "downstream" with "upstream" in the Remove Request Headers description. This setting affects the headers sent to an upstream service.