### PR TITLE
fix: add blocking robots.txt for 0-31-0 branch deploy

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,5 +1,5 @@
 # Old release branch — block all crawlers.
-# Current docs live at www.pomerium.com/docs/ (served from 0-32-0 branch).
+# Current docs live at www.pomerium.com/docs/
 # See: https://linear.app/pomerium/issue/ENG-3768
 
 User-agent: *


### PR DESCRIPTION
## Summary
Adds `robots.txt` with `Disallow: /` to block all crawlers from the 0-31-0 branch deploy.

## Problem
`0-31-0.docs.pomerium.com` is live and fully crawlable:
- **No `robots.txt`** (returns 404) — LLM crawlers freely scrape old docs
- **`x-robots-tag: all`** in response (Netlify deploy is stale, never rebuilt after noindex commit) — Google can index it too
- This creates duplicate content competing with current production docs (v0.32)

## Fix
Simple `robots.txt` with `Disallow: /`. Also triggers a Netlify rebuild which should pick up the existing `_headers` noindex fix.

Ref: ENG-3768