### PR TITLE
fix: add 45 redirect rules for GSC 404 URLs

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -386,7 +386,7 @@ https://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
 
 # Old /docs/deploy/core sub-paths
 /docs/deploy/core/binary /docs/deploy/core
-/docs/deploy/core/from-source /docs/deploy/core
+/docs/deploy/core/from-source /docs/deploy/core#building-from-source-hard-fun-mode
 
 # Old /docs/enterprise paths
 /docs/enterprise/api.html /docs/internals/management-api-enterprise
@@ -411,29 +411,24 @@ https://docs.pomerium.io/* https://docs.pomerium.com/:splat 301!
 /docs/capabilities/tcp/* /docs/capabilities/non-http/:splat
 
 # Old /docs/guides paths that 404
-/docs/guides/enroll-device.html /docs/deploy/clients/clients
-/docs/guides/enroll-device /docs/deploy/clients/clients
-/docs/guides/kubernetes-dashboard /docs/guides
+/docs/guides/enroll-device.html /docs/integrations/device-context/webauthn
+/docs/guides/enroll-device /docs/integrations/device-context/webauthn
 /docs/guides/verify-jwt /docs/capabilities/getting-users-identity
 
-# Old /docs/reference individual setting pages (removed, redirect to parent)
-/docs/reference/authenticate-callback-path /docs/reference
-/docs/reference/client-certificate-authority /docs/reference
-/docs/reference/grpc-client-dns-roundrobin /docs/reference
-/docs/reference/identity-provider-scopes /docs/reference
-/docs/reference/identity-provider-service-account /docs/reference
-/docs/reference/metrics-address /docs/reference
-/docs/reference/metrics-client-certificate-authority /docs/reference
-/docs/reference/tls-downstream-server-name /docs/reference
+# Old /docs/reference individual setting pages (redirect to specific anchors)
+/docs/reference/client-certificate-authority /docs/reference/downstream-mtls-settings#ca
+/docs/reference/identity-provider-scopes /docs/reference/identity-provider-settings#identity-provider-scopes
+/docs/reference/metrics-address /docs/reference/metrics#metrics-address
+/docs/reference/metrics-client-certificate-authority /docs/reference/metrics#metrics-client-certificate-authority
+/docs/reference/tls-downstream-server-name /docs/reference/routes/tls#tls-downstream-server-name
 /docs/referenceundefined /docs/reference
 
 # Old /docs/reference/routes sub-pages
-/docs/reference/routes/host-rewrite /docs/capabilities/routing
-/docs/reference/routes/regex /docs/capabilities/routing
-/docs/reference/routes/tls-custom-certificate-authority /docs/capabilities/routing
-/docs/reference/routes/websocket-connections /docs/capabilities/routing
+/docs/reference/routes/host-rewrite /docs/reference/routes/headers#2-host-rewrite
+/docs/reference/routes/regex /docs/reference/routes/path-matching#regex
+/docs/reference/routes/tls-custom-certificate-authority /docs/reference/routes/tls#tls-custom-certificate-authority
+/docs/reference/routes/websocket-connections /docs/reference/routes/timeouts#websocket-connections
 
 # Old top-level paths
-/guides/traefik-ingress.html /docs/guides
 /recipes/argo.html /docs/guides/argo
 /products/zero /docs/deploy/cloud/install


### PR DESCRIPTION
## Summary
Adds redirect rules for 45 URLs currently returning 404 in Google Search Console, found during the 2026-03-18 SEO audit.

## Context
GSC reports 1,062 pages returning 404. After analysis:
- 554 are spam injection URLs (`/docs/reference/https://...`) — unfixable, ignored
- 354 are old versioned doc subdomains — handled by robots.txt fix in PR #2122
- 45 are legitimate old doc paths that need redirects — **this PR**

Categories of redirects added:
- Old `/docs/concepts/*` → current `/docs/capabilities/*` or `/docs/internals/*`
- Old `/docs/topics/*` → current `/docs/capabilities/*`
- Old `/docs/enterprise/*` → current `/docs/deploy/enterprise/*`
- Old `/docs/identity-providers/*` → current `/docs/integrations/user-identity/*`
- Old `/docs/reference/*` individual setting pages → `/docs/reference` parent
- Old `/docs/deploying/*` (typo) → `/docs/deploy/*`
- Misc old paths (`/enterprise/api`, `/guides/*`, `/recipes/*`, `/products/zero`)

## Test plan
- [ ] Verify redirects work on Netlify deploy preview
- [ ] Spot-check a few URLs with `curl -sI`

Fixes ENG-3770