### PR TITLE
docs: fix upstream/downstream terminology across docs

### DIFF
--- a/content/docs/capabilities/getting-users-identity.mdx
+++ b/content/docs/capabilities/getting-users-identity.mdx
@@ -68,8 +68,8 @@ If everything checks out, your service can trust the identity data in the token 
 ## Why JWT-Based Verification?
 
 - **Zero Trust**: Enforces that _every_ request is from a legitimate, authenticated user.
-- **Application Layer**: Even if TLS terminates at Pomerium, the downstream service can verify the request is valid.
-- **Single Sign-On**: A single IdP login flows downstream. Your app can read the user's email, groups, etc., from the JWT.
+- **Application Layer**: Even if TLS terminates at Pomerium, the upstream service can verify the request is valid.
+- **Single Sign-On**: A single IdP login provides identity to all services behind Pomerium. Your app can read the user's email, groups, etc., from the JWT.
 - **Local Validation**: JWTs are stateless. After an initial login, your service doesn't need to call the IdP again; it simply verifies the token signature.
 
 ## JWT Details

--- a/content/docs/capabilities/original-request-context.md
+++ b/content/docs/capabilities/original-request-context.md
@@ -57,7 +57,7 @@ routes:
 - **API** is also accessed through it's Pomerium Route, but is only accessible by the **App**, using a [service account](/docs/capabilities/service-accounts) to authenticate.
 - The **API** service needs to know the user making the request to **App** in order to formulate the correct response.
 
-Both Routes include [`pass_identity_headers`](/docs/reference/routes/pass-identity-headers-per-route), which provides (at minimum) the `X-Pomerium-Jwt-Assertion` header to the downstream application.
+Both Routes include [`pass_identity_headers`](/docs/reference/routes/pass-identity-headers-per-route), which provides (at minimum) the `X-Pomerium-Jwt-Assertion` header to the upstream application.
 
 When a user makes a request that requires data from the API service, the following happens:
 

--- a/content/docs/capabilities/routing.mdx
+++ b/content/docs/capabilities/routing.mdx
@@ -233,7 +233,7 @@ The 2nd, 3rd and 4th options correspond to the Envoy route action host related o
 
 #### Set Request Headers
 
-Set Request Headers allows you to set static values for given request headers. This can be useful if you want to pass along additional information to downstream applications as headers, or set authentication header to the request. For example:
+Set Request Headers allows you to set static values for given request headers. This can be useful if you want to pass along additional information to upstream applications as headers, or set authentication header to the request. For example:
 
 ```yaml
 - from: https://verify.corp.example.com
@@ -258,7 +258,7 @@ Neither `:-prefixed` pseudo-headers nor the `Host:` header may be modified via t
 
 #### Remove Request Headers
 
-Remove Request Headers allows you to remove given request headers. This can be useful if you want to prevent privacy information from being passed to downstream applications. For example:
+Remove Request Headers allows you to remove given request headers. This can be useful if you want to prevent privacy information from being passed to upstream applications. For example:
 
 ```yaml
 - from: https://verify.corp.example.com
@@ -275,7 +275,7 @@ Remove Request Headers allows you to remove given request headers. This can be u
 
 #### Rewrite Response Headers
 
-Rewrite Response Headers allows you to modify response headers before they are returned to the client. The `header` field will match the HTTP header name, and `prefix` will be replaced with `value`. For example, if the downstream server returns a header:
+Rewrite Response Headers allows you to modify response headers before they are returned to the client. The `header` field will match the HTTP header name, and `prefix` will be replaced with `value`. For example, if the upstream server returns a header:
 
 ```text
 Location: http://localhost:8000/two/some/path/

--- a/content/docs/deploy/k8s/ingress.md
+++ b/content/docs/deploy/k8s/ingress.md
@@ -814,7 +814,7 @@ spec:
 
 #### MCP Server with Custom Path
 
-If your upstream client application makes use of [MCP Routes Enumeration](https://main.docs.pomerium.com/docs/capabilities/mcp#listing-available-mcp-servers) to determine the exact URL the MCP Streaming HTTP is exposed at, you may specify it with this annotation.
+If your MCP client application makes use of [MCP Routes Enumeration](https://main.docs.pomerium.com/docs/capabilities/mcp#listing-available-mcp-servers) to determine the exact URL the MCP Streaming HTTP is exposed at, you may specify it with this annotation.
 
 ```yaml
 apiVersion: networking.k8s.io/v1

