### PR TITLE
fix: block LLM/search crawlers on branch deploy subdomains

### DIFF
--- a/content/docs/capabilities/mcp/mcp-upstream-oauth.mdx
+++ b/content/docs/capabilities/mcp/mcp-upstream-oauth.mdx
@@ -174,10 +174,10 @@ routes:
         upstream_oauth2:
           client_id: <your-google-oauth-client-id>
           client_secret: <your-google-oauth-client-secret>
-          scopes: ["https://www.googleapis.com/auth/datastore"]
+          scopes: ['https://www.googleapis.com/auth/datastore']
           authorization_url_params:
-            access_type: "offline"
-            prompt: "consent"
+            access_type: 'offline'
+            prompt: 'consent'
     policy:
       allow:
         and:
@@ -191,7 +191,7 @@ Note the absence of `endpoint` — Pomerium discovers `accounts.google.com` as t
 
 ```yaml
 mcp_allowed_as_metadata_domains:
-  - "accounts.google.com"
+  - 'accounts.google.com'
 ```
 
 ## Auto-Discovery (RFC 9728)

--- a/content/docs/capabilities/mcp/reference.mdx
+++ b/content/docs/capabilities/mcp/reference.mdx
@@ -1,9 +1,9 @@
 ---
-title: "MCP Full Reference"
-sidebar_label: "Full Reference"
+title: 'MCP Full Reference'
+sidebar_label: 'Full Reference'
 sidebar_position: 10
 lang: en-US
-description: "Complete reference for Pomerium MCP support: token types, configuration options, user identity, security, observability, and policy-based tool access control."
+description: 'Complete reference for Pomerium MCP support: token types, configuration options, user identity, security, observability, and policy-based tool access control.'
 keywords: [MCP, model context protocol, AI agents, LLM, AI gateway]
 ---
 
