### PR TITLE
docs: document unified upstream OAuth pipeline for MCP

### DIFF
--- a/content/docs/capabilities/mcp.mdx
+++ b/content/docs/capabilities/mcp.mdx
@@ -29,16 +29,19 @@ See [Protect an MCP Server](/docs/capabilities/mcp/protect-mcp-server) for setup
 
 ### MCP Bridging
 
-Pomerium acts as an **MCP-aware bridge** between your clients and remote third-party MCP servers that have their own authentication and authorization. Rather than exposing upstream credentials to each client, Pomerium sits in the middle and handles the full upstream OAuth lifecycle on the user's behalf.
+Pomerium acts as an **MCP-aware bridge** that manages upstream OAuth on behalf of your users. This applies to two scenarios:
+
+- **Third-party hosted MCP servers** (GitHub, Linear, Notion, Google) that enforce their own OAuth — Pomerium handles the upstream auth flow transparently.
+- **Self-hosted MCP servers** that call upstream APIs — your server receives a valid upstream access token on every proxied request without implementing OAuth itself.
 
 When a client connects to a Pomerium-fronted MCP route, Pomerium:
 
 - **Authenticates the user** through your identity provider (downstream OAuth 2.1)
-- **Authenticates with the upstream MCP server** by managing the upstream OAuth flow — acquiring, caching, and automatically refreshing access tokens
+- **Authenticates with the upstream service** by managing the upstream OAuth flow — acquiring, caching, and automatically refreshing access tokens
 - **Enforces authorization policies** on every request, including fine-grained tool-level access control
-- **Injects the upstream token** into proxied requests transparently — your MCP server receives a valid bearer token without the client ever seeing it
+- **Injects the upstream token** into proxied requests transparently — clients never see upstream credentials
 
-This means third-party MCP servers with their own auth (GitHub, Linear, Notion, Google, and others) can be securely bridged through Pomerium. Clients authenticate once with Pomerium and never handle upstream credentials directly. Pomerium uses a unified upstream OAuth pipeline that adapts to what you configure — from fully static credentials and endpoints, to pre-registered credentials with automatic endpoint discovery via [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728), to full auto-discovery where Pomerium handles client registration and the entire OAuth lifecycle.
+Pomerium uses a unified upstream OAuth pipeline that adapts to what you configure — from pre-registered credentials for providers that require manual app registration (GitHub, Google), to full auto-discovery via [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) for MCP servers that advertise their own authorization requirements.
 
 See [MCP + Upstream OAuth](/docs/capabilities/mcp/mcp-upstream-oauth) for setup instructions.
 

--- a/content/docs/capabilities/mcp.mdx
+++ b/content/docs/capabilities/mcp.mdx
@@ -38,7 +38,7 @@ When a client connects to a Pomerium-fronted MCP route, Pomerium:
 - **Enforces authorization policies** on every request, including fine-grained tool-level access control
 - **Injects the upstream token** into proxied requests transparently — your MCP server receives a valid bearer token without the client ever seeing it
 
-This means third-party MCP servers with their own auth (GitHub, Linear, Notion, Google, and others) can be securely bridged through Pomerium. Clients authenticate once with Pomerium and never handle upstream credentials directly. Pomerium supports both static OAuth2 configuration (where you register client credentials) and automatic [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) discovery for MCP servers that advertise their own authorization requirements.
+This means third-party MCP servers with their own auth (GitHub, Linear, Notion, Google, and others) can be securely bridged through Pomerium. Clients authenticate once with Pomerium and never handle upstream credentials directly. Pomerium uses a unified upstream OAuth pipeline that adapts to what you configure — from fully static credentials and endpoints, to pre-registered credentials with automatic endpoint discovery via [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728), to full auto-discovery where Pomerium handles client registration and the entire OAuth lifecycle.
 
 See [MCP + Upstream OAuth](/docs/capabilities/mcp/mcp-upstream-oauth) for setup instructions.
 