--- a/content/docs/guides/ad-guard.md
+++ b/content/docs/guides/ad-guard.md
@@ -8,7 +8,7 @@ keywords: [pomerium, identity access proxy, adguard, ad guard, pi hole, piehole]
 description: This guide covers how to add authentication and authorization to a hosted, fully online instance of Adguard.
 ---
 
-This guide covers how to add authentication and authorization to an instance of AdGuard while giving us a great excuse to demonstrate how to use Pomerium's [add headers](/docs/reference) functionality to **transparently pass along basic authentication credentials to a downstream app**.
+This guide covers how to add authentication and authorization to an instance of AdGuard while giving us a great excuse to demonstrate how to use Pomerium's [add headers](/docs/reference) functionality to **transparently pass along basic authentication credentials to an upstream app**.
 
 ## What is AdGuard?
 

--- a/content/docs/internals/glossary.md
+++ b/content/docs/internals/glossary.md
@@ -153,8 +153,14 @@ Hardware-based isolation for sensitive operations and key storage. Pomerium can 
 
 ## Upstream / Downstream
 
-- **Upstream**: The protected backend services.
-- **Downstream**: Clients or end users connecting to Pomerium from the internet.
+Pomerium inherits these terms from [Envoy](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/intro/terminology):
+
+- **Downstream**: A downstream host connects to Pomerium, sends requests, and receives responses. This is the client side — typically a web browser, the Pomerium CLI, or the Pomerium Desktop client.
+- **Upstream**: An upstream host receives connections and requests from Pomerium and returns responses. This is the backend service side — the applications and APIs that Pomerium protects.
+
+Related Envoy-inherited concepts used in Pomerium:
+
+- **Listener**: A named network location (port, address) that accepts connections from downstream clients. Pomerium configures several Envoy listeners (e.g., `https-ingress` on port 443). See [Connections](/docs/internals/connection#listeners).
 
 ## Users and Groups
 

--- a/content/docs/reference/routes/headers.mdx
+++ b/content/docs/reference/routes/headers.mdx
@@ -407,7 +407,7 @@ resource "pomerium_route" "verify_route" {
 
 ### Examples {#examples-rewrite-response-headers}
 
-If the downstream server returns a header:
+If the upstream server returns a header:
 
 ```text
 Location: http://localhost:8000/two/some/path/
@@ -440,7 +440,7 @@ Configure **Rewrite Response Headers** in the Console:
 
 ### Examples
 
-If the downstream server returns a header:
+If the upstream server returns a header:
 
 ```text
 Location: http://localhost:8000/two/some/path/

--- a/content/docs/reference/set-response-headers.mdx
+++ b/content/docs/reference/set-response-headers.mdx
@@ -104,7 +104,7 @@ See [MDN Web Docs - Strict-Transport-Security](https://developer.mozilla.org/en-
 
 :::tip
 
-Several security-related headers are not set by default since doing so might break legacy sites. These include: `Cross-Origin Resource Policy`, `Cross-Origin Opener Policy`, and `Cross-Origin Embedder Policy`. If possible, users are encouraged to add these to `set_response_headers` or their downstream applications.
+Several security-related headers are not set by default since doing so might break legacy sites. These include: `Cross-Origin Resource Policy`, `Cross-Origin Opener Policy`, and `Cross-Origin Embedder Policy`. If possible, users are encouraged to add these to `set_response_headers` or their upstream applications.
 
 :::
 


### PR DESCRIPTION
## Summary

- Replace "downstream"  to "upstream" in 9 locations where backend services were incorrectly called downstream (Envoy defines upstream = backend, downstream = client)
- Reword "flows downstream" to avoid ambiguity with Envoy terminology
- Fix contradictory "upstream client" → "MCP client" in ingress docs
- Expand glossary entry with Envoy attribution and Listener definition