@@ -157,12 +157,12 @@ When MCP clients use URL-based client IDs (per the [OAuth 2.0 Client ID Metadata
 
 ```yaml
 mcp_allowed_client_id_domains:
-  - "example.com"
-  - "*.trusted-provider.com"
+  - 'example.com'
+  - '*.trusted-provider.com'
 ```
 
-| Setting                         | Description                                                                                                                                                    |
-| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Setting | Description |
+| --- | --- |
 | `mcp_allowed_client_id_domains` | List of allowed domain patterns for MCP client ID metadata URLs. Supports wildcard patterns (e.g., `*.example.com`). Required when using URL-based client IDs. |
 
 **Behavior:**
@@ -177,12 +177,12 @@ When Pomerium performs upstream OAuth discovery (for both auto-discovery and pre
 
 ```yaml
 mcp_allowed_as_metadata_domains:
-  - "accounts.google.com"
-  - "*.oauth-provider.com"
+  - 'accounts.google.com'
+  - '*.oauth-provider.com'
 ```
 
-| Setting                           | Description                                                                                                                                                                                                              |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Setting | Description |
+| --- | --- |
 | `mcp_allowed_as_metadata_domains` | Domains Pomerium may contact during upstream OAuth discovery. This includes `resource_metadata` URLs from `WWW-Authenticate` headers and `authorization_servers` entries from PRM documents. Supports wildcard patterns. |
 
 **What needs to be listed:**
@@ -207,35 +207,35 @@ mcp:
   server:
     # Optional: Configure upstream OAuth2 for services requiring authentication
     upstream_oauth2:
-      client_id: "your-oauth-client-id"
-      client_secret: "your-oauth-client-secret"
+      client_id: 'your-oauth-client-id'
+      client_secret: 'your-oauth-client-secret'
       endpoint:
-        auth_url: "https://provider.com/oauth/authorize"
-        token_url: "https://provider.com/oauth/token"
-        auth_style: "header" # or "params"
-      scopes: ["scope1", "scope2"]
+        auth_url: 'https://provider.com/oauth/authorize'
+        token_url: 'https://provider.com/oauth/token'
+        auth_style: 'header' # or "params"
+      scopes: ['scope1', 'scope2']
       # Optional: extra query parameters for the authorization URL
       authorization_url_params:
-        access_type: "offline" # Google: required for refresh tokens
-        prompt: "consent" # Google: force re-consent to get new refresh token
+        access_type: 'offline' # Google: required for refresh tokens
+        prompt: 'consent' # Google: force re-consent to get new refresh token
 
     # Optional: Maximum request body size (default: 4KiB)
     max_request_bytes: 1048576
 
     # Optional: Sub-path appended to the upstream URL for the MCP endpoint
-    path: "/mcp"
+    path: '/mcp'
 
     # Optional: Fallback AS issuer URL when PRM discovery fails (must be HTTPS)
-    authorization_server_url: "https://auth.provider.com"
+    authorization_server_url: 'https://auth.provider.com'
 ```
 
 All `upstream_oauth2` fields are optional. Pomerium uses a unified pipeline that adapts based on what you configure:
 
-| What you provide                                      | What Pomerium does                                                                                                                     |
-| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| Everything (`client_id`, `client_secret`, `endpoint`) | Uses your credentials and endpoints directly — no discovery or registration                                                            |
-| `client_id` + `client_secret` (no `endpoint`)         | Discovers endpoints via [RFC 9728 PRM](https://datatracker.ietf.org/doc/html/rfc9728), uses your credentials — no dynamic registration |
-| Nothing                                               | Full auto-discovery: discovers endpoints, registers as a client via CIMD/DCR, manages the full lifecycle                               |
+| What you provide | What Pomerium does |
+| --- | --- |
+| Everything (`client_id`, `client_secret`, `endpoint`) | Uses your credentials and endpoints directly — no discovery or registration |
+| `client_id` + `client_secret` (no `endpoint`) | Discovers endpoints via [RFC 9728 PRM](https://datatracker.ietf.org/doc/html/rfc9728), uses your credentials — no dynamic registration |
+| Nothing | Full auto-discovery: discovers endpoints, registers as a client via CIMD/DCR, manages the full lifecycle |
 
 `client_secret` is never stored per-user — it is read from the route config at token refresh time.
 
@@ -408,11 +408,11 @@ For general observability features, see [Metrics](/docs/reference/metrics) and [
 
 Pomerium includes three specialized log fields for MCP monitoring:
 
-| Field                 | Description                                                      | Example Value                                    |
-| --------------------- | ---------------------------------------------------------------- | ------------------------------------------------ |
-| `mcp-method`          | The MCP JSON-RPC method being called                             | `"tools/call"`, `"tools/list"`                   |
-| `mcp-tool`            | The specific tool name being invoked (for `tools/call` requests) | `"database_query"`, `"list_files"`               |
-| `mcp-tool-parameters` | The parameters passed to the tool                                | `{"query": "SELECT * FROM users", "limit": 100}` |
+| Field | Description | Example Value |
+| --- | --- | --- |
+| `mcp-method` | The MCP JSON-RPC method being called | `"tools/call"`, `"tools/list"` |
+| `mcp-tool` | The specific tool name being invoked (for `tools/call` requests) | `"database_query"`, `"list_files"` |
+| `mcp-tool-parameters` | The parameters passed to the tool | `{"query": "SELECT * FROM users", "limit": 100}` |
 
 ### Configuration
 
@@ -526,14 +526,14 @@ For broader policy examples, see the [Authorization documentation](/docs/capabil
 
 The `mcp_tool` criterion is designed specifically for MCP routes and allows policy enforcement at the individual tool level. It uses the [String Matcher](/docs/internals/ppl#string-matcher) format and supports all standard string matching operators.
 
-| Operator      | Description                                                                                     | Example                                               |
-| ------------- | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| `is`          | Exact match of the tool name                                                                    | `mcp_tool: { is: "database_query" }`                  |
-| `starts_with` | Tool name starts with the specified prefix                                                      | `mcp_tool: { starts_with: "db_" }`                    |
-| `ends_with`   | Tool name ends with the specified suffix                                                        | `mcp_tool: { ends_with: "_query" }`                   |
-| `contains`    | Tool name contains the specified substring                                                      | `mcp_tool: { contains: "read" }`                      |
-| `in`          | Tool name matches one of the provided values                                                    | `mcp_tool: { in: ["list_tables", "describe_table"] }` |
-| `not_in`      | Tool name does not match any of the provided values (useful to enforce allowlists under `deny`) | `mcp_tool: { not_in: ["query", "list_tables"] }`      |
+| Operator | Description | Example |
+| --- | --- | --- |
+| `is` | Exact match of the tool name | `mcp_tool: { is: "database_query" }` |
+| `starts_with` | Tool name starts with the specified prefix | `mcp_tool: { starts_with: "db_" }` |
+| `ends_with` | Tool name ends with the specified suffix | `mcp_tool: { ends_with: "_query" }` |
+| `contains` | Tool name contains the specified substring | `mcp_tool: { contains: "read" }` |
+| `in` | Tool name matches one of the provided values | `mcp_tool: { in: ["list_tables", "describe_table"] }` |
+| `not_in` | Tool name does not match any of the provided values (useful to enforce allowlists under `deny`) | `mcp_tool: { not_in: ["query", "list_tables"] }` |
 
 #### Evaluation semantics
 
@@ -575,7 +575,7 @@ policy:
   deny:
     and:
       - mcp_tool:
-          starts_with: "admin_"
+          starts_with: 'admin_'
 ```
 
 Note:
@@ -593,7 +593,7 @@ policy:
   deny:
     and:
       - mcp_tool:
-          not_in: ["query", "list_tables"]
+          not_in: ['query', 'list_tables']
 ```
 
 ### Example
@@ -607,13 +607,13 @@ policy:
       - domain:
           is: company.com
       - groups:
-          has: "data-analysts"
+          has: 'data-analysts'
   deny:
     or:
       - mcp_tool:
-          in: ["update_data", "drop_table", "delete_records"]
+          in: ['update_data', 'drop_table', 'delete_records']
       - mcp_tool:
-          starts_with: "admin_"
+          starts_with: 'admin_'
 ```
 
 For more advanced policy patterns, see the [PPL documentation](/docs/internals/ppl).

--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -1097,6 +1097,13 @@
     "title": "MCP Server Upstream OAuth2 Authentication URL",
     "type": "string"
   },
+  "mcp-server-upstream-oauth2-authorization-url-params": {
+    "description": "Extra query parameters appended to the OAuth authorization URL (e.g., access_type, prompt, audience).",
+    "id": "mcp-server-upstream-oauth2-authorization-url-params",
+    "path": "/../capabilities/mcp/reference#mcp-server-configuration",
+    "title": "MCP Server Upstream OAuth2 Authorization URL Params",
+    "type": "map of strings"
+  },
   "mcp-server-upstream-oauth2-client-id": {
     "description": "OAuth client identifier issued by the upstream provider.",
     "id": "mcp-server-upstream-oauth2-client-id",
@@ -1110,13 +1117,6 @@
     "path": "/../capabilities/mcp/reference#mcp-server-configuration",
     "title": "MCP Server Upstream OAuth2 Client Secret",
     "type": "string"
-  },
-  "mcp-server-upstream-oauth2-authorization-url-params": {
-    "description": "Extra query parameters appended to the OAuth authorization URL (e.g., access_type, prompt, audience).",
-    "id": "mcp-server-upstream-oauth2-authorization-url-params",
-    "path": "/../capabilities/mcp/reference#mcp-server-configuration",
-    "title": "MCP Server Upstream OAuth2 Authorization URL Params",
-    "type": "map of strings"
   },
   "mcp-server-upstream-oauth2-scopes": {
     "description": "OAuth scopes to request from the provider (e.g., read:user, user:email).",

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -271,6 +271,8 @@ const config: Config = {
         id: process.env.GTM,
       },
     ],
+    // Branch deploys default to disallow; release branches rewrite robots.txt.
+    require.resolve('./plugins/robots-txt-plugin'),
     // Generate llms.txt file for LLM consumption
     require.resolve('./plugins/llms-txt-plugin'),
     // async function customPlugin(context, opts) {

--- a/plugins/robots-txt-plugin.js
+++ b/plugins/robots-txt-plugin.js
@@ -1,0 +1,93 @@
+const fs = require('fs');
+const path = require('path');
+
+const RELEASE_BRANCH_RE = /^\d+-\d+-\d+$/;
+const ALLOW_TEMPLATE_PATH = path.join(
+  __dirname,
+  '..',
+  'templates',
+  'robots-allow.txt',
+);
+
+function resolveRobotsMode() {
+  const forcedMode = process.env.POMERIUM_DOCS_ROBOTS_MODE;
+  if (forcedMode === 'allow' || forcedMode === 'disallow') {
+    return forcedMode;
+  }
+
+  const branch = process.env.HEAD || process.env.BRANCH || '';
+  if (RELEASE_BRANCH_RE.test(branch)) {
+    return 'allow';
+  }
+
+  const context = process.env.CONTEXT || '';
+  if (context === 'deploy-preview' || context === 'branch-deploy') {
+    return 'disallow';
+  }
+
+  if (branch) {
+    // Production docs are expected to build from numbered release branches.
+    // If that changes, set POMERIUM_DOCS_ROBOTS_MODE=allow explicitly.
+    return 'disallow';
+  }
+
+  // Local/manual builds default to the checked-in allow template.
+  return 'allow';
+}
+
+function buildDisallowRobots(branch, context) {
+  const details = [];
+  if (branch) details.push(`branch=${branch}`);
+  if (context) details.push(`context=${context}`);
+
+  return [
+    '# Non-release docs build. Block crawlers by default.',
+    details.length > 0
+      ? `# ${details.join(' ')}`
+      : '# Branch/context unavailable.',
+    '# Stable release branches keep the checked-in allow template.',
+    'User-agent: *',
+    'Disallow: /',
+    '',
+  ].join('\n');
+}
+
+async function readAllowTemplate() {
+  return fs.promises.readFile(ALLOW_TEMPLATE_PATH, 'utf8');
+}
+
+async function pluginRobotsTxt(_context, _options) {
+  return {
+    name: 'robots-txt-plugin',
+
+    async postBuild({outDir}) {
+      const mode = resolveRobotsMode();
+      const branch = process.env.HEAD || process.env.BRANCH || '';
+      const context = process.env.CONTEXT || '';
+
+      const robotsPath = path.join(outDir, 'robots.txt');
+      if (mode === 'allow') {
+        await fs.promises.writeFile(
+          robotsPath,
+          await readAllowTemplate(),
+          'utf8',
+        );
+        console.log(
+          `✅ Wrote allow robots.txt template (${branch || 'no-branch'}${context ? `, ${context}` : ''})`,
+        );
+        return;
+      }
+
+      await fs.promises.writeFile(
+        robotsPath,
+        buildDisallowRobots(branch, context),
+        'utf8',
+      );
+      console.log(
+        `✅ Wrote disallow robots.txt (${branch || 'no-branch'}${context ? `, ${context}` : ''})`,
+      );
+    },
+  };
+}
+
+module.exports = pluginRobotsTxt;

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,37 +1,6 @@
+# Branch deploy / preview — block all crawlers.
+# Production (0-32-0 branch) has its own permissive robots.txt.
+# See: https://linear.app/pomerium/issue/ENG-3768
+
 User-agent: *
-Allow: /
-
-# LLM crawlers - explicitly allowed
-User-agent: GPTBot
-Allow: /
-
-User-agent: OAI-SearchBot
-Allow: /
-
-User-agent: ClaudeBot
-Allow: /
-
-User-agent: Claude-User
-Allow: /
-
-User-agent: Claude-SearchBot
-Allow: /
-
-User-agent: Amazonbot
-Allow: /
-
-User-agent: Google-Extended
-Allow: /
-
-User-agent: PerplexityBot
-Allow: /
-
-User-agent: YouBot
-Allow: /
-
-# LLM-readable documentation (llmstxt.org)
-# https://www.pomerium.com/llms.txt        — curated navigator
-# https://www.pomerium.com/llms-full.txt   — key docs inline (~80K tokens)
-# https://www.pomerium.com/llms-index.txt  — exhaustive page index
-
-Sitemap: https://www.pomerium.com/sitemap.xml
+Disallow: /

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,6 +1,4 @@
-# Branch deploy / preview — block all crawlers.
-# Production (0-32-0 branch) has its own permissive robots.txt.
-# See: https://linear.app/pomerium/issue/ENG-3768
-
+# Non-release docs build. Block crawlers by default.
+# Release branches write the allow template at build time.
 User-agent: *
 Disallow: /

--- a/templates/robots-allow.txt
+++ b/templates/robots-allow.txt
@@ -1,0 +1,37 @@
+User-agent: *
+Allow: /
+
+# LLM crawlers - explicitly allowed
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: YouBot
+Allow: /
+
+# LLM-readable documentation (llmstxt.org)
+# https://www.pomerium.com/llms.txt        — curated navigator
+# https://www.pomerium.com/llms-full.txt   — key docs inline (~80K tokens)
+# https://www.pomerium.com/llms-index.txt  — exhaustive page index
+
+Sitemap: https://www.pomerium.com/sitemap.xml


### PR DESCRIPTION
## Summary
- make docs `robots.txt` branch-aware instead of relying on a manual revert when the next release branch is cut
- keep non-release branch deploys and previews blocked by default
- automatically write the permissive `robots.txt` for numbered release branches like `0-33-0`

## Problem
`*.docs.pomerium.com` wildcard DNS routes branch deploys through Netlify, so branch builds are publicly fetchable unless we actively block crawlers.

The first draft of this change hard-coded `static/robots.txt` to `Disallow: /` on `main`, which would have required a manual undo when the next stable release branch is cut. That is exactly the kind of thing we forget.

## Approach
This PR keeps the checked-in fallback safe (`Disallow: /`) and adds a small Docusaurus post-build plugin that writes the allow template only when the build is for a numbered release branch.

Behavior:
- `deploy-preview` / `branch-deploy` on `main` or any other non-release branch: `Disallow: /`
- numbered release branches like `0-33-0`: write the normal permissive `robots.txt`
- explicit escape hatch: `POMERIUM_DOCS_ROBOTS_MODE=allow|disallow`

This means we do not need to remember a revert when we cut `0-33-0`; the release branch will emit the right file automatically.

## Verification
Verified locally with full builds:
- `HEAD=main BRANCH=main CONTEXT=branch-deploy yarn build` -> `build/robots.txt` is `Disallow: /`
- `HEAD=0-33-0 BRANCH=0-33-0 CONTEXT=branch-deploy yarn build` -> `build/robots.txt` is the normal allow template

Fixes ENG-3768
