### PR TITLE
fix: add blocking robots.txt for 0-30-0 branch deploy

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,5 +1,5 @@
 # Old release branch — block all crawlers.
-# Current docs live at www.pomerium.com/docs/ (served from 0-32-0 branch).
+# Current docs live at www.pomerium.com/docs/
 # See: https://linear.app/pomerium/issue/ENG-3768
 
 User-agent: *


### PR DESCRIPTION
## Summary
Adds `robots.txt` with `Disallow: /` to block all crawlers from the 0-30-0 branch deploy.

## Problem
`0-30-0.docs.pomerium.com` is live and crawlable by LLM scrapers:
- **No `robots.txt`** (returns 404) — GPTBot, ClaudeBot freely scrape old v0.30 docs
- Has `x-robots-tag: noindex` (blocks Google) but LLM crawlers don't respect this header

## Fix
Simple `robots.txt` with `Disallow: /`.

Ref: ENG-3768