### PR TITLE
docs: repurpose llms-full.txt into curated context bundle

### DIFF
--- a/content/docs/capabilities/service-accounts.md
+++ b/content/docs/capabilities/service-accounts.md
@@ -1,6 +1,7 @@
 ---
 #cSpell:ignore etag
 title: Service Accounts
+description: Create and manage service accounts for machine-to-machine authentication between services protected by Pomerium.
 lang: en-US
 keywords:
   [

--- a/content/docs/deploy/enterprise/install.mdx
+++ b/content/docs/deploy/enterprise/install.mdx
@@ -1,5 +1,6 @@
 ---
 title: Install
+description: Install Pomerium Enterprise Console alongside Pomerium Core using Docker, Kubernetes, or system packages.
 lang: en-US
 keywords:
   [

--- a/content/docs/deploy/k8s/ingress.md
+++ b/content/docs/deploy/k8s/ingress.md
@@ -3,6 +3,7 @@
 
 title: Pomerium Ingress Controller for Kubernetes
 sidebar_label: Ingress Configuration
+description: Configure routes, policies, and TLS settings using the Pomerium Ingress Controller for Kubernetes.
 lang: en-US
 keywords:
   [

--- a/content/docs/deploy/k8s/quickstart.mdx
+++ b/content/docs/deploy/k8s/quickstart.mdx
@@ -2,6 +2,7 @@
 # cSpell:ignore customresourcedefinition serviceaccount clusterrole clusterrolebinding ingressclass whpnw cckv5 4pdkd kubeconfig
 
 title: Kubernetes Quickstart
+description: Deploy Pomerium Core to a Kubernetes cluster using the Pomerium Ingress Controller and hosted authenticate service.
 sidebar_label: Quickstart
 sidebar_position: 1
 lang: en-US

--- a/content/docs/get-started/fundamentals/zero/zero-advanced-policies.mdx
+++ b/content/docs/get-started/fundamentals/zero/zero-advanced-policies.mdx
@@ -1,6 +1,7 @@
 ---
 id: zero-advanced-policies
 title: Advanced Policies
+description: Build advanced authorization policies in Pomerium Zero using chained policy blocks, operators, criteria, and matchers.
 sidebar_label: 4. Advanced Policies
 sidebar_position: 4
 ---

--- a/content/docs/get-started/fundamentals/zero/zero-advanced-routes.mdx
+++ b/content/docs/get-started/fundamentals/zero/zero-advanced-routes.mdx
@@ -3,6 +3,7 @@
 
 id: zero-advanced-routes
 title: Advanced Routes
+description: Configure advanced route settings in Pomerium Zero including headers, path matching, path rewriting, and more.
 sidebar_label: 5. Advanced Routes
 sidebar_position: 5
 ---

--- a/content/docs/get-started/fundamentals/zero/zero-single-sign-on.mdx
+++ b/content/docs/get-started/fundamentals/zero/zero-single-sign-on.mdx
@@ -3,6 +3,7 @@
 
 id: zero-single-sign-on
 title: Single Sign On
+description: Set up single sign-on in Pomerium Zero by forwarding JWTs as identity headers to upstream services like Grafana.
 sidebar_label: 3. Single Sign-on with JWTs
 sidebar_position: 3
 ---

--- a/content/docs/get-started/fundamentals/zero/zero-tcp-routes.mdx
+++ b/content/docs/get-started/fundamentals/zero/zero-tcp-routes.mdx
@@ -3,6 +3,7 @@
 
 id: zero-tcp-routes
 title: TCP Routes
+description: Proxy TCP and SSH connections through Pomerium Zero using Pomerium CLI to secure non-HTTP services.
 sidebar_label: 6. TCP Routes
 sidebar_position: 6
 ---

--- a/content/docs/integrations/user-identity/auth0.mdx
+++ b/content/docs/integrations/user-identity/auth0.mdx
@@ -1,5 +1,6 @@
 ---
 title: Auth0
+description: Configure Auth0 as an identity provider for Pomerium Core and Enterprise.
 lang: en-US
 keywords: [auth0, pomerium, identity provider, idp]
 pagination_prev: null

--- a/content/docs/integrations/user-identity/google.mdx
+++ b/content/docs/integrations/user-identity/google.mdx
@@ -1,6 +1,7 @@
 ---
 title: Google Workspace (formerly known as G Suite)
 sidebar_label: Google
+description: Configure Google Workspace as an identity provider for Pomerium with OAuth 2.0 and directory sync.
 lang: en-US
 keywords:
   [

--- a/content/docs/integrations/user-identity/okta.mdx
+++ b/content/docs/integrations/user-identity/okta.mdx
@@ -1,5 +1,6 @@
 ---
 title: Okta
+description: Configure Okta as an identity provider for Pomerium with OIDC and directory sync.
 lang: en-US
 keywords: [okta oidc, identity provider, idp, context, context-aware]
 pagination_prev: null

--- a/content/docs/reference/routes/allow-any-authenticated-user.mdx
+++ b/content/docs/reference/routes/allow-any-authenticated-user.mdx
@@ -1,6 +1,7 @@
 ---
 id: allow-any-authenticated-user
 title: Allow Any Authenticated User
+description: Allow access to any user or service account that authenticates against your identity provider, bypassing policy.
 keywords:
   - reference
   - Allow Any Authenticated User

--- a/content/docs/reference/routes/enable-google-cloud-serverless-authentication.mdx
+++ b/content/docs/reference/routes/enable-google-cloud-serverless-authentication.mdx
@@ -1,6 +1,7 @@
 ---
 id: enable-google-cloud-serverless-authentication
 title: Enable Google Cloud Serverless Authentication
+description: Send signed authorization headers to upstream GCP services like Cloud Run, Cloud Functions, and App Engine.
 keywords:
   - reference
   - Enable Google Cloud Serverless Authentication

--- a/content/docs/reference/routes/public-access.mdx
+++ b/content/docs/reference/routes/public-access.mdx
@@ -1,6 +1,7 @@
 ---
 id: public-access
 title: Public Access
+description: Grant unauthenticated public access to an upstream service by bypassing Pomerium authentication and authorization.
 keywords:
   - reference
   - Public Access

--- a/cspell.json
+++ b/cspell.json
@@ -21,6 +21,8 @@
     "ABAC",
     "actionscript",
     "adguard",
+    "agentic",
+    "llmstxt",
     "alpn",
     "apiextensions",
     "apiserver",

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -30,6 +30,18 @@ const config: Config = {
     xgridKey: process.env.XGRID_KEY,
   },
 
+  headTags: [
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'alternate',
+        type: 'text/plain',
+        href: '/llms.txt',
+        title: 'LLM-readable documentation',
+      },
+    },
+  ],
+
   scripts: [
     {
       src: './static/js/syft.js',

--- a/plugins/llms-txt-plugin.js
+++ b/plugins/llms-txt-plugin.js
@@ -4,7 +4,7 @@ const {remark} = require('remark');
 const remarkParse = require('remark-parse').default;
 const remarkStringify = require('remark-stringify').default;
 const remarkMdx = require('remark-mdx').default;
-const visit = require('unist-util-visit').visit;
+const {visit, SKIP} = require('unist-util-visit');
 
 /**
  * Pre-clean Docusaurus MDX files before remark parsing.
@@ -19,21 +19,30 @@ function preCleanDocusaurusMDX(raw) {
   // Remove all Docusaurus import lines
   raw = raw.replace(/^\s*import\s.*from\s+['"][^'"]+['"];?\s*$/gm, '');
 
-  // Remove <Tabs>, </Tabs>, <TabItem ...>, </TabItem>
+  // Convert <TabItem> opening tags to bold labels, then strip remaining tags
+  raw = raw.replace(
+    /<TabItem[^>]*\blabel=["']([^"']+)["'][^>]*>/g,
+    '\n**$1:**\n',
+  );
   raw = raw.replace(/<\/?Tabs[^>]*>/g, '');
   raw = raw.replace(/<\/?TabItem[^>]*>/g, '');
 
-  // Remove all Docusaurus admonition blocks (with all contents)
+  // Unwrap admonition blocks but keep their body text (handles indented blocks too)
   raw = raw.replace(
-    /^:::(info|note|caution|tip|danger|important|success|failure|admonition)[^\n]*\n([\s\S]*?)^:::\s*$/gm,
-    '',
+    /^[ \t]*:::(info|note|caution|tip|danger|important|success|failure|admonition|enterprise|warning)[^\n]*\n([\s\S]*?)^[ \t]*:::\s*$/gm,
+    '$2',
   );
 
-  // Remove any "orphan" closing or opening :::
-  raw = raw.replace(/^:::\s*$/gm, '');
+  // Remove any "orphan" closing ::: or unclosed opening :::type lines (indented or not)
+  raw = raw.replace(/^[ \t]*:{3,}\s*$/gm, '');
+  raw = raw.replace(/^[ \t]*:{3,}\s*:::\w[^\n]*$/gm, '');
+  raw = raw.replace(/^[ \t]*:::\w[^\n]*$/gm, '');
 
-  // Optionally strip extra blank lines
-  raw = raw.replace(/^\s*\n/gm, '');
+  // Strip Docusaurus heading anchor IDs (e.g., {#host-rewrite}, {#config.databroker.build})
+  raw = raw.replace(/ \{#[^}]+}/g, '');
+
+  // Collapse 3+ blank lines to one; preserve single blank lines for paragraph breaks
+  raw = raw.replace(/(\s*\n){3,}/g, '\n\n');
 
   return raw;
 }
@@ -59,10 +68,18 @@ async function cleanMarkdownForLLM(rawContent) {
           node.type !== 'mdxJsxFlowElement' &&
           node.type !== 'mdxJsxTextElement',
       );
-      // Remove images
+      // Replace images with alt text or remove if no alt
       visit(tree, (node, index, parent) => {
         if (node.type === 'image' && parent && typeof index === 'number') {
-          parent.children.splice(index, 1);
+          if (node.alt) {
+            parent.children.splice(index, 1, {
+              type: 'text',
+              value: `[${node.alt}]`,
+            });
+          } else {
+            parent.children.splice(index, 1);
+          }
+          return [SKIP, index];
         }
       });
     })
@@ -77,8 +94,13 @@ async function cleanMarkdownForLLM(rawContent) {
 
   const result = await processor.process(rawContent);
 
-  // Optionally trim excessive blank lines
-  return result.value.replace(/\n{3,}/g, '\n\n');
+  let cleaned = result.value;
+  // Collapse excessive blank lines
+  cleaned = cleaned.replace(/\n{3,}/g, '\n\n');
+  // Strip escaped Docusaurus heading anchor IDs (e.g., \{#host-rewrite}, \{#config.databroker.build})
+  cleaned = cleaned.replace(/ \\{#[^}]+}/g, '');
+
+  return cleaned;
 }
 
 /**
@@ -299,35 +321,170 @@ const LLM_AGENT_INSTRUCTIONS = [
   'For MCP questions, prefer the current MCP capability pages and reference docs over older guides or blog posts.',
 ];
 
-const CURATED_ROUTE_PATTERNS = [
-  /^\/docs\/get-started\/quickstart$/,
-  /^\/docs\/get-started\/fundamentals\/core\/(advanced-policies|advanced-routes|jwt-verification|self-hosted-pomerium|tcp-routes)$/,
-  /^\/docs\/get-started\/fundamentals\/zero\/(zero-advanced-policies|zero-advanced-routes|zero-build-policies|zero-build-routes|zero-single-sign-on|zero-tcp-routes)$/,
-  /^\/docs\/deploy\/(core|enterprise\/quickstart|k8s\/quickstart|clients\/clients)$/,
-  /^\/docs\/capabilities\/(authentication|authorization|routing|native-ssh-access|kubernetes-access|service-accounts|mcp|non-http)$/,
-  /^\/docs\/capabilities\/mcp\/(protect-mcp-server|limit-mcp-tools|delegate-mcp-to-llm|mcp-upstream-oauth|reference)$/,
-  /^\/docs\/internals\/ppl$/,
-  /^\/docs\/integrations\/user-standing\/directory-sync$/,
-  /^\/docs\/integrations\/user-identity\/(google|okta|auth0|azure|keycloak)$/,
-  /^\/docs\/reference\/(jwt-groups-filter|google-cloud-serverless-authentication-service-account|identity-provider-settings|authorize-log-fields)$/,
-  /^\/docs\/reference\/routes\/(enable-google-cloud-serverless-authentication|jwt-groups-filter|public-access|allow-any-authenticated-user)$/,
-  /^\/docs\/guides\/(jenkins|grafana|code-server|local-mcp|zero-ssh|llm)$/,
+/**
+ * Explicit route manifests (Sets) to prevent silent drift from regex patterns.
+ *
+ * CURATED_ROUTES — pages linked in llms.txt (the navigator).
+ * TIER1_ROUTES   — pages whose full cleaned content is inlined in llms-full.txt.
+ */
+const CURATED_ROUTES = new Set([
+  // Getting started
+  '/docs/get-started/quickstart',
+  '/docs/get-started/fundamentals/core/advanced-policies',
+  '/docs/get-started/fundamentals/core/advanced-routes',
+  '/docs/get-started/fundamentals/core/jwt-verification',
+  '/docs/get-started/fundamentals/core/self-hosted-pomerium',
+  '/docs/get-started/fundamentals/core/tcp-routes',
+  '/docs/get-started/fundamentals/zero/zero-advanced-policies',
+  '/docs/get-started/fundamentals/zero/zero-advanced-routes',
+  '/docs/get-started/fundamentals/zero/zero-build-policies',
+  '/docs/get-started/fundamentals/zero/zero-build-routes',
+  '/docs/get-started/fundamentals/zero/zero-single-sign-on',
+  '/docs/get-started/fundamentals/zero/zero-tcp-routes',
+  // Deploy
+  '/docs/deploy/core',
+  '/docs/deploy/enterprise/quickstart',
+  '/docs/deploy/enterprise/install',
+  '/docs/deploy/k8s/quickstart',
+  '/docs/deploy/k8s/ingress',
+  '/docs/deploy/clients/clients',
+  // Capabilities
+  '/docs/capabilities/authentication',
+  '/docs/capabilities/authorization',
+  '/docs/capabilities/routing',
+  '/docs/capabilities/native-ssh-access',
+  '/docs/capabilities/kubernetes-access',
+  '/docs/capabilities/service-accounts',
+  '/docs/capabilities/non-http',
+  '/docs/capabilities/getting-users-identity',
+  // MCP
+  '/docs/capabilities/mcp',
+  '/docs/capabilities/mcp/protect-mcp-server',
+  '/docs/capabilities/mcp/limit-mcp-tools',
+  '/docs/capabilities/mcp/delegate-mcp-to-llm',
+  '/docs/capabilities/mcp/mcp-upstream-oauth',
+  '/docs/capabilities/mcp/reference',
+  // Internals
+  '/docs/internals/ppl',
+  '/docs/internals/configuration',
+  '/docs/internals/troubleshooting',
+  // Reference (GSC high-traffic)
+  '/docs/reference/metrics',
+  // Integrations
+  '/docs/integrations/user-standing/directory-sync',
+  '/docs/integrations/user-identity/google',
+  '/docs/integrations/user-identity/okta',
+  '/docs/integrations/user-identity/auth0',
+  '/docs/integrations/user-identity/azure',
+  '/docs/integrations/user-identity/keycloak',
+  // Reference
+  '/docs/reference/jwt-groups-filter',
+  '/docs/reference/google-cloud-serverless-authentication-service-account',
+  '/docs/reference/identity-provider-settings',
+  '/docs/reference/authorize-log-fields',
+  '/docs/reference/routes/enable-google-cloud-serverless-authentication',
+  '/docs/reference/routes/jwt-groups-filter',
+  '/docs/reference/routes/public-access',
+  '/docs/reference/routes/allow-any-authenticated-user',
+  // Guides
+  '/docs/guides/jenkins',
+  '/docs/guides/grafana',
+  '/docs/guides/code-server',
+  '/docs/guides/local-mcp',
+  '/docs/guides/zero-ssh',
+  '/docs/guides/llm',
+]);
+
+const TIER1_ROUTES = new Set([
+  // Getting started
+  '/docs/index',
+  '/docs/get-started/quickstart',
+  // Core capabilities
+  '/docs/capabilities/authentication',
+  '/docs/capabilities/authorization',
+  '/docs/capabilities/routing',
+  '/docs/capabilities/kubernetes-access',
+  '/docs/capabilities/native-ssh-access',
+  '/docs/capabilities/non-http',
+  '/docs/capabilities/service-accounts',
+  // MCP (all current pages)
+  '/docs/capabilities/mcp',
+  '/docs/capabilities/mcp/protect-mcp-server',
+  '/docs/capabilities/mcp/limit-mcp-tools',
+  '/docs/capabilities/mcp/delegate-mcp-to-llm',
+  '/docs/capabilities/mcp/mcp-upstream-oauth',
+  '/docs/capabilities/mcp/reference',
+  '/docs/capabilities/mcp/develop-mcp-app',
+  '/docs/capabilities/mcp/tunnel-to-chatgpt',
+  // Internals
+  '/docs/internals/ppl',
+  '/docs/internals/architecture',
+  '/docs/internals/glossary',
+  '/docs/internals/connection',
+  '/docs/internals/configuration',
+  '/docs/internals/troubleshooting',
+  '/docs/internals/programmatic-access',
+  // Capabilities (GSC high-traffic)
+  '/docs/capabilities/getting-users-identity',
+  // Deployment
+  '/docs/deploy/core',
+  // Reference — expanded bundle (common reverse proxy settings)
+  '/docs/reference/routes/readme',
+  '/docs/reference/routes/from',
+  '/docs/reference/routes/to',
+  '/docs/reference/routes/policy',
+  '/docs/reference/routes/headers',
+  '/docs/reference/routes/path-rewriting',
+  '/docs/reference/routes/timeouts',
+  '/docs/reference/routes/tls',
+  '/docs/reference/routes/load-balancing',
+  '/docs/reference/routes/load-balancing-policy-config',
+  '/docs/reference/routes/public-access',
+  '/docs/reference/routes/allow-any-authenticated-user',
+  '/docs/reference/routes/pass-identity-headers',
+  '/docs/reference/identity-provider-settings',
+  '/docs/reference/service-urls',
+  '/docs/reference/pass-identity-headers',
+  '/docs/reference/jwt-claim-headers',
+  '/docs/reference/jwt-groups-filter',
+  '/docs/reference/routes/jwt-groups-filter',
+  '/docs/reference/global-timeouts',
+]);
+
+/**
+ * Ordered demotion list: if llms-full.txt exceeds the size budget, demote
+ * these Tier 1 routes to link-only entries in this order.
+ */
+const TIER1_DEMOTION_ORDER = [
+  '/docs/reference/routes/load-balancing-policy-config',
+  '/docs/reference/routes/load-balancing',
+  '/docs/reference/global-timeouts',
+  '/docs/reference/routes/timeouts',
+  '/docs/reference/routes/tls',
+  '/docs/reference/routes/public-access',
+  '/docs/reference/routes/allow-any-authenticated-user',
 ];
 
-function matchesCuratedRoute(routePath) {
-  return CURATED_ROUTE_PATTERNS.some((pattern) => pattern.test(routePath));
+/** Hard size limit for llms-full.txt in characters (~100K tokens). */
+const LLMS_FULL_SIZE_LIMIT = 400_000;
+
+// Validate demotion list at module load
+for (const p of TIER1_DEMOTION_ORDER) {
+  if (!TIER1_ROUTES.has(p)) {
+    throw new Error(`TIER1_DEMOTION_ORDER entry "${p}" is not in TIER1_ROUTES`);
+  }
+}
+
+function isCuratedRoute(routePath) {
+  return CURATED_ROUTES.has(routePath);
+}
+
+function isTier1Route(routePath) {
+  return TIER1_ROUTES.has(routePath);
 }
 
 function filterCuratedRoutes(routes) {
-  return routes.filter((route) => matchesCuratedRoute(route.path));
-}
-
-function generateInstructionsBlock() {
-  return `## Instructions for LLM Agents
-
-${LLM_AGENT_INSTRUCTIONS.map((instruction) => `- ${instruction}`).join('\n')}
-
-`;
+  return routes.filter((route) => isCuratedRoute(route.path));
 }
 
 function normalizeRouteMarkdownPath(routePath) {
@@ -350,6 +507,10 @@ function buildMarkdownUrl(route, context) {
   const routePath = normalizeRouteMarkdownPath(route.path);
   if (!routePath) return '';
 
+  // Avoid double-index for routes that already end in /index (e.g., /docs/index)
+  if (routePath.endsWith('/index')) {
+    return getAbsoluteSiteUrl(context, `${routePath}.md`);
+  }
   return getAbsoluteSiteUrl(context, `${routePath}/index.md`);
 }
 
@@ -409,62 +570,219 @@ function validateRouteMarkdownCollisions(routes) {
 }
 
 /**
- * Generate the llms.txt file content
+ * Build a single link-list entry for a route.
  */
-function generateLlmsTxtContent(routesByCategory, context, options = {}) {
-  const {
-    title: documentTitle = 'Pomerium Documentation',
-    intro = "This file contains information about Pomerium's public documentation to help LLMs understand and reference our documentation.",
-    includeInstructions = false,
-    footer = 'This documentation is publicly available and approved for LLM training and reference.',
-  } = options;
+function formatRouteLinkEntry(route, context) {
+  const routeTitle = getRouteTitle(route);
+  const description = getRouteDescription(route);
+  const mdUrl = buildMarkdownUrl(route, context);
 
-  let content = `# ${documentTitle}
+  if (description && mdUrl) {
+    return `- [${routeTitle}](${mdUrl}): ${description}`;
+  } else if (mdUrl) {
+    return `- [${routeTitle}](${mdUrl})`;
+  } else if (description) {
+    return `- ${routeTitle}: ${description}`;
+  }
+  return `- ${routeTitle}`;
+}
 
-${intro}
+/**
+ * Generate link-only llms-index.txt (exhaustive discovery index).
+ * This is what llms-full.txt used to be.
+ */
+function generateLlmsIndexTxtContent(routesByCategory, context) {
+  const fullUrl = getAbsoluteSiteUrl(context, 'llms-full.txt');
 
-Pomerium is an identity and context-aware access proxy that provides secure access to applications and services.
+  let content = `# Pomerium Documentation Index
+
+> Exhaustive index of all Pomerium documentation pages.
+> For curated docs with inline content, see [llms-full.txt](${fullUrl}).
 
 `;
 
-  if (includeInstructions) {
-    content += generateInstructionsBlock();
-  }
-
   Object.entries(routesByCategory).forEach(([categoryName, routes]) => {
     content += `## ${categoryName}\n\n`;
-
     const sortedRoutes = sortRoutes(routes);
-
     sortedRoutes.forEach((route) => {
-      const routeTitle = getRouteTitle(route);
-      const description = getRouteDescription(route);
-      const mdUrl = buildMarkdownUrl(route, context);
-
-      if (description && mdUrl) {
-        content += `- [${routeTitle}](${mdUrl}): ${description}\n`;
-      } else if (mdUrl) {
-        content += `- [${routeTitle}](${mdUrl})\n`;
-      } else if (description) {
-        content += `- ${routeTitle}: ${description}\n`;
-      } else {
-        content += `- ${routeTitle}\n`;
-      }
+      content += formatRouteLinkEntry(route, context) + '\n';
     });
-
     content += '\n';
   });
 
-  content += `${footer}\n`;
+  return content;
+}
+
+/**
+ * Generate spec-shaped llms.txt (navigator / "skill").
+ *
+ * Follows the llmstxt.org convention:
+ *   H1 > blockquote > plain-text retrieval instructions > H2 link sections
+ */
+function generateLlmsTxtContent(
+  routesByCategory,
+  context,
+  {fullTxtTokenEstimate = '~80K'} = {},
+) {
+  const fullUrl = getAbsoluteSiteUrl(context, 'llms-full.txt');
+  const indexUrl = getAbsoluteSiteUrl(context, 'llms-index.txt');
+
+  let content = `# Pomerium
+
+> Pomerium is an identity and context-aware access proxy that brings
+> secure, zero-trust access to applications and services.
+
+For common Pomerium questions, start with the curated context bundle:
+- [llms-full.txt](${fullUrl}): Key documentation inline (${fullTxtTokenEstimate} tokens)
+
+For exhaustive page discovery:
+- [llms-index.txt](${indexUrl}): Complete documentation index
+
+For a specific page, fetch its markdown sidecar by appending /index.md:
+- Example: https://www.pomerium.com/docs/capabilities/mcp/index.md
+
+${LLM_AGENT_INSTRUCTIONS.map((i) => `- ${i}`).join('\n')}
+
+`;
+
+  Object.entries(routesByCategory).forEach(([categoryName, routes]) => {
+    content += `## ${categoryName}\n\n`;
+    const sortedRoutes = sortRoutes(routes);
+    sortedRoutes.forEach((route) => {
+      content += formatRouteLinkEntry(route, context) + '\n';
+    });
+    content += '\n';
+  });
 
   return content;
+}
+
+/**
+ * Generate llms-full.txt as a hybrid context bundle.
+ *
+ * Tier 1 routes get their full cleaned markdown inlined.
+ * Tier 2 routes appear as link entries.
+ * Mixed categories show inline content first, then an "Additional …" section.
+ */
+function generateLlmsFullTxtContent(
+  routesByCategory,
+  context,
+  cleanedContentMap,
+  activeTier1,
+) {
+  const llmsTxtUrl = getAbsoluteSiteUrl(context, 'llms.txt');
+  const indexUrl = getAbsoluteSiteUrl(context, 'llms-index.txt');
+
+  let content = `# Pomerium Documentation
+
+> Curated Pomerium documentation with key topics inline. For the navigation
+> index, see [llms.txt](${llmsTxtUrl}). For exhaustive page discovery,
+> see [llms-index.txt](${indexUrl}).
+
+${LLM_AGENT_INSTRUCTIONS.map((i) => `- ${i}`).join('\n')}
+
+`;
+
+  const inlinedPaths = new Set();
+
+  Object.entries(routesByCategory).forEach(([categoryName, routes]) => {
+    const sortedRoutes = sortRoutes(routes);
+
+    // Split into inline (Tier 1 with content) and link-only (Tier 2)
+    const inlineRoutes = [];
+    const linkRoutes = [];
+
+    sortedRoutes.forEach((route) => {
+      const body = cleanedContentMap.get(route.path);
+      if (
+        activeTier1.has(route.path) &&
+        body &&
+        !inlinedPaths.has(route.path)
+      ) {
+        inlineRoutes.push(route);
+      } else {
+        linkRoutes.push(route);
+      }
+    });
+
+    // Skip completely empty categories
+    if (inlineRoutes.length === 0 && linkRoutes.length === 0) return;
+
+    content += `## ${categoryName}\n\n`;
+
+    // Inline Tier 1 pages
+    inlineRoutes.forEach((route, idx) => {
+      const routeTitle = getRouteTitle(route);
+      const mdUrl = buildMarkdownUrl(route, context);
+      const body = cleanedContentMap.get(route.path);
+
+      content += `### ${routeTitle}\n\n`;
+      if (mdUrl) {
+        content += `Source: ${mdUrl}\n\n`;
+      }
+      content += body.trim() + '\n\n';
+      inlinedPaths.add(route.path);
+
+      if (idx < inlineRoutes.length - 1 || linkRoutes.length > 0) {
+        content += '---\n\n';
+      }
+    });
+
+    // Link-only Tier 2 pages
+    if (linkRoutes.length > 0) {
+      if (inlineRoutes.length > 0) {
+        content += `### Additional ${categoryName}\n\n`;
+      }
+      linkRoutes.forEach((route) => {
+        content += formatRouteLinkEntry(route, context) + '\n';
+      });
+      content += '\n';
+    }
+  });
+
+  return content;
+}
+
+/**
+ * Agentic footer appended to all generated files.
+ * Tells LLM agents where to find each resource, with size hints.
+ */
+function generateAgenticFooter(
+  context,
+  {navSize = '', fullTxtSize = '', indexSize = ''} = {},
+) {
+  const llmsTxtUrl = getAbsoluteSiteUrl(context, 'llms.txt');
+  const fullUrl = getAbsoluteSiteUrl(context, 'llms-full.txt');
+  const indexUrl = getAbsoluteSiteUrl(context, 'llms-index.txt');
+  const buildDate = new Date().toISOString().slice(0, 10);
+
+  const fullSizeHint = fullTxtSize ? ` (${fullTxtSize})` : '';
+  const indexSizeHint = indexSize ? ` (${indexSize})` : '';
+
+  return `---
+
+## How to Use These Docs
+
+Last-Updated: ${buildDate}
+
+This documentation is publicly available and approved for LLM training and reference.
+
+| Resource | URL | Size | Use it for |
+|----------|-----|------|------------|
+| Navigator | ${llmsTxtUrl} | ${navSize || '~14KB'} | Quick orientation and curated links |
+| Context bundle | ${fullUrl} | ${fullTxtSize || '~80K tokens'} | Key docs inline — start here for most questions |
+| Full index | ${indexUrl} | ${indexSize || '~36KB'} | Exhaustive page discovery |
+| Individual page | Append \`/index.md\` to any doc URL | varies | Deep-dive on a specific topic |
+
+Cite only \`www.pomerium.com\` docs. Do not cite \`docs.pomerium.com\` or archive hosts.
+`;
 }
 
 /**
  * Sort routes within a category for better organization
  */
 function sortRoutes(routes) {
-  return routes.sort((a, b) => {
+  return [...routes].sort((a, b) => {
     // Custom sorting logic - prioritize important pages first
     const priorityOrder = [
       'quickstart',
@@ -728,10 +1046,9 @@ async function pluginLlmsTxt(context, options) {
 
     async postBuild({outDir, routes, ...buildContext}) {
       try {
-        // Use Docusaurus routes data instead of manual file scanning
+        // ── 1. Discover routes ──────────────────────────────────────
         const docRoutes = filterDocumentationRoutes(routes);
 
-        // If routes are not properly populated, fallback to file scanning
         let finalRoutes = docRoutes;
         if (docRoutes.length < 10) {
           console.log(
@@ -741,83 +1058,35 @@ async function pluginLlmsTxt(context, options) {
           finalRoutes = await scanDocumentationFiles(contentDir);
         }
 
-        // Auto-detect categories from sidebars and route structure
-        const routesByCategory = await groupRoutesByCategoryAuto(
-          finalRoutes,
-          context,
-        );
-        const curatedRoutes = filterCuratedRoutes(finalRoutes);
-        if (curatedRoutes.length === 0) {
-          console.warn(
-            '⚠️  No curated llms.txt routes matched the current route set.',
-          );
-        }
         validateRouteMarkdownCollisions(finalRoutes);
-        const curatedRoutesByCategory = await groupRoutesByCategoryAuto(
-          curatedRoutes,
-          context,
-        );
 
-        // Generate the llms.txt content
-        const llmsTxtContent = generateLlmsTxtContent(
-          curatedRoutesByCategory,
-          context,
-          {
-            intro: `This file contains curated public documentation entry points to help LLM agents quickly find current Pomerium guidance. For the exhaustive current docs index, see ${getAbsoluteSiteUrl(context, 'llms-full.txt')}.`,
-            includeInstructions: true,
-          },
-        );
-        const llmsFullTxtContent = generateLlmsTxtContent(
-          routesByCategory,
-          context,
-          {
-            title: 'Pomerium Documentation (Full)',
-            intro:
-              "This file contains the exhaustive current public documentation index for Pomerium's docs site.",
-            includeInstructions: true,
-          },
-        );
-
-        // Write the llms.txt file to the build output
-        const llmsTxtPath = path.join(outDir, 'llms.txt');
-        await fs.promises.writeFile(llmsTxtPath, llmsTxtContent, 'utf8');
-        const llmsFullTxtPath = path.join(outDir, 'llms-full.txt');
-        await fs.promises.writeFile(
-          llmsFullTxtPath,
-          llmsFullTxtContent,
-          'utf8',
-        );
-
-        // Copy and CLEAN referenced markdown files to the build output (as .md)
+        // ── 2. Clean + copy markdown sidecars, collect Tier 1 content ─
         const docsRoot = path.join(context.siteDir, 'content', 'docs');
+        const cleanedContentMap = new Map();
         let copied = 0,
           errors = 0;
+
         for (const route of finalRoutes) {
-          let srcFile = route.filePath;
+          const srcFile = route.filePath;
           if (!srcFile) continue;
+          if (shouldSkipMarkdownCopy(srcFile)) continue;
 
-          if (shouldSkipMarkdownCopy(srcFile)) {
-            continue; // Skip this file silently
-          }
-
-          // Always copy as .md
+          // Destination paths
           let destRel = path.relative(docsRoot, srcFile).replace(/\\/g, '/');
           destRel = destRel.replace(/\.(mdx|md)$/, '.md');
           if (destRel.startsWith('..')) {
             destRel = path.basename(srcFile).replace(/\.(mdx|md)$/, '.md');
           }
-          // Keep legacy /content/docs markdown copies for compatibility while
-          // llms consumers and infra transition to route-mirrored .md URLs.
           const contentDestFile = path.join(outDir, 'content', 'docs', destRel);
           const routeDestFile = resolveRouteMarkdownOutputFile(
             outDir,
             route.path,
           );
-          // Ensure directory exists
+
           await fs.promises.mkdir(path.dirname(contentDestFile), {
             recursive: true,
           });
-          // Read, clean, and write file
+
           try {
             const rawContent = await fs.promises.readFile(srcFile, 'utf8');
             const preCleanedContent = preCleanDocusaurusMDX(rawContent);
@@ -829,9 +1098,14 @@ async function pluginLlmsTxt(context, options) {
                 `Warning: Could not fully process ${srcFile}, writing pre-cleaned version instead:`,
                 err.message,
               );
-              cleanedContent = preCleanedContent;
+              // Apply post-processing that cleanMarkdownForLLM would have done
+              cleanedContent = preCleanedContent
+                .replace(/\n{3,}/g, '\n\n')
+                .replace(/ \\{#[^}]+}/g, '');
               errors++;
             }
+
+            // Write sidecar copies
             await fs.promises.writeFile(
               contentDestFile,
               cleanedContent,
@@ -851,6 +1125,12 @@ async function pluginLlmsTxt(context, options) {
                 `Warning: Could not resolve route markdown path for ${route.path}, skipping route-mirrored copy.`,
               );
             }
+
+            // Collect cleaned content for Tier 1 routes
+            if (isTier1Route(route.path) && cleanedContent.trim().length > 0) {
+              cleanedContentMap.set(route.path, cleanedContent);
+            }
+
             copied++;
           } catch (err) {
             console.warn(
@@ -861,8 +1141,130 @@ async function pluginLlmsTxt(context, options) {
           }
         }
 
+        // ── 3. Categorize routes ────────────────────────────────────
+        const routesByCategory = await groupRoutesByCategoryAuto(
+          finalRoutes,
+          context,
+        );
+        const curatedRoutes = filterCuratedRoutes(finalRoutes);
+        if (curatedRoutes.length === 0) {
+          console.warn(
+            '⚠️  No curated llms.txt routes matched the current route set.',
+          );
+        }
+
+        // Warn about stale manifest entries that no longer match any route
+        const knownPaths = new Set(finalRoutes.map((r) => r.path));
+        for (const manifest of [
+          {name: 'CURATED_ROUTES', set: CURATED_ROUTES},
+          {name: 'TIER1_ROUTES', set: TIER1_ROUTES},
+        ]) {
+          for (const p of manifest.set) {
+            if (!knownPaths.has(p)) {
+              console.warn(`⚠️  ${manifest.name} contains stale entry: ${p}`);
+            }
+          }
+        }
+
+        const curatedRoutesByCategory = await groupRoutesByCategoryAuto(
+          curatedRoutes,
+          context,
+        );
+
+        // ── 4. Generate llms-full.txt (hybrid context bundle) ───────
+        // Start with the full Tier 1 set; demote if over budget.
+        let activeTier1 = new Set(TIER1_ROUTES);
+
+        let llmsFullTxtContent = generateLlmsFullTxtContent(
+          routesByCategory,
+          context,
+          cleanedContentMap,
+          activeTier1,
+        );
+
+        // Size guard: demote routes until under budget
+        let demotions = 0;
+        for (const demotePath of TIER1_DEMOTION_ORDER) {
+          if (llmsFullTxtContent.length <= LLMS_FULL_SIZE_LIMIT) break;
+          if (!cleanedContentMap.has(demotePath)) continue;
+          activeTier1.delete(demotePath);
+          llmsFullTxtContent = generateLlmsFullTxtContent(
+            routesByCategory,
+            context,
+            cleanedContentMap,
+            activeTier1,
+          );
+          demotions++;
+          console.log(
+            `  ⚠️  Demoted ${demotePath} to link-only (size guard: ${(llmsFullTxtContent.length / 1024).toFixed(0)}KB)`,
+          );
+        }
+
+        if (llmsFullTxtContent.length > LLMS_FULL_SIZE_LIMIT) {
+          console.warn(
+            `⚠️  llms-full.txt still exceeds ${(LLMS_FULL_SIZE_LIMIT / 1024).toFixed(0)}KB after all demotions (${(llmsFullTxtContent.length / 1024).toFixed(0)}KB)`,
+          );
+        }
+
+        // ── 5. Generate llms.txt (spec-shaped navigator) ────────────
+        // Generated after llms-full.txt so we can report the real token count.
+        const fullTxtTokenEstimate = `~${Math.round(llmsFullTxtContent.length / 4000)}K`;
+        const llmsTxtContent = generateLlmsTxtContent(
+          curatedRoutesByCategory,
+          context,
+          {fullTxtTokenEstimate},
+        );
+
+        // ── 6. Generate llms-index.txt (exhaustive link index) ──────
+        const llmsIndexTxtContent = generateLlmsIndexTxtContent(
+          routesByCategory,
+          context,
+        );
+
+        // ── 7. Append dynamic footers with actual computed sizes ────
+        const navSizeHint = `~${Math.round(llmsTxtContent.length / 1024)}KB`;
+        const fullSizeHint = `~${Math.round(llmsFullTxtContent.length / 4000)}K tokens`;
+        const indexSizeHint = `~${Math.round(llmsIndexTxtContent.length / 1024)}KB`;
+        const footer = generateAgenticFooter(context, {
+          navSize: navSizeHint,
+          fullTxtSize: fullSizeHint,
+          indexSize: indexSizeHint,
+        });
+
+        const finalLlmsTxt = llmsTxtContent + footer;
+        const finalLlmsFullTxt = llmsFullTxtContent + footer;
+        const finalLlmsIndexTxt = llmsIndexTxtContent + footer;
+
+        await fs.promises.writeFile(
+          path.join(outDir, 'llms-full.txt'),
+          finalLlmsFullTxt,
+          'utf8',
+        );
+        await fs.promises.writeFile(
+          path.join(outDir, 'llms.txt'),
+          finalLlmsTxt,
+          'utf8',
+        );
+        await fs.promises.writeFile(
+          path.join(outDir, 'llms-index.txt'),
+          finalLlmsIndexTxt,
+          'utf8',
+        );
+
+        // ── 8. Report ───────────────────────────────────────────────
+        const fullSizeKB = (finalLlmsFullTxt.length / 1024).toFixed(0);
+        const fullTokens = Math.round(finalLlmsFullTxt.length / 4);
+        const inlineCount = [...activeTier1].filter((p) =>
+          cleanedContentMap.has(p),
+        ).length;
+        const linkedCount = finalRoutes.length - inlineCount;
+
         console.log(
-          `✅ Generated llms.txt (${curatedRoutes.length} curated pages) and llms-full.txt (${finalRoutes.length} documentation pages). Copied and cleaned ${copied} markdown sources. ${errors ? `(${errors} errors)` : ''}`,
+          `✅ Generated llms.txt (${curatedRoutes.length} curated), ` +
+            `llms-full.txt (${fullSizeKB}KB ~${fullTokens} tokens, ${inlineCount} inline, ${linkedCount} linked` +
+            `${demotions ? `, ${demotions} demoted` : ''}), ` +
+            `llms-index.txt (${finalRoutes.length} pages). ` +
+            `Cleaned ${copied} markdown sources.${errors ? ` (${errors} errors)` : ''}`,
         );
       } catch (error) {
         console.error('❌ Error generating llms.txt:', error);

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -29,7 +29,9 @@ Allow: /
 User-agent: YouBot
 Allow: /
 
-# LLM-friendly content index
-# See https://llmstxt.org/ for specification
+# LLM-readable documentation (llmstxt.org)
+# https://www.pomerium.com/llms.txt        — curated navigator
+# https://www.pomerium.com/llms-full.txt   — key docs inline (~80K tokens)
+# https://www.pomerium.com/llms-index.txt  — exhaustive page index
 
 Sitemap: https://www.pomerium.com/sitemap.xml


### PR DESCRIPTION
## Summary

Refactors the llms-txt Docusaurus plugin to generate a three-file LLM documentation system:

- **llms.txt** (14KB) — Spec-shaped navigator per llmstxt.org with curated links to 56 key pages
- **llms-full.txt** (372KB, ~95K tokens) — Hybrid context bundle: 46 pages inline + 168 linked
- **llms-index.txt** (38KB) — Exhaustive link index of all 214 pages (replaces old llms-full.txt format)

### What changed

**Plugin (`plugins/llms-txt-plugin.js`)**
- Fix: admonition blocks were **deleted entirely** — now preserve body text
- Fix: blank line stripping destroyed paragraph boundaries
- Fix: AST visitor skipped consecutive image nodes after splice
- Fix: 101 escaped `\{#anchor}` heading IDs leaked into output — now stripped
- Add: `enterprise`, `warning` admonition types; handle indented blocks
- Add: `<TabItem>` tags converted to bold labels before stripping
- Add: images replaced with alt text instead of removed
- Add: explicit `Set`-based route manifests (TIER1_ROUTES, CURATED_ROUTES) replacing regex patterns
- Add: build-time staleness warnings for manifest entries
- Add: size guard (400K chars) with ordered demotion list
- Add: dynamic agentic footer with computed sizes and Last-Updated timestamp

**SEO/Discoverability**
- Add `<link rel="alternate" type="text/plain" href="/llms.txt">` to all HTML pages
- Add explicit llms.txt/llms-full.txt/llms-index.txt references in robots.txt
- All footer resource tables show dynamic sizes

**Content (14 MDX files)**
- Add missing `description` frontmatter to pages used in curated link entries

**Tier selections informed by GSC data** (16 months, 166K clicks) — promoted high-traffic pages like `deploy/enterprise/install` (925 clicks), `deploy/k8s/ingress` (745), `internals/configuration` (635), `internals/troubleshooting` (435).

### Review process

- Claude review via `review-major-change.sh` (Codex) — 3 passes
- GPT-4o review — 2 passes  
- SEO expert review
- All feedback incorporated

## Test plan

- [x] `yarn build` passes (zero plugin errors)
- [x] Zero escaped `\{#anchor}` artifacts in all 214 sidecars
- [x] Zero orphan `:::` directives in all 214 sidecars
- [x] Zero curated entries without descriptions
- [x] Dynamic footer sizes match actual file sizes
- [x] `<link rel="alternate">` present in HTML output
- [x] robots.txt references present
- [x] Paragraph breaks preserved in inline content
- [x] `yarn format` clean
- [x] `cspell` clean (added `agentic`, `llmstxt` to dictionary)
- [ ] Verify llms.txt, llms-full.txt, llms-index.txt served correctly after deploy