--- a/content/docs/capabilities/mcp/mcp-upstream-oauth.mdx
+++ b/content/docs/capabilities/mcp/mcp-upstream-oauth.mdx
@@ -20,17 +20,20 @@ keywords:
 
 # MCP + Upstream OAuth
 
-Many MCP servers require their own authentication — either because they front an upstream API (GitHub, Google Drive, Notion) or because the MCP server itself enforces OAuth. Pomerium manages the entire upstream OAuth flow and token lifecycle so your clients never handle upstream credentials directly.
+Upstream OAuth applies to two scenarios:
 
-Pomerium uses a unified upstream OAuth pipeline that adapts based on what you configure. You can supply as much or as little as you need:
+- **Third-party hosted MCP servers** (Notion, Linear, Google) that enforce their own OAuth — Pomerium handles the upstream auth flow so your users authenticate once and tool calls are proxied with valid tokens.
+- **Self-hosted MCP servers** that call upstream APIs under the hood — your server receives a valid upstream access token in the `Authorization: Bearer` header on every proxied request, so it never needs to implement OAuth itself.
 
-- **Static OAuth2** — you register client credentials and endpoints in your route config. Best for upstream APIs where you control the OAuth app registration (GitHub Apps, Google Cloud, etc.).
-- **Pre-registered credentials** — you supply `client_id` and `client_secret` but omit endpoints. Pomerium discovers the authorization and token endpoints automatically via [RFC 9728 Protected Resource Metadata](https://datatracker.ietf.org/doc/html/rfc9728), then uses your credentials directly — no dynamic client registration needed.
-- **Auto-discovery** — no upstream OAuth config at all. Pomerium discovers the server's authorization requirements at runtime and registers itself as an OAuth client via [CIMD](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document) or [DCR](https://datatracker.ietf.org/doc/html/rfc7591). Best for third-party MCP servers that advertise their own OAuth configuration.
+In both cases, external MCP clients only hold a Pomerium-issued token (TE) and never see upstream credentials.
 
-These modes are not separate code paths — they are points on a single configuration spectrum. Pomerium skips discovery and registration steps that your config makes unnecessary, and fills in what's missing from upstream metadata.
+Pomerium uses a unified upstream OAuth pipeline that adapts based on what you configure. The [MCP authorization spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization) defines a priority order for how clients identify themselves to upstream authorization servers:
 
-In all modes, your MCP server receives a valid upstream token on every proxied request — no OAuth logic needed on the server side. External clients only hold a Pomerium-issued external token (TE) and never see the upstream token.
+1. **Pre-registered credentials** — use when the upstream authorization server requires manual app registration and does not support automatic client registration. You supply `client_id` and `client_secret` (and optionally endpoints) in your route config.
+2. **[CIMD](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document)** — the recommended automatic mechanism. Pomerium publishes its client metadata at an HTTPS URL that serves as its `client_id`. The upstream AS fetches metadata on demand.
+3. **[DCR](https://datatracker.ietf.org/doc/html/rfc7591)** — a fallback for authorization servers that support dynamic registration but not CIMD.
+
+When no `upstream_oauth2` config is present, Pomerium tries CIMD first, then falls back to DCR. When `client_id` and `client_secret` are provided, Pomerium uses them directly and skips automatic registration. When endpoints are also provided, Pomerium skips [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) discovery as well.
 
 ## Architecture
 
@@ -148,9 +151,9 @@ After both steps, the client receives an external token (TE) and can make tool c
 
 ## Pre-Registered Credentials
 
-Use this mode when you have OAuth client credentials but the upstream server advertises its own endpoints via [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728). Pomerium discovers the authorization and token endpoints automatically, then uses your credentials — skipping dynamic client registration entirely.
+Use this mode when the upstream authorization server does not support automatic client registration (neither [CIMD](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document) nor [DCR](https://datatracker.ietf.org/doc/html/rfc7591)). You register an OAuth app manually with the provider and supply the credentials in your route config. Pomerium can still discover the authorization and token endpoints automatically via [RFC 9728 PRM](https://datatracker.ietf.org/doc/html/rfc9728) if the upstream advertises them — you only need to provide `endpoint` when it doesn't.
 
-This is common with providers like Google Cloud, where you create an OAuth app in their console but the MCP server's Protected Resource Metadata (PRM) already points to the correct authorization server.
+This is the common case for providers like Google Cloud and GitHub, where you must create an OAuth app in their console.
 
 ### Configuration
 
@@ -165,8 +168,8 @@ routes:
       server:
         path: /mcp
         upstream_oauth2:
-          client_id: 123456789.apps.googleusercontent.com
-          client_secret: your-client-secret
+          client_id: <your-google-oauth-client-id>
+          client_secret: <your-google-oauth-client-secret>
           scopes: ["https://www.googleapis.com/auth/datastore"]
     policy:
       allow:
@@ -177,7 +180,7 @@ routes:
 
 {/* spellchecker: enable */}
 
-Note the absence of `endpoint` — Pomerium discovers `accounts.google.com` as the authorization server from the upstream server's PRM metadata. You still need to add `accounts.google.com` to `mcp_allowed_as_metadata_domains` since it's a third-party domain not derivable from the route config:
+Note the absence of `endpoint` — Pomerium discovers `accounts.google.com` as the authorization server from the upstream server's [Protected Resource Metadata](https://datatracker.ietf.org/doc/html/rfc9728). You still need to add `accounts.google.com` to `mcp_allowed_as_metadata_domains` since it's a third-party domain not derivable from the route config:
 
 ```yaml
 mcp_allowed_as_metadata_domains:

--- a/content/docs/capabilities/mcp/mcp-upstream-oauth.mdx
+++ b/content/docs/capabilities/mcp/mcp-upstream-oauth.mdx
@@ -22,12 +22,15 @@ keywords:
 
 Many MCP servers require their own authentication — either because they front an upstream API (GitHub, Google Drive, Notion) or because the MCP server itself enforces OAuth. Pomerium manages the entire upstream OAuth flow and token lifecycle so your clients never handle upstream credentials directly.
 
-Pomerium supports two modes:
+Pomerium uses a unified upstream OAuth pipeline that adapts based on what you configure. You can supply as much or as little as you need:
 
 - **Static OAuth2** — you register client credentials and endpoints in your route config. Best for upstream APIs where you control the OAuth app registration (GitHub Apps, Google Cloud, etc.).
-- **Auto-discovery** — Pomerium automatically discovers the server's authorization requirements at runtime using [RFC 9728 Protected Resource Metadata](https://datatracker.ietf.org/doc/html/rfc9728). Best for third-party MCP servers that advertise their own OAuth configuration.
+- **Pre-registered credentials** — you supply `client_id` and `client_secret` but omit endpoints. Pomerium discovers the authorization and token endpoints automatically via [RFC 9728 Protected Resource Metadata](https://datatracker.ietf.org/doc/html/rfc9728), then uses your credentials directly — no dynamic client registration needed.
+- **Auto-discovery** — no upstream OAuth config at all. Pomerium discovers the server's authorization requirements at runtime and registers itself as an OAuth client via [CIMD](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document) or [DCR](https://datatracker.ietf.org/doc/html/rfc7591). Best for third-party MCP servers that advertise their own OAuth configuration.
 
-In both modes, your MCP server receives a valid upstream token on every proxied request — no OAuth logic needed on the server side. External clients only hold a Pomerium-issued external token (TE) and never see the upstream token.
+These modes are not separate code paths — they are points on a single configuration spectrum. Pomerium skips discovery and registration steps that your config makes unnecessary, and fills in what's missing from upstream metadata.
+
+In all modes, your MCP server receives a valid upstream token on every proxied request — no OAuth logic needed on the server side. External clients only hold a Pomerium-issued external token (TE) and never see the upstream token.
 
 ## Architecture
 
@@ -55,7 +58,7 @@ sequenceDiagram
 
 ## Static OAuth2
 
-Use static OAuth2 when you have pre-registered OAuth credentials for the upstream service.
+Use static OAuth2 when you have pre-registered OAuth credentials and know the provider's endpoints.
 
 ### Configuration
 
@@ -76,6 +79,9 @@ routes:
           endpoint:
             auth_url: 'https://github.com/login/oauth/authorize'
             token_url: 'https://github.com/login/oauth/access_token'
+          # Optional: extra query parameters for the authorization URL
+          # authorization_url_params:
+          #   login_hint: 'user@company.com'
     policy:
       allow:
         and:
@@ -139,6 +145,44 @@ After both steps, the client receives an external token (TE) and can make tool c
 | GitHub | `https://github.com/login/oauth/authorize` | `https://github.com/login/oauth/access_token` | `read:user`, `repo` |
 | Google | `https://accounts.google.com/o/oauth2/auth` | `https://oauth2.googleapis.com/token` | `https://www.googleapis.com/auth/drive.readonly` |
 | Notion | `https://api.notion.com/v1/oauth/authorize` | `https://api.notion.com/v1/oauth/token` | — (configured in integration) |
+
+## Pre-Registered Credentials
+
+Use this mode when you have OAuth client credentials but the upstream server advertises its own endpoints via [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728). Pomerium discovers the authorization and token endpoints automatically, then uses your credentials — skipping dynamic client registration entirely.
+
+This is common with providers like Google Cloud, where you create an OAuth app in their console but the MCP server's Protected Resource Metadata (PRM) already points to the correct authorization server.
+
+### Configuration
+
+{/* spellchecker: disable */}
+
+```yaml
+routes:
+  - from: https://firestore.your-domain.com
+    to: https://firestore.googleapis.com/
+    name: Google Firestore
+    mcp:
+      server:
+        path: /mcp
+        upstream_oauth2:
+          client_id: 123456789.apps.googleusercontent.com
+          client_secret: your-client-secret
+          scopes: ["https://www.googleapis.com/auth/datastore"]
+    policy:
+      allow:
+        and:
+          - domain:
+              is: company.com
+```
+
+{/* spellchecker: enable */}
+
+Note the absence of `endpoint` — Pomerium discovers `accounts.google.com` as the authorization server from the upstream server's PRM metadata. You still need to add `accounts.google.com` to `mcp_allowed_as_metadata_domains` since it's a third-party domain not derivable from the route config:
+
+```yaml
+mcp_allowed_as_metadata_domains:
+  - "accounts.google.com"
+```
 
 ## Auto-Discovery (RFC 9728)
 

--- a/content/docs/capabilities/mcp/mcp-upstream-oauth.mdx
+++ b/content/docs/capabilities/mcp/mcp-upstream-oauth.mdx
@@ -110,7 +110,7 @@ MCP support is currently an experimental feature only available in the `main` br
 Register an OAuth application with the upstream service. For GitHub:
 
 1. Go to **Settings → Developer settings → OAuth Apps → New OAuth App**
-2. Set the authorization callback URL to your Pomerium authenticate service URL
+2. Set the **authorization callback URL** to `https://<your-route-from-domain>/.pomerium/mcp/client/oauth/callback` — for example, if your route's `from` is `https://github.your-domain.com`, the callback URL is `https://github.your-domain.com/.pomerium/mcp/client/oauth/callback`
 3. Note the **Client ID** and **Client Secret**
 
 For other providers, refer to their OAuth documentation. You need:
@@ -118,6 +118,7 @@ For other providers, refer to their OAuth documentation. You need:
 - `client_id` and `client_secret`
 - `auth_url` and `token_url` endpoints
 - The appropriate `scopes` for your use-case
+- The **redirect/callback URI** set to `https://<your-route-from-domain>/.pomerium/mcp/client/oauth/callback`
 
 #### 2. Configure the route
 
@@ -155,6 +156,8 @@ After both steps, the client receives an external token (TE) and can make tool c
 Use this mode when the upstream authorization server does not support automatic client registration (neither [CIMD](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document) nor [DCR](https://datatracker.ietf.org/doc/html/rfc7591)). You register an OAuth app manually with the provider and supply the credentials in your route config. Pomerium can still discover the authorization and token endpoints automatically via [RFC 9728 PRM](https://datatracker.ietf.org/doc/html/rfc9728) if the upstream advertises them — you only need to provide `endpoint` when it doesn't.
 
 This is the common case for providers like Google Cloud and GitHub, where you must create an OAuth app in their console.
+
+When registering your OAuth app, set the redirect/callback URI to `https://<your-route-from-domain>/.pomerium/mcp/client/oauth/callback`.
 
 ### Configuration
 

--- a/content/docs/capabilities/mcp/mcp-upstream-oauth.mdx
+++ b/content/docs/capabilities/mcp/mcp-upstream-oauth.mdx
@@ -84,7 +84,8 @@ routes:
             token_url: 'https://github.com/login/oauth/access_token'
           # Optional: extra query parameters for the authorization URL
           # authorization_url_params:
-          #   login_hint: 'user@company.com'
+          #   access_type: 'offline'
+          #   prompt: 'consent'
     policy:
       allow:
         and:
@@ -171,6 +172,9 @@ routes:
           client_id: <your-google-oauth-client-id>
           client_secret: <your-google-oauth-client-secret>
           scopes: ["https://www.googleapis.com/auth/datastore"]
+          authorization_url_params:
+            access_type: "offline"
+            prompt: "consent"
     policy:
       allow:
         and:

--- a/content/docs/capabilities/mcp/reference.mdx
+++ b/content/docs/capabilities/mcp/reference.mdx
@@ -216,7 +216,8 @@ mcp:
       scopes: ["scope1", "scope2"]
       # Optional: extra query parameters for the authorization URL
       authorization_url_params:
-        login_hint: "user@company.com"
+        access_type: "offline" # Google: required for refresh tokens
+        prompt: "consent" # Google: force re-consent to get new refresh token
 
     # Optional: Maximum request body size (default: 4KiB)
     max_request_bytes: 1048576

--- a/content/docs/capabilities/mcp/reference.mdx
+++ b/content/docs/capabilities/mcp/reference.mdx
@@ -221,6 +221,12 @@ mcp:
 
     # Optional: Maximum request body size (default: 4KiB)
     max_request_bytes: 1048576
+
+    # Optional: Sub-path appended to the upstream URL for the MCP endpoint
+    path: "/mcp"
+
+    # Optional: Fallback AS issuer URL when PRM discovery fails (must be HTTPS)
+    authorization_server_url: "https://auth.provider.com"
 ```
 
 All `upstream_oauth2` fields are optional. Pomerium uses a unified pipeline that adapts based on what you configure:
@@ -232,6 +238,8 @@ All `upstream_oauth2` fields are optional. Pomerium uses a unified pipeline that
 | Nothing                                               | Full auto-discovery: discovers endpoints, registers as a client via CIMD/DCR, manages the full lifecycle                               |
 
 `client_secret` is never stored per-user — it is read from the route config at token refresh time.
+
+When using static or pre-registered credentials, set the OAuth app's **redirect/callback URI** to `https://<your-route-from-domain>/.pomerium/mcp/client/oauth/callback`. In auto-discovery mode, this is handled automatically via CIMD or DCR.
 
 ** Tool Call Authorization **
 

--- a/content/docs/capabilities/mcp/reference.mdx
+++ b/content/docs/capabilities/mcp/reference.mdx
@@ -1,9 +1,9 @@
 ---
-title: 'MCP Full Reference'
-sidebar_label: 'Full Reference'
+title: "MCP Full Reference"
+sidebar_label: "Full Reference"
 sidebar_position: 10
 lang: en-US
-description: 'Complete reference for Pomerium MCP support: token types, configuration options, user identity, security, observability, and policy-based tool access control.'
+description: "Complete reference for Pomerium MCP support: token types, configuration options, user identity, security, observability, and policy-based tool access control."
 keywords: [MCP, model context protocol, AI agents, LLM, AI gateway]
 ---
 
@@ -157,12 +157,12 @@ When MCP clients use URL-based client IDs (per the [OAuth 2.0 Client ID Metadata
 
 ```yaml
 mcp_allowed_client_id_domains:
-  - 'example.com'
-  - '*.trusted-provider.com'
+  - "example.com"
+  - "*.trusted-provider.com"
 ```
 
-| Setting | Description |
-| --- | --- |
+| Setting                         | Description                                                                                                                                                    |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `mcp_allowed_client_id_domains` | List of allowed domain patterns for MCP client ID metadata URLs. Supports wildcard patterns (e.g., `*.example.com`). Required when using URL-based client IDs. |
 
 **Behavior:**
@@ -170,6 +170,25 @@ mcp_allowed_client_id_domains:
 - Only domains matching the configured patterns can be used as client ID metadata URLs
 - Wildcard patterns like `*.example.com` match subdomains (e.g., `app.example.com`) but not the bare domain
 - If a client attempts to use a client ID from a domain not in the allowed list, Pomerium displays a user-friendly error page explaining the restriction, along with the request ID and the attempted client ID for troubleshooting
+
+#### Allowed AS Metadata Domains
+
+When Pomerium performs upstream OAuth discovery (for both auto-discovery and pre-registered credential modes), it fetches metadata documents from URLs that originate in upstream server responses. To protect against SSRF, these URLs are validated against a domain allowlist.
+
+```yaml
+mcp_allowed_as_metadata_domains:
+  - "accounts.google.com"
+  - "*.oauth-provider.com"
+```
+
+| Setting                           | Description                                                                                                                                                                                                              |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `mcp_allowed_as_metadata_domains` | Domains Pomerium may contact during upstream OAuth discovery. This includes `resource_metadata` URLs from `WWW-Authenticate` headers and `authorization_servers` entries from PRM documents. Supports wildcard patterns. |
+
+**What needs to be listed:**
+
+- The route's upstream (`to`) domain is used for PRM fetches and is validated against this list
+- Third-party authorization server domains discovered inside PRM documents (e.g. `accounts.google.com` for Google APIs) must be explicitly added — they cannot be inferred from route config
 
 **Example error scenario:**
 
@@ -188,17 +207,30 @@ mcp:
   server:
     # Optional: Configure upstream OAuth2 for services requiring authentication
     upstream_oauth2:
-      client_id: 'your-oauth-client-id'
-      client_secret: 'your-oauth-client-secret'
+      client_id: "your-oauth-client-id"
+      client_secret: "your-oauth-client-secret"
       endpoint:
-        auth_url: 'https://provider.com/oauth/authorize'
-        token_url: 'https://provider.com/oauth/token'
-        auth_style: 'header' # or "params"
-      scopes: ['scope1', 'scope2']
+        auth_url: "https://provider.com/oauth/authorize"
+        token_url: "https://provider.com/oauth/token"
+        auth_style: "header" # or "params"
+      scopes: ["scope1", "scope2"]
+      # Optional: extra query parameters for the authorization URL
+      authorization_url_params:
+        login_hint: "user@company.com"
 
     # Optional: Maximum request body size (default: 4KiB)
     max_request_bytes: 1048576
 ```
+
+All `upstream_oauth2` fields are optional. Pomerium uses a unified pipeline that adapts based on what you configure:
+
+| What you provide                                      | What Pomerium does                                                                                                                     |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Everything (`client_id`, `client_secret`, `endpoint`) | Uses your credentials and endpoints directly — no discovery or registration                                                            |
+| `client_id` + `client_secret` (no `endpoint`)         | Discovers endpoints via [RFC 9728 PRM](https://datatracker.ietf.org/doc/html/rfc9728), uses your credentials — no dynamic registration |
+| Nothing                                               | Full auto-discovery: discovers endpoints, registers as a client via CIMD/DCR, manages the full lifecycle                               |
+
+`client_secret` is never stored per-user — it is read from the route config at token refresh time.
 
 ** Tool Call Authorization **
 
@@ -367,11 +399,11 @@ For general observability features, see [Metrics](/docs/reference/metrics) and [
 
 Pomerium includes three specialized log fields for MCP monitoring:
 
-| Field | Description | Example Value |
-| --- | --- | --- |
-| `mcp-method` | The MCP JSON-RPC method being called | `"tools/call"`, `"tools/list"` |
-| `mcp-tool` | The specific tool name being invoked (for `tools/call` requests) | `"database_query"`, `"list_files"` |
-| `mcp-tool-parameters` | The parameters passed to the tool | `{"query": "SELECT * FROM users", "limit": 100}` |
+| Field                 | Description                                                      | Example Value                                    |
+| --------------------- | ---------------------------------------------------------------- | ------------------------------------------------ |
+| `mcp-method`          | The MCP JSON-RPC method being called                             | `"tools/call"`, `"tools/list"`                   |
+| `mcp-tool`            | The specific tool name being invoked (for `tools/call` requests) | `"database_query"`, `"list_files"`               |
+| `mcp-tool-parameters` | The parameters passed to the tool                                | `{"query": "SELECT * FROM users", "limit": 100}` |
 
 ### Configuration
 
@@ -485,14 +517,14 @@ For broader policy examples, see the [Authorization documentation](/docs/capabil
 
 The `mcp_tool` criterion is designed specifically for MCP routes and allows policy enforcement at the individual tool level. It uses the [String Matcher](/docs/internals/ppl#string-matcher) format and supports all standard string matching operators.
 
-| Operator | Description | Example |
-| --- | --- | --- |
-| `is` | Exact match of the tool name | `mcp_tool: { is: "database_query" }` |
-| `starts_with` | Tool name starts with the specified prefix | `mcp_tool: { starts_with: "db_" }` |
-| `ends_with` | Tool name ends with the specified suffix | `mcp_tool: { ends_with: "_query" }` |
-| `contains` | Tool name contains the specified substring | `mcp_tool: { contains: "read" }` |
-| `in` | Tool name matches one of the provided values | `mcp_tool: { in: ["list_tables", "describe_table"] }` |
-| `not_in` | Tool name does not match any of the provided values (useful to enforce allowlists under `deny`) | `mcp_tool: { not_in: ["query", "list_tables"] }` |
+| Operator      | Description                                                                                     | Example                                               |
+| ------------- | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `is`          | Exact match of the tool name                                                                    | `mcp_tool: { is: "database_query" }`                  |
+| `starts_with` | Tool name starts with the specified prefix                                                      | `mcp_tool: { starts_with: "db_" }`                    |
+| `ends_with`   | Tool name ends with the specified suffix                                                        | `mcp_tool: { ends_with: "_query" }`                   |
+| `contains`    | Tool name contains the specified substring                                                      | `mcp_tool: { contains: "read" }`                      |
+| `in`          | Tool name matches one of the provided values                                                    | `mcp_tool: { in: ["list_tables", "describe_table"] }` |
+| `not_in`      | Tool name does not match any of the provided values (useful to enforce allowlists under `deny`) | `mcp_tool: { not_in: ["query", "list_tables"] }`      |
 
 #### Evaluation semantics
 
@@ -534,7 +566,7 @@ policy:
   deny:
     and:
       - mcp_tool:
-          starts_with: 'admin_'
+          starts_with: "admin_"
 ```
 
 Note:
@@ -552,7 +584,7 @@ policy:
   deny:
     and:
       - mcp_tool:
-          not_in: ['query', 'list_tables']
+          not_in: ["query", "list_tables"]
 ```
 
 ### Example
@@ -566,13 +598,13 @@ policy:
       - domain:
           is: company.com
       - groups:
-          has: 'data-analysts'
+          has: "data-analysts"
   deny:
     or:
       - mcp_tool:
-          in: ['update_data', 'drop_table', 'delete_records']
+          in: ["update_data", "drop_table", "delete_records"]
       - mcp_tool:
-          starts_with: 'admin_'
+          starts_with: "admin_"
 ```
 
 For more advanced policy patterns, see the [PPL documentation](/docs/internals/ppl).

--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -1039,6 +1039,14 @@
     "path": "/../capabilities/device-identity",
     "title": "Manage Devices"
   },
+  "mcp-allowed-as-metadata-domains": {
+    "description": "Domains Pomerium may contact during upstream OAuth discovery. Includes resource_metadata URLs from WWW-Authenticate headers and authorization_servers entries from PRM documents. Supports wildcard patterns.",
+    "id": "mcp-allowed-as-metadata-domains",
+    "path": "/../capabilities/mcp/reference#allowed-as-metadata-domains",
+    "services": [],
+    "title": "MCP Allowed AS Metadata Domains",
+    "type": "array of strings"
+  },
   "mcp-allowed-client-id-domains": {
     "description": "List of allowed domain patterns for MCP client ID metadata URLs. Supports wildcard patterns (e.g., *.example.com). Required when using URL-based client IDs.",
     "id": "mcp-allowed-client-id-domains",
@@ -1046,6 +1054,13 @@
     "services": [],
     "title": "MCP Allowed Client ID Domains",
     "type": "array of strings"
+  },
+  "mcp-server-authorization-server-url": {
+    "description": "Fallback Authorization Server URL used when RFC 9728 PRM discovery fails. Must be HTTPS.",
+    "id": "mcp-server-authorization-server-url",
+    "path": "/../capabilities/mcp/reference#mcp-server-configuration",
+    "title": "MCP Server Authorization Server URL",
+    "type": "string"
   },
   "mcp-server-max-request-bytes": {
     "description": "Maximum MCP request size in bytes. Adjust if you are passing some large payloads that cause errors.",
@@ -1095,6 +1110,13 @@
     "path": "/../capabilities/mcp/reference#mcp-server-configuration",
     "title": "MCP Server Upstream OAuth2 Client Secret",
     "type": "string"
+  },
+  "mcp-server-upstream-oauth2-authorization-url-params": {
+    "description": "Extra query parameters appended to the OAuth authorization URL (e.g., access_type, prompt, audience).",
+    "id": "mcp-server-upstream-oauth2-authorization-url-params",
+    "path": "/../capabilities/mcp/reference#mcp-server-configuration",
+    "title": "MCP Server Upstream OAuth2 Authorization URL Params",
+    "type": "map of strings"
   },
   "mcp-server-upstream-oauth2-scopes": {
     "description": "OAuth scopes to request from the provider (e.g., read:user, user:email).",


### PR DESCRIPTION
## Summary

- Add new **Pre-Registered Credentials** section to MCP + Upstream OAuth blueprint with Google Cloud / Firestore example
- Document new `authorization_url_params` config option
- Document `mcp_allowed_as_metadata_domains` in Full Reference (was only mentioned in the upstream-oauth page)
- Add config spectrum table showing what Pomerium does based on what you provide (full static → pre-registered → auto-discovery)
- Note that `client_secret` is never stored per-user
- Update landing page to describe the unified pipeline

Tracks [ENG-3698](https://linear.app/pomerium/issue/ENG-3698/mcp-unify-upstream-oauth-flows-support-pre-registered-client)

See docs at https://deploy-preview-2109--pomerium-docs.netlify.app/docs/capabilities/mcp/mcp-upstream-oauth

## Test plan

- [ ] Verify docs build with `yarn build`
- [ ] Review Pre-Registered Credentials section for accuracy against implementation
- [ ] Confirm config spectrum table matches actual behavior