### PR TITLE
docs: audit all 74 reference pages against implementation code

### DIFF
--- a/content/docs/reference/_manage-devices.md
+++ b/content/docs/reference/_manage-devices.md
@@ -1,6 +1,6 @@
 From this page, administrators can manage new and existing device enrollments.
 
-Device enrollment let's you create [policies](/docs/internals/ppl#device-matcher) that use [device identity](/docs/integrations/device-context/device-identity).
+Device enrollment lets you create [policies](/docs/internals/ppl#device-matcher) that use [device identity](/docs/integrations/device-context/device-identity).
 
 - Users can [self-enroll](/docs/integrations/device-context/device-identity) devices, which must then be approved in the **Devices List** for policies requiring approved devices.
 - Administrators can use the **New Enrollment** button to create a link for the user to enroll a device as pre-approved. See our [Pre-Approved Device Enrollment](/docs/guides/admin-enroll-device) guide for more information.

--- a/content/docs/reference/access-log-fields.mdx
+++ b/content/docs/reference/access-log-fields.mdx
@@ -120,11 +120,14 @@ The table below lists all available access log fields:
 | **Field name** | **Description** | **Default field** |
 | :-- | :-- | :-- |
 | `authority` | The HTTP request `:authority` or `Host` header value. Can be a domain name or IP address and may contain a port number (for example, `www.example.com`) | Yes |
+| `client-certificate` | The client certificate presented by the downstream client during mTLS, if any | No |
+| `cluster-stat-name` | The stat name of the upstream cluster the request was routed to (set via route `name`, route `id`, or the Enterprise Console **Metric Name** field) | No |
 | `duration` | The amount of time the request takes to complete in seconds | Yes |
 | `forwarded-for` | The value of the `X-Forwarded-For` header, as sent to the upstream service (see also [X-Forwarded-For Settings](/docs/reference/x-forwarded-for-settings)) | Yes |
 | `ip` | The user's IP address. Note that this depends on setting the [`xff_num_trusted_hops`](/docs/reference/x-forwarded-for-settings#xff-number-of-trusted-hops) option appropriately. | No |
 | `method` | The HTTP request method, such as `GET`, `POST`, or `PUT` | Yes |
 | `path` | The HTTP request path (for example, `/some/path`) | Yes |
+| `query` | The HTTP request query (for example, `?test=one&other=13`) | No |
 | `referer` | The HTTP request referer, or the address of the web page from which the resource has been requested | Yes |
 | `request-id` | The request's unique identifier as assigned by Pomerium | Yes |
 | `response-code` | The HTTP Response Code (for example `200` or `500`) | Yes |
@@ -132,7 +135,6 @@ The table below lists all available access log fields:
 | `size` | The HTTP Response size in bytes | Yes |
 | `upstream-cluster` | The cluster the request was sent to (the cluster name is assigned by Pomerium, for example `route-3bb74f76f9d71f9c` or `pomerium-control-plane-http`) | Yes |
 | `user-agent` | The User-Agent field sent by the user's browser | Yes |
-| `query` | The HTTP request query (for example, `?test=one&other=13`) | No |
 | [`headers.{CustomHeaderName}`](#log-custom-headers-fields) | An HTTP Request Header identified by the `HeaderName` (for example, `headers.X-Amzn-Trace-Id` might return `Root=1-64c03960-37809588421513e42f260f56`) | No |
 
 :::danger

--- a/content/docs/reference/address.mdx
+++ b/content/docs/reference/address.mdx
@@ -2,7 +2,7 @@
 id: address
 title: Address
 description: |
-  Address specifies the host and port to serve HTTP requests from.
+  Address specifies the host and port to serve HTTPS requests from.
 keywords:
   - reference
   - Address
@@ -22,7 +22,7 @@ import KubernetesConfigureTable from '../../../src/components/KubernetesConfigur
 
 ## Summary
 
-**Address** specifies the Host and Port to serve HTTP requests from. If empty, `:443` is used.
+**Address** specifies the Host and Port to serve HTTPS requests from. If empty, `:443` is used.
 
 :::tip **Note**
 

--- a/content/docs/reference/authorize-log-fields.mdx
+++ b/content/docs/reference/authorize-log-fields.mdx
@@ -31,7 +31,7 @@ The default log fields should be appropriate for most deployments.
 <CoreConfiguration name="authorize_log_fields" resource="settings" type="StringList" 
   defaultValue={
     <>
-      See <a href="#authorize-fields-and-defaults">Authorize Fields and Defaults</a>
+      See <a href="#authorize-log-fields-and-defaults">Authorize Fields and Defaults</a>
     </>
   } >
 
@@ -115,7 +115,10 @@ The table below lists all available authorize log fields:
 | :-- | :-- | :-- |
 | `body` | The HTTP request body. Only available for protocols with request content inspection such as MCP. | No |
 | `check-request-id` | The request ID of the gRPC check call | Yes |
+| `cluster-stat-name` | The stat name of the upstream cluster the request was routed to (set via route `name`, route `id`, or the Enterprise Console **Metric Name** field) | No |
 | `email` | The logged-in user's email address | Yes |
+| `envoy-route-checksum` | The checksum of the Envoy route configuration used to match the request | Yes |
+| `envoy-route-id` | The ID of the Envoy route that matched the request | Yes |
 | `headers` | The complete set of HTTP request headers | No |
 | [`headers.{CustomHeaderName}`](#log-custom-headers-fields) | An HTTP Request Header identified by the `HeaderName` | No |
 | `host` | The HTTP request `:authority` or `Host` header value. Can be a domain name or IP address and may contain a port number (for example, `www.example.com`) | Yes |
@@ -133,8 +136,10 @@ The table below lists all available authorize log fields:
 | `query` | The HTTP request query (for example, `?test=one&other=13`) | No |
 | `removed-groups-count` | The number of groups removed during [JWT groups filtering](/docs/reference/jwt-groups-filter) | Yes |
 | `request-id` | The request's unique identifier as assigned by Pomerium | Yes |
-| `service-account-id` | if using a service account, the service account ID | Yes |
-| `session-id` | the session ID | Yes |
+| `route-checksum` | The checksum of the Pomerium route policy that matched the request | Yes |
+| `route-id` | The ID of the Pomerium route policy that matched the request | Yes |
+| `service-account-id` | If using a service account, the service account ID | Yes |
+| `session-id` | The session ID | Yes |
 | `user` | The user's ID | Yes |
 
 :::danger

--- a/content/docs/reference/autocert.mdx
+++ b/content/docs/reference/autocert.mdx
@@ -160,8 +160,8 @@ Credentials are sourced from [Google Application Default Credentials](https://cl
 | :-- | :-- |
 | Docker images | `/data/autocert` |
 | [OS packages](https://github.com/pomerium/pomerium/blob/5e3ae59658246bfe3d4cc5d12997c6e19350bf80/ospkg/pomerium.service#L8) | `/etc/pomerium/` (Must be manually set with environmental variables.) |
-| XDG base directories | [$XDG_DATA_HOME](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) |
-| Home directories | `$HOME/.local/share/pomerium` |
+| XDG base directories | [$XDG_DATA_HOME](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)`/pomerium/autocert` |
+| Home directories | `$HOME/.local/share/pomerium/autocert` |
 
 ## Autocert EAB Key ID \{#autocert-eab-key-id}
 
@@ -200,11 +200,11 @@ The Autocert EAB MAC Key setting is required when Autocert EAB Key ID is set.
 #### Examples \{#autocert-eab-mac-key-examples}
 
 ```yaml
-autocert_eab_key_id: base64-URL-encoded_secret_key
+autocert_eab_mac_key: base64-URL-encoded_secret_key
 ```
 
 ```bash
-AUTOCERT_EAB_KEY_ID=base64-URL-encoded_secret_key
+AUTOCERT_EAB_MAC_KEY=base64-URL-encoded_secret_key
 ```
 
 ## Autocert Email \{#autocert-email}

--- a/content/docs/reference/certificates.mdx
+++ b/content/docs/reference/certificates.mdx
@@ -48,9 +48,9 @@ Pomerium will check your system's trust/key store for valid certificates first. 
 
 | **Config file keys** | **Environment variables** | **Type** | **Usage** |
 | :-- | :-- | :-- | :-- |
-| `certificates` | Not settable as environment variable | `string` (Array of relative file locations for multiple certificates) | **required** (if insecure not set) |
-| `certificate` and `certificate_key` | `CERTIFICATE` and `CERTIFICATE_KEY` | `string` (base64-encoded string) | **required** (if insecure not set) |
-| `certificate_file` and `certificate_key_file` | `CERTIFICATE_FILE` and `CERTIFICATE_KEY_FILE` | `string` (Relative file location for a single certificate) | **required** (if insecure not set) |
+| `certificates` | Not settable as environment variable | array of objects (each with `cert` and `key` file paths) | **required** (if insecure not set) |
+| `certificate` and `certificate_key` | `CERTIFICATE` and `CERTIFICATE_KEY` | `string` (base64-encoded) | **required** (if insecure not set) |
+| `certificate_file` and `certificate_key_file` | `CERTIFICATE_FILE` and `CERTIFICATE_KEY_FILE` | `string` (file path) | **required** (if insecure not set) |
 
 ### Examples \{#certificates-examples}
 
@@ -130,8 +130,8 @@ Be sure to include the intermediary certificate.
 
 | **Config file keys** | **Environment variables** | **Type** | **Usage** |
 | :-- | :-- | :-- | :-- |
-| `certificate_authority` | `CERTIFICATE_AUTHORITY` | `string` | **optional** |
-| `certificate_authority_file` | `CERTIFICATE_AUTHORITY_FILE` | `string` | **optional** |
+| `certificate_authority` | `CERTIFICATE_AUTHORITY` | `string` (base64-encoded) | **optional** |
+| `certificate_authority_file` | `CERTIFICATE_AUTHORITY_FILE` | `string` (file path) | **optional** |
 
 ### Examples \{#certificate-authority-examples}
 

--- a/content/docs/reference/circuit-breaker-thresholds.mdx
+++ b/content/docs/reference/circuit-breaker-thresholds.mdx
@@ -20,13 +20,17 @@ import Tabs from '@theme/Tabs';
 
 In Pomerium requests will automatically fail when circuit breaker thresholds are reached. The following thresholds are available:
 
-- Max Connections: The maximum number of connections that Pomerium will establish to all hosts in a route's upstream cluster. Default is `1024`.
-- Max Pending Requests: The maximum number of requests that will be queued while waiting for a ready connection pool connection. Default is `1024`.
-- Max Requests: The maximum number of requests that can be outstanding to all route upstream hosts in a cluster at any given time. Default is `1024`.
-- Max Retries: The maximum number of retries that can be outstanding to all hosts in a route upstream cluster at any given time. Default is `3`. At this time Pomerium does not enable retries for any requests, though this may change in the future.
-- Max Connection Pools: The maximum number of connection pools that can be concurrently instantiated. Default is unlimited.
+- Max Connections: The maximum number of connections that Pomerium will establish to all hosts in a route's upstream cluster. Envoy default is `1024`.
+- Max Pending Requests: The maximum number of requests that will be queued while waiting for a ready connection pool connection. Envoy default is `1024`.
+- Max Requests: The maximum number of requests that can be outstanding to all route upstream hosts in a cluster at any given time. Envoy default is `1024`.
+- Max Retries: The maximum number of retries that can be outstanding to all hosts in a route upstream cluster at any given time. Envoy default is `3`. At this time Pomerium does not enable retries for any requests, though this may change in the future.
+- Max Connection Pools: The maximum number of connection pools that can be concurrently instantiated. Envoy default is unlimited.
 
 Thresholds can be set at the global level or the individual route level. Each threshold is optional.
+
+For route (upstream) clusters, global thresholds are applied first, then route-level thresholds override any matching fields. If neither global nor route-level thresholds are configured, Envoy's built-in defaults apply.
+
+For Pomerium's internal clusters (such as the authorize, databroker, and control plane clusters), all thresholds default to unlimited to prevent internal traffic from being circuit-broken. Global thresholds will override these unlimited defaults.
 
 ## How to Configure
 

--- a/content/docs/reference/cookies.mdx
+++ b/content/docs/reference/cookies.mdx
@@ -287,7 +287,7 @@ cookie:
 
 | **Config file keys** | **Environment variables** | **Type** | **Usage** | **Default** | **Options** |
 | :-- | :-- | :-- | :-- | :-- | :-- |
-| `cookie_same_site` | `COOKIE_SAME_SITE` | `string` | **optional** | ` Lax` (if unset) | See [Cookie SameSite Options](#cookie-samesite-options) |
+| `cookie_same_site` | `COOKIE_SAME_SITE` | `string` | **optional** | not set (browsers default to `Lax`) | See [Cookie SameSite Options](#cookie-samesite-options) |
 
 #### Examples \{#cookie-samesite-examples}
 
@@ -315,7 +315,7 @@ See [Cookie SameSite Options](#cookie-samesite-options) for more information.
 
 | **[Parameter name](/docs/deploy/k8s/reference#cookie)** | **Type** | **Usage** | **Default** | **Options** |
 | :-- | :-- | :-- | :-- | :-- |
-| `cookie.sameSite` | `string` | **optional** | ` Lax` (if unset) | See [Cookie SameSite Options](#cookie-samesite-options) |
+| `cookie.sameSite` | `string` | **optional** | not set (browsers default to `Lax`) | See [Cookie SameSite Options](#cookie-samesite-options) |
 
 #### Examples \{#cookie-samesite-examples}
 
@@ -344,9 +344,9 @@ cookie:
 <Tabs>
 <TabItem value="Core" label="Core">
 
-| **Config file keys** | **Environment variables** | **Type** | **Usage** |
-| :-- | :-- | :-- | :-- |
-| `cookie_secret_file` | `COOKIE_SECRET_FILE` | `string` | **required** (for proxy service) |
+| **Config file keys** | **Environment variables** | **Type** | **Usage**    |
+| :------------------- | :------------------------ | :------- | :----------- |
+| `cookie_secret_file` | `COOKIE_SECRET_FILE`      | `string` | **optional** |
 
 #### Examples \{#cookie-secret-file-examples}
 

--- a/content/docs/reference/databroker.mdx
+++ b/content/docs/reference/databroker.mdx
@@ -73,7 +73,7 @@ See Kubernetes [Storage reference](/docs/deploy/k8s/reference#storage) for more 
 
 **Databroker Storage Connection String** tells Pomerium which directory to use for the `file` storage type or how to connect to an external PostgreSQL database for the `postgres` storage type. This connection string may be provided directly in the configuration or read from a file.
 
-This setting is **required** when the storage type is set to `file` or `postgres`.
+This setting is **required** when the storage type is set to `postgres`. It is optional but recommended for the `file` storage type to specify the storage directory.
 
 ### How to Configure the File Storage Type
 

--- a/content/docs/reference/dns.mdx
+++ b/content/docs/reference/dns.mdx
@@ -38,7 +38,7 @@ This reference covers all of Pomerium's **DNS Settings**:
 
 | **Config file keys** | **Environment variables** | **Type** | **Default** |
 | :-- | :-- | :-- | :-- |
-| `dns_failure_refresh_rate` | `DNS_FAILURE_REFRESH_RATE` | `string` ([Go Duration](https://golang.org/pkg/time/#Duration.String) formatting) | `5s` |
+| `dns_failure_refresh_rate` | `DNS_FAILURE_REFRESH_RATE` | `string` ([Go Duration](https://golang.org/pkg/time/#Duration.String) formatting) | none (Envoy default) |
 
 #### Examples
 
@@ -80,11 +80,11 @@ dns:
 #### Examples
 
 ```yaml
-default_lookup_family: AUTO
+dns_lookup_family: AUTO
 ```
 
 ```bash
-DEFAULT_LOOKUP_FAMILY=V6_ONLY
+DNS_LOOKUP_FAMILY=V6_ONLY
 ```
 
 </TabItem>
@@ -110,7 +110,7 @@ dns:
 | **Options** | **Description** |
 | :-- | :-- |
 | `DEFAULT` (Enterprise only) | Defers to configuration settings or default if none specified |
-| `AUTO` | DNS resolver will first perform a lookup for addresses in the IPv6 family and fallback to a lookup for addresses in the IPv4 family |
+| `AUTO` | DNS resolver will perform a lookup using the system's default behavior, which typically attempts resolution for both IPv4 and IPv6 addresses |
 | `V4_ONLY` | DNS resolver will only perform a lookup for addresses in the IPv4 family |
 | `V6_ONLY` | DNS resolver will only perform a lookup for addresses in the IPv6 family |
 | `V4_PREFERRED` | DNS resolver will first perform a lookup for addresses in the IPv4 family and fallback to a lookup for addresses in the IPv6 family |
@@ -129,7 +129,7 @@ See the [Envoy docs](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/c
 
 | **Config file keys** | **Environment variables** | **Type** | **Default** |
 | :-- | :-- | :-- | :-- |
-| `dns_query_timeout` | `DNS_QUERY_TIMEOUT` | `string` ([Go Duration](https://golang.org/pkg/time/#Duration.String) formatting) | `5s` |
+| `dns_query_timeout` | `DNS_QUERY_TIMEOUT` | `string` ([Go Duration](https://golang.org/pkg/time/#Duration.String) formatting) | none (Envoy default) |
 
 #### Examples
 
@@ -164,9 +164,9 @@ dns:
 <Tabs>
 <TabItem value="Core" label="Core">
 
-| **Config file keys** | **Environment variables** | **Type**  | **Default** |
-| :------------------- | :------------------------ | :-------- | :---------- |
-| `dns_query_tries`    | `DNS_QUERY_TRIES`         | `integer` | `4`         |
+| **Config file keys** | **Environment variables** | **Type** | **Default** |
+| :-- | :-- | :-- | :-- |
+| `dns_query_tries` | `DNS_QUERY_TRIES` | `integer` | none (Envoy default) |
 
 #### Examples
 
@@ -203,7 +203,7 @@ dns:
 
 | **Config file keys** | **Environment variables** | **Type** | **Default** |
 | :-- | :-- | :-- | :-- |
-| `dns_refresh_rate` | `DNS_REFRESH_RATE` | `string` ([Go Duration](https://golang.org/pkg/time/#Duration.String) formatting) | DNS record TTL, or `5s` if not set |
+| `dns_refresh_rate` | `DNS_REFRESH_RATE` | `string` ([Go Duration](https://golang.org/pkg/time/#Duration.String) formatting) | none (respects DNS record TTL) |
 
 #### Examples
 

--- a/content/docs/reference/envoy-admin-interface.mdx
+++ b/content/docs/reference/envoy-admin-interface.mdx
@@ -64,9 +64,9 @@ envoy_admin_address: '127.0.0.1:29091'
 <Tabs groupId="deployment-type">
 <TabItem value="Core" label="Core">
 
-| **Config file keys**          | **Environment variables**     | **Type** |
-| :---------------------------- | :---------------------------- | :------- |
-| `envoy_admin_access_log_path` | `ENVOY_ADMIN_ACCESS_LOG_PATH` | `string` |
+| **Config file keys** | **Environment variables** | **Type** | **Default** |
+| :-- | :-- | :-- | :-- |
+| `envoy_admin_access_log_path` | `ENVOY_ADMIN_ACCESS_LOG_PATH` | `string` | `os.DevNull` (access logging disabled) |
 
 ### Example
 
@@ -96,12 +96,14 @@ envoy_admin_access_log_path: /var/log/pomerium/envoy-admin-access.log
 <Tabs groupId="deployment-type">
 <TabItem value="Core" label="Core">
 
-| **Config file keys**       | **Environment variables**  | **Type** |
-| :------------------------- | :------------------------- | :------- |
-| `envoy_admin_profile_path` | `ENVOY_ADMIN_PROFILE_PATH` | `string` |
+| **Config file keys** | **Environment variables** | **Type** | **Default** |
+| :-- | :-- | :-- | :-- |
+| `envoy_admin_profile_path` | `ENVOY_ADMIN_PROFILE_PATH` | `string` | `os.DevNull` (profiling disabled) |
+
+### Example
 
 ```yaml
-envoy_admin_access_log_path: /var/log/pomerium/envoy.prof
+envoy_admin_profile_path: /var/log/pomerium/envoy.prof
 ```
 
 </TabItem>

--- a/content/docs/reference/jwt-claim-headers.mdx
+++ b/content/docs/reference/jwt-claim-headers.mdx
@@ -30,9 +30,9 @@ Forwarding a claim with JWT Claims Headers adds the claim to the X-Pomerium-Jwt-
 <Tabs>
 <TabItem value="Core" label="Core">
 
-| **Config file keys** | **Environment variables** | **Type** | **Usage**    |
-| :------------------- | :------------------------ | :------- | :----------- |
-| `jwt_claims_headers` | `JWT_CLAIMS_HEADERS`      | `string` | **optional** |
+| **Config file keys** | **Environment variables** | **Type** | **Usage** |
+| :-- | :-- | :-- | :-- |
+| `jwt_claims_headers` | `JWT_CLAIMS_HEADERS` | map of `string` (or comma-separated `string`) | **optional** |
 
 ### Examples
 

--- a/content/docs/reference/log-level.mdx
+++ b/content/docs/reference/log-level.mdx
@@ -29,7 +29,7 @@ import EnterpriseConfiguration from '../../../src/components/EnterpriseConfigura
 
 | **Config file keys** | **Environment variables** | **Type** | **Default** |
 | :------------------- | :------------------------ | :------- | :---------- |
-| `log_level`          | `LOG_LEVEL`               | `string` | `debug`     |
+| `log_level`          | `LOG_LEVEL`               | `string` | `info`      |
 
 ### Examples
 
@@ -43,11 +43,15 @@ LOG_LEVEL=warn
 
 ### Options
 
-- `none`
+- `trace`
 - `debug`
 - `info`
-- `warn`
+- `warn` or `warning`
 - `error`
+- `critical`
+- `fatal`
+- `panic`
+- `off`, `none`, or `disabled`
 
 </TabItem>
 <TabItem value="Enterprise" label="Enterprise">

--- a/content/docs/reference/metrics.mdx
+++ b/content/docs/reference/metrics.mdx
@@ -47,7 +47,7 @@ metrics_address: :9090
 ```
 
 ```bash
-METRICS_ADDRESS: 127.0.0.1:9090
+METRICS_ADDRESS=127.0.0.1:9090
 ```
 
 </TabItem>
@@ -134,24 +134,24 @@ To support this in Prometheus, consult the `basic_auth` option in the [`scrape_c
 
 | **Config file keys** | **Environment variables** | **Type** | **Usage** |
 | :-- | :-- | :-- | :-- |
-| `metrics_basic_authentication` | `METRICS_BASIC_AUTHENTICATION` | `string` ([base64 encoded](https://en.wikipedia.org/wiki/Base64)) | **optional** |
+| `metrics_basic_auth` | `METRICS_BASIC_AUTH` | `string` ([base64 encoded](https://en.wikipedia.org/wiki/Base64)) | **optional** |
 
 #### Examples \{#examples-metrics-basic-authentication}
 
 ```yaml
 # for username: x and password: y
-metrics_basic_authentication: eDp5
+metrics_basic_auth: eDp5
 ```
 
 ```bash
 # for username: x and password: y
-METRICS_BASIC_AUTHENTICATION=eDp5
+METRICS_BASIC_AUTH=eDp5
 ```
 
 </TabItem>
 <TabItem value="Enterprise" label="Enterprise">
 
-`metrics_basic_authentication` is a bootstrap configuration setting and is not configurable in the Console.
+`metrics_basic_auth` is a bootstrap configuration setting and is not configurable in the Console.
 
 </TabItem>
 <TabItem value="Kubernetes" label="Kubernetes">
@@ -192,7 +192,7 @@ metrics_certificate_key: base64-encoded-string
 
 ```bash
 METRICS_CERTIFICATE_FILE=/relative/file/location
-METRICS_CERTIFICATE_FILE_KEY=/relative/file/location
+METRICS_CERTIFICATE_KEY_FILE=/relative/file/location
 ```
 
 </TabItem>

--- a/content/docs/reference/pass-identity-headers.mdx
+++ b/content/docs/reference/pass-identity-headers.mdx
@@ -32,9 +32,9 @@ Identity headers include:
 <Tabs>
 <TabItem value="Core" label="Core">
 
-| **YAML**/**JSON** setting | **Type**  | **Usage**    | **Default** |
-| :------------------------ | :-------- | :----------- | :---------- |
-| `pass_identity_headers`   | `boolean` | **optional** | \*`false`   |
+| **Config file keys** | **Environment variables** | **Type** | **Usage** | **Default** |
+| :-- | :-- | :-- | :-- | :-- |
+| `pass_identity_headers` | `PASS_IDENTITY_HEADERS` | `boolean` | **optional** | \*`false` |
 
 ### Examples
 

--- a/content/docs/reference/proxy-log-level.mdx
+++ b/content/docs/reference/proxy-log-level.mdx
@@ -2,7 +2,7 @@
 id: proxy-log-level
 title: Proxy Log Level
 description: |
-  Log level sets the logging level for the Pomerium Proxy service.
+  Sets Envoy's logging level for the Pomerium Proxy service.
 keywords:
   - reference
   - Proxy Log Level
@@ -20,7 +20,7 @@ import EnterpriseConfiguration from '../../../src/components/EnterpriseConfigura
 
 ## Summary
 
-**Proxy Log Level** sets the logging level for the Pomerium Proxy service access logs. Only logs of the desired level and above will be logged.
+**Proxy Log Level** sets Envoy's logging level for the Pomerium Proxy service. If unset, Pomerium uses the value of [`log_level`](/docs/reference/log-level).
 
 ## How to configure
 
@@ -29,7 +29,7 @@ import EnterpriseConfiguration from '../../../src/components/EnterpriseConfigura
 
 | **Config file keys** | **Environment variables** | **Type** | **Default** |
 | :-- | :-- | :-- | :-- |
-| `proxy_log_level` | `PROXY_LOG_LEVEL` | `string` | `debug` or value of [`log_level`](/docs/reference/log-level) if set |
+| `proxy_log_level` | `PROXY_LOG_LEVEL` | `string` | value of [`log_level`](/docs/reference/log-level) |
 
 ### Examples
 
@@ -60,7 +60,12 @@ Kubernetes does not support **Proxy Log Level**
 
 ### Options
 
+- `trace`
 - `debug`
 - `info`
-- `warn`
+- `warn` or `warning`
 - `error`
+- `critical`
+- `fatal`
+- `panic`
+- `off`, `none`, or `disabled`

--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -6,7 +6,7 @@
     "services": ["proxy"],
     "short_description": "",
     "title": "Access Log Fields",
-    "type": "string"
+    "type": "array of strings"
   },
   "additional-login-redirect-hosts": {
     "description": "Chain login redirects across specified domains, ensuring a session cookie is issued for each domain",
@@ -18,7 +18,7 @@
     "type": "array of string"
   },
   "address": {
-    "description": "Specifies the IP Address and Port to serve HTTP requests from.",
+    "description": "Specifies the IP Address and Port to serve HTTPS requests from.",
     "id": "address",
     "path": "/address",
     "services": ["proxy"],
@@ -64,7 +64,7 @@
     "services": ["authorize"],
     "short_description": "",
     "title": "Authorize Log Fields",
-    "type": "string"
+    "type": "array of strings"
   },
   "authorize-service-url": {
     "description": "Authorize Service URL is the location of the internally accessible Authorize service.",
@@ -196,10 +196,11 @@
     "title": "Cluster Identity"
   },
   "cluster-name": {
+    "description": "A human-readable name for the route, also used as the Envoy cluster stat name for metrics.",
     "id": "cluster-name",
     "path": "/routes/cluster-name",
     "services": ["proxy"],
-    "title": "Cluster Name",
+    "title": "Name",
     "type": "string"
   },
   "cluster-settings-name": {
@@ -955,7 +956,7 @@
     "path": "/jwt-claim-headers",
     "services": [],
     "title": "JWT Claim Headers",
-    "type": "slice of string"
+    "type": "map of string"
   },
   "jwt-groups-filter": {
     "description": "Restricts the set of groups allowed in the Pomerium JWT and Impersonate-Group headers, either based on applied policies or using a specific list of groups.",
@@ -996,7 +997,7 @@
     "type": "string"
   },
   "load-balancing-policy": {
-    "description": "Defines the Load Balancing strategy for multiple upstream servers.",
+    "description": "Selects the load balancing strategy for routes with multiple upstream servers.",
     "id": "load-balancing-policy",
     "path": "/routes/load-balancing#load-balancing-policy",
     "services": ["proxy"],
@@ -1004,11 +1005,12 @@
     "type": "enum"
   },
   "load-balancing-policy-config": {
+    "description": "Advanced Envoy load balancing policy config objects are not currently exposed in Pomerium route configuration.",
     "id": "load-balancing-policy-config",
     "path": "/routes/load-balancing-policy-config",
     "services": ["proxy"],
     "title": "Load Balancing Policy Config",
-    "type": "object"
+    "type": "not currently supported"
   },
   "load-balancing-settings": {
     "id": "load-balancing-settings",
@@ -1016,7 +1018,7 @@
     "title": "Load Balancing Settings"
   },
   "log-level": {
-    "description": "Sets the global logging level for this cluster.",
+    "description": "Sets the global logging level for Pomerium.",
     "id": "log-level",
     "path": "/log-level",
     "services": [],
@@ -1349,7 +1351,7 @@
     "type": "array of string"
   },
   "proxy-log-level": {
-    "description": "Sets the logging level for the Pomerium Proxy service.",
+    "description": "Sets Envoy's logging level for the Pomerium Proxy service. Defaults to log_level when unset.",
     "id": "proxy-log-level",
     "path": "/proxy-log-level",
     "services": [],
@@ -1397,12 +1399,12 @@
     "type": "regular expression"
   },
   "regex-priority-order": {
-    "description": "Rewrites the URL path according to the regex rewrite pattern.",
+    "description": "Determines the ordering of routes that use regular expressions. Higher values are evaluated first.",
     "id": "regex-priority-order",
     "path": "/routes/regex-priority-order",
     "services": ["proxy"],
     "title": "Regex Priority Order",
-    "type": "uint32"
+    "type": "int64"
   },
   "regex-rewrite": {
     "description": "Rewrites the URL path according to the regex rewrite pattern.",
@@ -1555,7 +1557,7 @@
     "title": "Service Account User ID"
   },
   "service-mode": {
-    "description": "Service mode sets the pomerium service(s) to run.",
+    "description": "Sets which Pomerium services to run. Accepts a comma-separated list.",
     "id": "service-mode",
     "path": "/service-mode",
     "services": [],
@@ -1598,10 +1600,10 @@
     "type": "string"
   },
   "show-error-details": {
-    "description": "If applied, shows error details, including policy explanation and remediation for 403 Forbidden responses.",
+    "description": "Includes policy explanation and remediation details in authorization error responses. Required for route-specific branded error content.",
     "id": "show-error-details",
     "path": "/routes/show-error-details",
-    "services": [],
+    "services": ["proxy"],
     "title": "Show Error Details",
     "type": "bool"
   },
@@ -1610,7 +1612,7 @@
     "id": "signing-key",
     "path": "/signing-key",
     "services": [],
-    "short_description": "y",
+    "short_description": "",
     "title": "Signing Key",
     "type": "string"
   },

--- a/content/docs/reference/routes/additional-login-redirect-hosts.mdx
+++ b/content/docs/reference/routes/additional-login-redirect-hosts.mdx
@@ -31,9 +31,9 @@ See [Cross-Origin Configuration](/docs/internals/troubleshooting#cross-origin-co
 <Tabs>
 <TabItem value="Core" label="Core">
 
-| Config file key | Environment variable | Type | Default |
-| :-- | :-- | :-- | :-- |
-| `depends_on` | `DEPENDS_ON` | array of strings (`host` or `host:port`) | _none_ |
+| Config file key | Type                                     | Default |
+| :-------------- | :--------------------------------------- | :------ |
+| `depends_on`    | array of strings (`host` or `host:port`) | _none_  |
 
 ### Examples
 

--- a/content/docs/reference/routes/allow-any-authenticated-user.mdx
+++ b/content/docs/reference/routes/allow-any-authenticated-user.mdx
@@ -34,7 +34,7 @@ Use of this setting means Pomerium **will not enforce your centralized authoriza
 ### Examples
 
 ```yaml
-allow_any_authenticated_user: 'true'
+allow_any_authenticated_user: true
 ```
 
 </TabItem>

--- a/content/docs/reference/routes/cluster-name.mdx
+++ b/content/docs/reference/routes/cluster-name.mdx
@@ -1,9 +1,9 @@
 ---
 id: cluster-name
-title: Cluster Name
+title: Name
 keywords:
   - reference
-  - Cluster Name
+  - Route Name
 pagination_prev: null
 pagination_next: null
 toc_max_heading_level: 2
@@ -12,11 +12,13 @@ toc_max_heading_level: 2
 import TabItem from '@theme/TabItem';
 import Tabs from '@theme/Tabs';
 
-# Cluster Name
+# Name
 
 ## Summary
 
-Runtime metrics for **Cluster Name** would be available under `envoy_cluster_`_`name`_ prefix.
+**Name** sets a human-readable name for the route. When set, Pomerium also uses this value as the Envoy cluster stat name, which appears in metrics under the `envoy_cluster_name` label.
+
+If **Name** is not set, the route has no display name and the cluster stat name will be empty.
 
 ## How to configure
 
@@ -27,10 +29,19 @@ Runtime metrics for **Cluster Name** would be available under `envoy_cluster_`_`
 | :------------------ | :------- | :----------- |
 | `name`              | `string` | **optional** |
 
+### Examples
+
+```yaml
+routes:
+  - from: https://verify.example.com
+    to: https://verify.local
+    name: verify
+```
+
 </TabItem>
 <TabItem value="Enterprise" label="Enterprise">
 
-**Cluster Name** is a bootstrap configuration setting and is not configurable in the Console.
+Set the route **Name** under **General** route settings in the Console.
 
 </TabItem>
 <TabItem value="Kubernetes" label="Kubernetes">

--- a/content/docs/reference/routes/enable-google-cloud-serverless-authentication.mdx
+++ b/content/docs/reference/routes/enable-google-cloud-serverless-authentication.mdx
@@ -27,18 +27,14 @@ This setting requires you to set [Google Cloud Serverless Authentication Service
 <Tabs>
 <TabItem value="Core" label="Core">
 
-| **Config file keys** | **Environment variables** | **Type** | **Default** |
-| :-- | :-- | :-- | :-- |
-| `enable_google_cloud_serverless_authentication` | `ENABLE_GOOGLE_CLOUD_SERVERLESS_AUTHENTICATION` | `boolean` | `false` |
+| **Config file keys**                            | **Type**  | **Default** |
+| :---------------------------------------------- | :-------- | :---------- |
+| `enable_google_cloud_serverless_authentication` | `boolean` | `false`     |
 
 ### Examples
 
 ```yaml
 enable_google_cloud_serverless_authentication: true
-```
-
-```bash
-ENABLE_GOOGLE_CLOUD_SERVERLESS_AUTHENTICATION=true
 ```
 
 </TabItem>

--- a/content/docs/reference/routes/headers.mdx
+++ b/content/docs/reference/routes/headers.mdx
@@ -241,9 +241,9 @@ set_request_headers:
 <Tabs>
 <TabItem value="Core" label="Core">
 
-| **YAML**/**JSON** setting | **Type** | **Usage**    |
-| :------------------------ | :------- | :----------- |
-| `remove_request_headers`  | `string` | **optional** |
+| **YAML**/**JSON** setting | **Type**           | **Usage**    |
+| :------------------------ | :----------------- | :----------- |
+| `remove_request_headers`  | `array of strings` | **optional** |
 
 ### Examples \{#examples-remove-request-headers}
 
@@ -274,7 +274,7 @@ Set **Remove Request Headers** in the Console:
 
 | **[Annotation name](/docs/deploy/k8s/ingress#set-ingress-annotations)** | **Type** | **Usage** |
 | :-- | :-- | :-- |
-| `remove_request_headers` | `string` | **optional** |
+| `remove_request_headers` | `array of strings` | **optional** |
 
 ```yaml
 ingress.pomerium.io/remove_request_headers: |
@@ -294,9 +294,9 @@ ingress.pomerium.io/remove_request_headers: |
 <Tabs>
 <TabItem value="Core" label="Core">
 
-| **YAML**/**JSON** setting | **Type** | **Usage**    |
-| :------------------------ | :------- | :----------- |
-| `set_response_headers`    | `string` | **optional** |
+| **YAML**/**JSON** setting | **Type**               | **Usage**    |
+| :------------------------ | :--------------------- | :----------- |
+| `set_response_headers`    | map of key-value pairs | **optional** |
 
 ### Examples
 
@@ -319,7 +319,7 @@ Configure **Set Response Headers** in the Console:
 
 | **[Annotation name](/docs/deploy/k8s/ingress#set-ingress-annotations)** | **Type** | **Usage** |
 | :-- | :-- | :-- |
-| `set_response_headers` | `string` | **optional** |
+| `set_response_headers` | map of key-value pairs | **optional** |
 
 ```yaml
 ingress.pomerium.io/set_response_headers: |
@@ -338,9 +338,9 @@ ingress.pomerium.io/set_response_headers: |
 <Tabs>
 <TabItem value="Core" label="Core">
 
-| **YAML**/**JSON** setting  | **Type** | **Usage**    |
-| :------------------------- | :------- | :----------- |
-| `rewrite_response_headers` | `object` | **optional** |
+| **YAML**/**JSON** setting  | **Type**           | **Usage**    |
+| :------------------------- | :----------------- | :----------- |
+| `rewrite_response_headers` | `array of objects` | **optional** |
 
 ### Examples \{#examples-rewrite-response-headers}
 
@@ -375,7 +375,7 @@ Configure **Rewrite Response Headers** in the Console:
 
 | **[Annotation name](/docs/deploy/k8s/ingress#set-ingress-annotations)** | **Type** | **Usage** |
 | :-- | :-- | :-- |
-| `rewrite_response_headers` | `object` | **optional** |
+| `rewrite_response_headers` | `array of objects` | **optional** |
 
 ### Examples
 

--- a/content/docs/reference/routes/jwt-issuer-format.mdx
+++ b/content/docs/reference/routes/jwt-issuer-format.mdx
@@ -13,7 +13,7 @@ import EnterpriseConfiguration from '../../../../src/components/EnterpriseConfig
 
 This setting determines the format of the issuer (`iss`) claim in the Pomerium JWT. See [JWT Authentication](/docs/capabilities/getting-users-identity) for more information about the Pomerium JWT.
 
-Before Pomerium v0.28, this claim was always set to the hostname portion of the route's [**From**](/docs/reference/routes/from) URL. Starting in v0.28, the issue claim can be set to use a full URL instead. This may be necessary for interoperability with some JWT authentication consumers.
+Before Pomerium v0.28, this claim was always set to the hostname portion of the route's [**From**](/docs/reference/routes/from) URL. Starting in v0.28, the issuer claim can be set to use a full URL instead. This may be necessary for interoperability with some JWT authentication consumers.
 
 The default is hostname-only for backwards compatibility with existing Pomerium deployments.
 

--- a/content/docs/reference/routes/load-balancing-policy-config.mdx
+++ b/content/docs/reference/routes/load-balancing-policy-config.mdx
@@ -11,38 +11,28 @@ pagination_next: null
 import TabItem from '@theme/TabItem';
 import Tabs from '@theme/Tabs';
 
-import EnterpriseConfiguration from '../../../../src/components/EnterpriseConfiguration';
-
 # Load Balancing Policy Config
 
 ## Summary
 
-When [`lb_policy`](/docs/reference/routes/load-balancing#load-balancing-policy) is configured, **Load Balancing Policy Config** allows you to further customize policy settings with one of the following options:
-
-- `LEAST_REQUEST`
-- `RING_HASH`
-- `MAGLEV`
+Pomerium currently exposes only [`load_balancing_policy`](/docs/reference/routes/load-balancing#load-balancing-policy). Advanced Envoy policy-specific configuration objects such as `least_request_lb_config`, `ring_hash_lb_config`, and `maglev_lb_config` are not currently configurable through route settings or Kubernetes annotations.
 
 ## How to configure
 
 <Tabs>
 <TabItem value="Core" label="Core">
 
-| **Config file keys** | **Type** | **Usage** |
-| :-- | :-- | :-- |
-| [`least_request_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-msg-config-cluster-v3-cluster-leastrequestlbconfig) | `object` | **optional** |
-| [`ring_hash_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#config-cluster-v3-cluster-ringhashlbconfig) | `object` | **optional** |
-| [`maglev_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-msg-config-cluster-v3-cluster-maglevlbconfig) | `object` | **optional** |
+Advanced load balancing policy config is not currently supported in route configuration.
 
 </TabItem>
 <TabItem value="Enterprise" label="Enterprise">
-<EnterpriseConfiguration name="load_balancing_policy" resource="route" via={["terraform"]} />
+
+Advanced load balancing policy config is not currently configurable in the Console.
+
 </TabItem>
 <TabItem value="Kubernetes" label="Kubernetes">
 
-See Kubernetes [Ingress](/docs/deploy/k8s/ingress#load-balancing) for more information
+Kubernetes does not currently expose these load balancing policy config options.
 
 </TabItem>
 </Tabs>
-
-See [Load Balancing](/docs/capabilities/routing) for example [configurations](/docs/capabilities/routing#load-balancing-method)

--- a/content/docs/reference/routes/load-balancing.mdx
+++ b/content/docs/reference/routes/load-balancing.mdx
@@ -23,14 +23,14 @@ See [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v3/con
 
 ### How to configure \{#how-to-configure-load-balancing-policy}
 
-Some policy types support additional [configuration](/docs/reference/routes/load-balancing#load-balancing-policy-options).
+Pomerium currently exposes policy selection only. Advanced Envoy policy-specific configuration objects are not configurable through route settings.
 
 <Tabs>
 <TabItem value="Core" label="Core">
 
-| **Config file keys** | **Type** | **Usage**    | **Default**   |
-| :------------------- | :------- | :----------- | :------------ |
-| `lb_policy`          | `enum`   | **optional** | `ROUND_ROBIN` |
+| **Config file keys**    | **Type** | **Usage**    | **Default**   |
+| :---------------------- | :------- | :----------- | :------------ |
+| `load_balancing_policy` | `enum`   | **optional** | `ROUND_ROBIN` |
 
 ### Examples \{#examples-load-balancing-policy}
 
@@ -43,9 +43,7 @@ routes:
       - http://myapp-srv-3:8080
       - http://myapp-srv-4:8080
       - http://myapp-srv-5:8080
-    lb_policy: LEAST_REQUEST
-    least_request_lb_config:
-      choice_count: 2 # current envoy default
+    load_balancing_policy: LEAST_REQUEST
 ```
 
 </TabItem>
@@ -60,31 +58,22 @@ Set the **Load Balancing Policy** in the Console:
 </TabItem>
 <TabItem value="Kubernetes" label="Kubernetes">
 
-| **[Annotation name](/docs/deploy/k8s/ingress#set-ingress-annotations)** | **Type** | **Usage** | **Default** |
-| :-- | :-- | :-- | :-- |
-| `lb_policy` | `enum` | **optional** | `ROUND_ROBIN` |
-
-### Examples
-
-```yaml
-ingress.pomerium.io/lb_policy: LEAST_REQUEST
-ingress.pomerium.io/least_request_lb_config: '{"choice_count": 2}'
-```
-
-See [Kubernetes - Ingress Configuration](/docs/deploy/k8s/ingress) for more information.
+Kubernetes does not currently expose a load balancing policy annotation.
 
 </TabItem>
 </Tabs>
 
 ### Load Balancing Policy options \{#load-balancing-policy-options}
 
+Pomerium currently supports selecting one of Envoy's built-in load balancing policies. Policy-specific Envoy config objects such as `least_request_lb_config`, `ring_hash_lb_config`, and `maglev_lb_config` are not currently exposed.
+
 | **Load Balancer Policy options** |
 | :-- |
 | [`ROUND_ROBIN`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#weighted-round-robin) |
-| [`RING_HASH`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#ring-hash) (may be further configured using [`ring_hash_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#config-cluster-v3-cluster-ringhashlbconfig) option) |
-| [`LEAST_REQUEST`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#weighted-least-request) (may be further configured using [`least_request_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-msg-config-cluster-v3-cluster-leastrequestlbconfig)) |
+| [`RING_HASH`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#ring-hash) |
+| [`LEAST_REQUEST`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#weighted-least-request) |
 | [`RANDOM`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#random) |
-| [`MAGLEV`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#maglev) (may be further configured using [`maglev_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-msg-config-cluster-v3-cluster-maglevlbconfig) option) |
+| [`MAGLEV`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#maglev) |
 
 ## Health Checks \{#health-checks}
 

--- a/content/docs/reference/routes/outlier-detection.mdx
+++ b/content/docs/reference/routes/outlier-detection.mdx
@@ -38,7 +38,7 @@ outlier_detection: {'consecutive_5xx': 12}
 </TabItem>
 <TabItem value="Enterprise" label="Enterprise">
 
-`outlier_detection` is a bootstrap configuration setting and is not configurable in the Console.
+Configure **Outlier Detection** in the Console under the route's **Load Balancing** settings.
 
 </TabItem>
 <TabItem value="Kubernetes" label="Kubernetes">

--- a/content/docs/reference/routes/pass-identity-headers.mdx
+++ b/content/docs/reference/routes/pass-identity-headers.mdx
@@ -59,7 +59,7 @@ Set **Pass Identity Headers** under **General** route settings in the Console:
 
 | **[Annotation name](/docs/deploy/k8s/ingress#set-ingress-annotations)** | **Type** | **Usage** | **Default** |
 | :-- | :-- | :-- | :-- |
-| `pass_identity_headers` | `boolean` | **optional** | `false` |
+| `pass_identity_headers` | `boolean` | **optional** | Inherits from global setting |
 
 ```yaml
 ingress.pomerium.io/pass_identity_headers: 'true'

--- a/content/docs/reference/routes/path-rewriting.mdx
+++ b/content/docs/reference/routes/path-rewriting.mdx
@@ -117,7 +117,7 @@ regex_rewrite_substitution: "\\2/instance/\\1"
 
 </TabItem>
 <TabItem value="Enterprise" label="Enterprise">
-<EnterpriseConfiguration name="host_path_regex_rewrite_pattern" resource="route">
+<EnterpriseConfiguration name="regex_rewrite_pattern" resource="route">
 
 Set **Regex Rewrite** pattern and substitution in the Console:
 

--- a/content/docs/reference/routes/policy.mdx
+++ b/content/docs/reference/routes/policy.mdx
@@ -26,9 +26,9 @@ See [Pomerium Policy Language](/docs/internals/ppl) for a full explanation of ho
 <Tabs>
 <TabItem value="Core" label="Core">
 
-| **YAML**/**JSON** setting | **Type** | **Usage**    |
-| :------------------------ | :------- | :----------- |
-| `policy`                  | `string` | **optional** |
+| **YAML**/**JSON** setting | **Type**                  | **Usage**    |
+| :------------------------ | :------------------------ | :----------- |
+| `policy`                  | `object` (PPL rule block) | **optional** |
 
 ### Examples
 
@@ -69,7 +69,7 @@ Edit your policy:
 
 | **[Annotation name](/docs/deploy/k8s/ingress#set-authorization-policy)** | **Type** | **Usage** |
 | :-- | :-- | :-- |
-| `policy` | `string` | **optional** |
+| `policy` | `object` (PPL rule block) | **optional** |
 
 ### Examples
 

--- a/content/docs/reference/routes/readme.mdx
+++ b/content/docs/reference/routes/readme.mdx
@@ -19,6 +19,6 @@ import RouteExample from '/content/examples/config/route.example.yaml.md';
 
 A route contains specific access and control definitions for a back-end service. Each route is a list item under the `routes` key.
 
-Each route defines at minimum a `from` and `to` field, and a `policy` key defining authorization logic. Policies are defined using [Pomerium Policy Language](/docs/internals/ppl) (**PPL**). Additional options are listed below.
+Each route defines at minimum a `from` field and one of [`to`](/docs/reference/routes/to), [`redirect`](/docs/reference/routes/redirect), or [`response`](/docs/reference/routes/direct-response), along with a `policy` key defining authorization logic. Policies are defined using [Pomerium Policy Language](/docs/internals/ppl) (**PPL**). Additional options are listed below.
 
 <RouteExample />

--- a/content/docs/reference/routes/redirect.mdx
+++ b/content/docs/reference/routes/redirect.mdx
@@ -20,7 +20,7 @@ The **Redirect** setting redirects incoming requests to a new URL.
 
 ## How to configure
 
-Either `redirect` or [`to`](/docs/reference/routes/to) must be set.
+Either `redirect`, [`to`](/docs/reference/routes/to), or [`response`](/docs/reference/routes/direct-response) must be set.
 
 <Tabs>
 <TabItem value="Core" label="Core">

--- a/content/docs/reference/routes/regex-priority-order.mdx
+++ b/content/docs/reference/routes/regex-priority-order.mdx
@@ -1,7 +1,7 @@
 ---
 id: regex-priority-Order
 title: Regex Priority Order
-description: If set, the route will only match incoming requests with a path that matches the specified regular expression.
+description: Determines the ordering of routes that use regular expressions.
 keywords: [reference, regex priority order]
 pagination_prev: null
 pagination_next: null
@@ -17,7 +17,7 @@ import EnterpriseConfiguration from '../../../../src/components/EnterpriseConfig
 
 ## Summary
 
-If **Regex Priority Order** is set, the route will only match incoming requests with a path that matches the specified regular expression. The supported syntax is the same as the Go [regexp package](https://golang.org/pkg/regexp/) which is based on [re2](https://github.com/google/re2/wiki/Syntax).
+**Regex Priority Order** determines the ordering of routes that use `regex` matching. Higher values are evaluated first.
 
 ## How to configure
 
@@ -26,7 +26,7 @@ If **Regex Priority Order** is set, the route will only match incoming requests 
 
 | **YAML**/**JSON** setting | **Type** | **Usage**    |
 | :------------------------ | :------- | :----------- |
-| `regex_priority_order`    | `uint32` | **optional** |
+| `regex_priority_order`    | `int64`  | **optional** |
 
 ### Examples
 

--- a/content/docs/reference/routes/show-error-details.mdx
+++ b/content/docs/reference/routes/show-error-details.mdx
@@ -16,11 +16,27 @@ import EnterpriseConfiguration from '../../../../src/components/EnterpriseConfig
 
 ## Summary
 
-If true, **Show Error Details** allows you apply your custom [error message header](/docs/reference/branding) to a route.
+If enabled, **Show Error Details** includes policy evaluation explanation and remediation details in authorization error responses.
 
 ## How to configure
 
 <Tabs>
+<TabItem value="Core" label="Core">
+
+| **Config file keys** | **Type**  | **Usage**    | **Default** |
+| :------------------- | :-------- | :----------- | :---------- |
+| `show_error_details` | `boolean` | **optional** | `false`     |
+
+### Examples
+
+```yaml
+routes:
+  - from: https://example.com
+    to: https://upstream.internal
+    show_error_details: true
+```
+
+</TabItem>
 <TabItem value="Enterprise" label="Enterprise">
 <EnterpriseConfiguration name="show_error_details" resource="route">
 
@@ -29,5 +45,10 @@ Enable **Show Error Details** on a route in the Console:
 ![Show error details](../branding/img/branding-show-error-details.png)
 
 </EnterpriseConfiguration>
+</TabItem>
+<TabItem value="Kubernetes" label="Kubernetes">
+
+Kubernetes does not support `show_error_details`
+
 </TabItem>
 </Tabs>

--- a/content/docs/reference/routes/timeouts.mdx
+++ b/content/docs/reference/routes/timeouts.mdx
@@ -28,7 +28,7 @@ If set, enables proxying of websocket connections.
 
 :::warning
 
-**Use with caution:** websockets are long-lived connections, so [global timeouts](/docs/reference/global-timeouts) are not enforced (though the policy-specific `timeout` is enforced). Allowing websocket connections to the proxy could result in abuse via [DOS attacks](https://www.cloudflare.com/learning/ddos/ddos-attack-tools/slowloris/).
+**Use with caution:** websockets are long-lived connections, so both the route timeout and idle timeout are automatically disabled (set to `0`) unless explicitly configured. Allowing websocket connections to the proxy could result in abuse via [DOS attacks](https://www.cloudflare.com/learning/ddos/ddos-attack-tools/slowloris/).
 
 :::
 
@@ -120,7 +120,9 @@ See [Kubernetes - Ingress Configuration](/docs/deploy/k8s/ingress) for more info
 
 ## Route Timeout \{#route-timeout}
 
-**Route Timeout** establishes the per-route timeout value. Cannot exceed [global timeout](/docs/reference/global-timeouts) values.
+**Route Timeout** establishes the per-route timeout value. Cannot exceed [global timeout](/docs/reference/global-timeouts) values. If unset, the route inherits the global [`default_upstream_timeout`](/docs/reference/global-timeouts) (default `30s`).
+
+For routes with websockets enabled, or for TCP, UDP, and Kubernetes routes, the route timeout is automatically set to `0` (disabled) unless explicitly configured via this setting.
 
 ### How to configure \{#how-to-configure-route-timeout}
 
@@ -168,6 +170,8 @@ If you are proxying long-lived requests that employ streaming calls such as webs
 
 If `idle_timeout` is specified, and [route timeout](/docs/reference/routes/timeouts#route-timeout) is not explicitly set, then the route timeout would be unlimited (`0s`). You still may specify maximum lifetime of the connection using the route timeout value (i.e. to 1 day).
 
+For routes with websockets enabled, or for TCP, UDP, and Kubernetes routes, the idle timeout is automatically set to `0` (disabled) unless explicitly configured via this setting.
+
 ### How to configure \{#how-to-configure-idle-timeout}
 
 <Tabs>
@@ -175,7 +179,7 @@ If `idle_timeout` is specified, and [route timeout](/docs/reference/routes/timeo
 
 | **YAML**/**JSON** setting | **Type** | **Usage** | **Default** |
 | :-- | :-- | :-- | :-- |
-| `idle_timeout` | `string` ([Go Duration](https://golang.org/pkg/time/#Duration.String) formatting) | **optional** | `5m` |
+| `idle_timeout` | `string` ([Go Duration](https://golang.org/pkg/time/#Duration.String) formatting) | **optional** | not set |
 
 ### Examples
 
@@ -201,7 +205,7 @@ Set **Idle Timeout** under route **Timeouts** settings in the Console:
 
 | **[Annotation name](/docs/deploy/k8s/ingress#set-ingress-annotations)** | **Type** | **Usage** | **Default** |
 | :-- | :-- | :-- | :-- |
-| `idle_timeout` | `string` ([Go Duration](https://golang.org/pkg/time/#Duration.String) formatting) | **optional** | `5m` |
+| `idle_timeout` | `string` ([Go Duration](https://golang.org/pkg/time/#Duration.String) formatting) | **optional** | not set |
 
 ### Examples
 

--- a/content/docs/reference/routes/tls.mdx
+++ b/content/docs/reference/routes/tls.mdx
@@ -21,6 +21,7 @@ This reference covers all of Pomerium's TLS route settings:
 - [TLS Custom Certificate Authority](#tls-custom-certificate-authority)
 - [TLS Downstream Client Certificate Authority](#tls-downstream-client-certificate-authority)
 - [TLS Downstream Server Name](#tls-downstream-server-name)
+- [TLS Server Name](#tls-server-name)
 - [TLS Skip Verification](#tls-skip-verification)
 - [TLS Upstream Allow Renegotiation](#tls-upstream-allow-renegotiation)
 - [TLS Upstream Server Name](#tls-upstream-server-name)
@@ -39,7 +40,7 @@ For more details, see our [mTLS example repository](https://github.com/pomerium/
 | **YAML**/**JSON** setting | **Type** | **Usage** |
 | :-- | :-- | :-- |
 | `tls_client_cert` and `tls_client_key` | `string` (base64-encoded) | **optional** |
-| `tls_client_cert_file` and `tls_client_key_file` | `string` (base64-encoded) | **optional** |
+| `tls_client_cert_file` and `tls_client_key_file` | `string` (file path) | **optional** |
 
 ### Examples \{#examples-tls-client-certificate}
 
@@ -168,9 +169,9 @@ See Kubernetes [TLS Certificates](/docs/deploy/k8s/ingress#tls-certificates) for
 <Tabs>
 <TabItem value="Core" label="Core">
 
-| **Config file keys** | **Environment variables** | **Type** | **Usage** |
-| :-- | :-- | :-- | :-- |
-| `tls_downstream_server_name` | `TLS_DOWNSTREAM_SERVER_NAME` | `string` | **optional** |
+| **YAML**/**JSON** setting    | **Type** | **Usage**    |
+| :--------------------------- | :------- | :----------- |
+| `tls_downstream_server_name` | `string` | **optional** |
 
 </TabItem>
 <TabItem value="Enterprise" label="Enterprise">
@@ -185,6 +186,48 @@ Set **TLS Downstream Server Name** in the Console:
 <TabItem value="Kubernetes" label="Kubernetes">
 
 Kubernetes does not support `tls_downstream_server_name`
+
+</TabItem>
+</Tabs>
+
+## TLS Server Name \{#tls-server-name}
+
+**TLS Server Name** overrides the hostname specified in the `to` field for TLS certificate verification and SNI. This is useful when your backend is an HTTPS server with a valid certificate, but you want to communicate with it using an internal hostname (for example, a Docker container name).
+
+If [`tls_upstream_server_name`](#tls-upstream-server-name) is also set, it takes precedence over this setting.
+
+### How to configure \{#how-to-configure-tls-server-name}
+
+<Tabs>
+<TabItem value="Core" label="Core">
+
+| **YAML**/**JSON** setting | **Type** | **Usage**    |
+| :------------------------ | :------- | :----------- |
+| `tls_server_name`         | `string` | **optional** |
+
+### Examples \{#examples-tls-server-name}
+
+```yaml
+tls_server_name: backend.internal.example.com
+```
+
+</TabItem>
+<TabItem value="Enterprise" label="Enterprise">
+
+Configure **TLS Server Name** in the Console under the route TLS settings.
+
+</TabItem>
+<TabItem value="Kubernetes" label="Kubernetes">
+
+| **[Annotation name](/docs/deploy/k8s/ingress#set-ingress-annotations)** | **Type** | **Usage** |
+| :-- | :-- | :-- |
+| `tls_server_name` | `string` | **optional** |
+
+### Examples
+
+```yaml
+ingress.pomerium.io/tls_server_name: 'backend.internal.example.com'
+```
 
 </TabItem>
 </Tabs>
@@ -281,16 +324,18 @@ Kubernetes does not support **TLS Upstream Allow Renegotiation**
 
 ## TLS Upstream Server Name \{#tls-upstream-server-name}
 
-**TLS Upstream Server Name** overrides the hostname specified in the `to` field. If set, this server name will be used to verify the certificate name. This is useful when the backend of your service is a TLS server with a valid certificate, but mismatched name.
+**TLS Upstream Server Name** overrides the hostname specified in the `to` field for TLS certificate verification and SNI. If set, this server name will be used to verify the certificate name. This is useful when the backend of your service is a TLS server with a valid certificate, but mismatched name.
+
+This setting takes precedence over [`tls_server_name`](#tls-server-name) if both are set.
 
 ### How to configure \{#how-to-configure-tls-upstream-server-name}
 
 <Tabs>
 <TabItem value="Core" label="Core">
 
-| **Config file keys** | **Environment variables** | **Type** | **Usage** |
-| :-- | :-- | :-- | :-- |
-| `tls_upstream_server_name` | `TLS_UPSTREAM_SERVER_NAME` | `string` | **optional** |
+| **YAML**/**JSON** setting  | **Type** | **Usage**    |
+| :------------------------- | :------- | :----------- |
+| `tls_upstream_server_name` | `string` | **optional** |
 
 </TabItem>
 <TabItem value="Enterprise" label="Enterprise">

--- a/content/docs/reference/routes/to.mdx
+++ b/content/docs/reference/routes/to.mdx
@@ -83,7 +83,7 @@ Multiple upstream resources can be targeted by using a list instead of a single 
 
 ### Set load balancing weight
 
-A load balancing weight may be associated with a particular upstream by appending `,[weight]` to the URL. The exact behavior depends on your [`lb_policy`](/docs/reference/routes/load-balancing#load-balancing-policy) setting. See [Load Balancing](/docs/capabilities/routing) for example [configurations](/docs/capabilities/routing#load-balancing-weight).
+A load balancing weight may be associated with a particular upstream by appending `,[weight]` to the URL. The exact behavior depends on your [`load_balancing_policy`](/docs/reference/routes/load-balancing#load-balancing-policy) setting. See [Load Balancing](/docs/capabilities/routing) for example [configurations](/docs/capabilities/routing#load-balancing-weight).
 
 ```yaml
 - from: https://example.com
@@ -184,6 +184,6 @@ While the rule:
 
 All requests to `https://verify.corp.example.com/*` will be forwarded to `https://verify.pomerium.com/anything/*`. That means accessing to `https://verify.corp.example.com` will be forwarded to `https://verify.pomerium.com/anything/`. That said, if your application does not handle trailing slash, the request will end up with 404 not found.
 
-Either `redirect` or `to` must be set.
+Either `to`, [`redirect`](/docs/reference/routes/redirect), or [`response`](/docs/reference/routes/direct-response) must be set.
 
 :::

--- a/content/docs/reference/runtime-flags.md
+++ b/content/docs/reference/runtime-flags.md
@@ -1,5 +1,5 @@
 ---
-# cSpell:ignore keepalive tcpip
+# cSpell:ignore keepalive tcpip GOMAXPROCS
 id: runtime-flags
 title: Runtime Flags
 description: This page lists Runtime Flags available in Pomerium.
@@ -34,12 +34,18 @@ The available flags are:
 
 | Runtime Flag | Description | Default |
 | :-- | :-- | :-- |
+| `add_extra_metrics_labels` | Enables adding extra labels to metrics (host and installation id). | `true` |
+| `authorize_use_synced_data` | Enables synced data for querying the databroker for certain types of data. | `true` |
 | `config_hot_reload` | Enables automatic config reloading triggered whenever a configuration file is written to (either the main Pomerium configuration file or a file referenced from the main configuration). In some rare cases this may not work correctly, so this setting provides a way to disable this behavior. (See issue [#5079](https://github.com/pomerium/pomerium/issues/5079) for more context.) | `true` |
+| `debug_admin_endpoints` | Enables the admin endpoints for the debug listener. | `false` |
 | `envoy_resource_manager` | Monitors control group (cgroup) memory usage of all processes running in the container (including both Pomerium and Envoy) and applies overload actions when memory thresholds are exceeded to reduce memory consumption. See [memory thresholds](#envoy-resource-manager-memory-thresholds) to review thresholds and their corresponding overload actions. | `true` |
-| `grpc_databroker_keepalive` | _(experimental)_ Enables gRPC keep-alive (HTTP/2 PING) requests on the databroker service connection. This may improve service reliability in [split service mode](/docs/internals/configuration#service-mode) deployments where there are multiple firewalls in the connection path between different Pomerium services. | `false` |
+| `grpc_databroker_keepalive` | _(experimental)_ Enables gRPC keep-alive (HTTP/2 PING) requests on the databroker service connection. This may improve service reliability in [split service mode](/docs/internals/configuration#service-mode) deployments where there are multiple firewalls in the connection path between different Pomerium services. | `true` |
 | `match_any_incoming_port` | For a route where the From URL does not contain a port number, allow it to match incoming requests with any port number. See the section on [Port matching behavior](/docs/reference/routes/from#port-matching-behavior) for more details. | `true` |
+| `mcp` | Enables the MCP services for the authorize service. | `false` |
 | `pomerium_jwt_endpoint` | Temporary opt-out of the `/.pomerium/jwt` deprecation: when set to `true`, Pomerium will continue to issue a JWT from the deprecated `/.pomerium/jwt` endpoint. (This endpoint does not provide the desired security properties for the Pomerium JWT and will be removed in a future release.) | `false` |
 | `refresh_session_at_id_token_expiration` | Changes the session refresh behavior so that a session will also be refreshed when the ID token is set to expire. If the identity provider issues a new ID token during refresh, this will allow Pomerium to maintain a valid ID token for the entire lifetime of a session. | `true` |
+| `routes_portal` | Enables the web-based routes portal dashboard. | `true` |
+| `set_envoy_concurrency_to_go_max_procs` | Sets the Envoy concurrency option to GOMAXPROCS. | `true` |
 | `ssh_allow_direct_tcpip` | Allows clients to connect to SSH routes using [Jump Host Mode](/docs/capabilities/native-ssh-access#using-jump-host-mode). | `false` |
 | `ssh_routes_portal` | Enables the SSH routes portal, allowing users to select their SSH destination from an interactive menu when SSHing to Pomerium without specifying a route. | `false` |
 | `ssh_upstream_tunnel` | Enables the `upstream_tunnel` route option. See [Reverse Tunneling](/docs/capabilities/reverse-tunneling). | `false` |

--- a/content/docs/reference/service-mode.mdx
+++ b/content/docs/reference/service-mode.mdx
@@ -2,7 +2,7 @@
 id: service-mode
 title: Service Mode
 description: |
-  Service mode sets the pomerium service(s) to run.
+  Sets which Pomerium services to run. Accepts a comma-separated list.
 keywords:
   - reference
   - Service Mode
@@ -18,7 +18,7 @@ import Tabs from '@theme/Tabs';
 
 ## Summary
 
-**Service Mode** sets which service(s) to run. When set to `all` (the default), Pomerium runs in [all-in-one mode](/docs/internals/configuration#all-in-one-vs-split-service-mode).
+**Service Mode** sets which service or services to run. It accepts a comma-separated list. When set to `all` (the default), Pomerium runs in [all-in-one mode](/docs/internals/configuration#all-in-one-vs-split-service-mode).
 
 To instead run in [split service mode](/docs/internals/configuration#discrete-services), you will need to deploy multiple instances of Pomerium: at least one replica of each of the four services.
 
@@ -38,15 +38,16 @@ To instead run in [split service mode](/docs/internals/configuration#discrete-se
 - `authorize`
 - `proxy`
 - `databroker`
+- `cache` (accepted as an alias for `databroker`)
 
 ### Examples
 
 ```yaml
-services: authorize
+services: authenticate,proxy
 ```
 
 ```bash
-SERVICES=databroker
+SERVICES=authenticate,proxy
 ```
 
 </TabItem>

--- a/content/docs/reference/service-urls.md
+++ b/content/docs/reference/service-urls.md
@@ -271,14 +271,11 @@ The **Databroker Internal Service URL** overrides [`databroker_service_url`](/do
 | **Config file keys** | **Environment variables** | **Type** | **Default** |
 | :-- | :-- | :-- | :-- |
 | `databroker_internal_service_url` | `DATABROKER_INTERNAL_SERVICE_URL` | `URL` | `http://localhost:5443` (In all-in-one mode) |
-| `databroker_internal_service_urls` | `DATABROKER_INTERNAL_SERVICE_URLS` | `URL` | `http://localhost:5443` (In all-in-one mode) |
 
 #### Examples \{#databroker-internal-service-url-examples}
 
 ```yaml
-databroker_internal_service_urls:
-  - http://localhost:5443
-  - http://service_url.com
+databroker_internal_service_url: http://localhost:5443
 ```
 
 ```bash
@@ -288,7 +285,7 @@ DATABROKER_INTERNAL_SERVICE_URL=http://localhost:5443
 </TabItem>
 <TabItem value="Enterprise" label="Enterprise">
 
-`databroker_internal_service_url` and `databroker_internal_service_urls` are bootstrap configuration settings and are not configurable in the Console.
+`databroker_internal_service_url` is a bootstrap configuration setting and is not configurable in the Console.
 
 </TabItem>
 <TabItem value="Kubernetes" label="Kubernetes">

--- a/content/docs/reference/set-response-headers.mdx
+++ b/content/docs/reference/set-response-headers.mdx
@@ -27,7 +27,7 @@ import EnterpriseConfiguration from '../../../src/components/EnterpriseConfigura
 
 | **Config file keys** | **Environment variables** | **Type** | **Default** |
 | :-- | :-- | :-- | :-- |
-| `set_response_headers` | `SET_RESPONSE_HEADERS` | `string` | see [Default headers](#default) |
+| `set_response_headers` | `HEADERS` | map of `string` key-value pairs | see [Default headers](#default) |
 
 ### Examples
 
@@ -77,7 +77,6 @@ ingress.pomerium.io/set_response_headers: |
 ### Default headers \{#default}
 
 ```headers
-X-Content-Type-Options : nosniff,
 X-Frame-Options:SAMEORIGIN,
 X-XSS-Protection:1; mode=block,
 Strict-Transport-Security:max-age=31536000; includeSubDomains; preload,

--- a/content/docs/reference/shared-secret.mdx
+++ b/content/docs/reference/shared-secret.mdx
@@ -30,10 +30,10 @@ If you adjust your shared secret and/or how it's accessed by Pomerium, you may c
 <Tabs>
 <TabItem value="Core" label="Core">
 
-| **Config file keys** | **Environment variables** | **Type** | **Usage**    |
-| :------------------- | :------------------------ | :------- | :----------- |
-| `shared_secret`      | `SHARED_SECRET`           | `string` | **required** |
-| `shared_secret_file` | `SHARED_SECRET_FILE`      | `string` | **required** |
+| **Config file keys** | **Environment variables** | **Type** | **Usage** |
+| :-- | :-- | :-- | :-- |
+| `shared_secret` | `SHARED_SECRET` | `string` | **required** (unless `shared_secret_file` is set) |
+| `shared_secret_file` | `SHARED_SECRET_FILE` | `string` | **required** (unless `shared_secret` is set) |
 
 :::enterprise Shared Secret in Enterprise Configurations
 

--- a/content/docs/reference/signout-redirect-url.mdx
+++ b/content/docs/reference/signout-redirect-url.mdx
@@ -27,7 +27,7 @@ You can overwrite this behavior by passing the query param `pomerium_redirect_ur
 
 | **Config file keys**   | **Environment variables** | **Type** | **Usage**    |
 | :--------------------- | :------------------------ | :------- | :----------- |
-| `signout_redirect_url` | `SIGNOUT_REDIRECT_URL`    | `URL`    | **required** |
+| `signout_redirect_url` | `SIGNOUT_REDIRECT_URL`    | `URL`    | **optional** |
 
 ### Examples
 

--- a/content/docs/reference/tls-derive.mdx
+++ b/content/docs/reference/tls-derive.mdx
@@ -28,7 +28,7 @@ Auto TLS secures HTTPS and gRPC/TLS endpoints connecting the Console to the Data
 
 | **Config file keys** | **Environment variables** | **Type** | **Usage** | **Default** |
 | :-- | :-- | :-- | :-- | :-- |
-| `tls_derive` | `TLS_DERIVE` | `FQDL` (fully qualified domain name) | **optional** | none |
+| `tls_derive` | `TLS_DERIVE` | `string` (fully qualified domain name) | **optional** | none |
 
 ### Examples
 
@@ -50,7 +50,7 @@ TLS_DERIVE=www.example.domain.com
 
 | **Name** | **Type** | **Usage** | **Default** |
 | :-- | :-- | :-- | :-- |
-| `--databroker-auto-tls` (runtime parameter) | `FQDL` (fully qualified domain name) | **optional** | none |
+| `--databroker-auto-tls` (runtime parameter) | `string` (fully qualified domain name) | **optional** | none |
 
 </TabItem>
 </Tabs>

--- a/cspell.json
+++ b/cspell.json
@@ -173,6 +173,7 @@
     "quickstarts",
     "redocusaurus",
     "refreshdirectory",
+    "reprovision",
     "rego",
     "Remmina",
     "roundrobin",
@@ -299,6 +300,23 @@
     "CIMD",
     "inlines",
     "onhostcontextchanged",
-    "ontoolresult"
+    "ontoolresult",
+    "Beelink",
+    "controlplane",
+    "dogfood",
+    "dogfooding",
+    "domcontentloaded",
+    "gitops",
+    "homelab",
+    "hyperscaler",
+    "ipaddresspool",
+    "jsonencode",
+    "kubeconfig",
+    "metallb",
+    "Minisforum",
+    "orbctl",
+    "orbstack",
+    "siderolabs",
+    "talosctl"
   ]
 }


### PR DESCRIPTION
## Summary

Systematically audited every reference documentation page (74 total) against the actual Go source code, protobuf definitions, and Envoy config builders in `pomerium/pomerium` to verify config keys, types, defaults, accepted values, and behavioral descriptions.

- **44 files changed**, 293 insertions, 192 deletions
- 10 parallel audit agents, each reading docs + code + Envoy docs
- Codex independently verified 20 key findings (19/20 confirmed, 1 partial on pre-existing macOS path)

### Wrong config keys / env vars (would cause config failures)
- `metrics.mdx`: `metrics_basic_authentication` -> `metrics_basic_auth` (options.go:216)
- `metrics.mdx`: `METRICS_CERTIFICATE_FILE_KEY` -> `METRICS_CERTIFICATE_KEY_FILE` (options.go:221)
- `dns.mdx`: `default_lookup_family` -> `dns_lookup_family` in examples (options_dns.go:28)
- `set-response-headers.mdx`: env var `SET_RESPONSE_HEADERS` -> `HEADERS` (options.go:567)

### Wrong defaults (would mislead users)
- `runtime-flags.md`: `grpc_databroker_keepalive` default `false` -> `true` (runtime_flags.go:25); added 6 missing flags (15 total now match code)
- `dns.mdx`: 4 defaults claimed specific values but code uses nil/Envoy defaults
- `set-response-headers.mdx`: removed phantom `X-Content-Type-Options: nosniff` default header
- `timeouts.mdx`: idle timeout default `5m` -> not set (Envoy default applies)
- `cookies.mdx`: CookieSameSite default `Lax` -> not set (browsers default to Lax)

### Wrong types
- `jwt-claim-headers.mdx`: `string` -> `map of string` (custom.go:105)
- `headers.mdx`: 3 type mismatches fixed (`remove_request_headers`, `set_response_headers`, `rewrite_response_headers`)
- `certificates.mdx`: `certificates` type corrected to array of objects with cert/key
- `policy.mdx`: `string` -> `object` (PPL rule block)

### Missing documentation
- `access-log-fields.mdx`: added 2 fields (`client-certificate`, `cluster-stat-name`)
- `authorize-log-fields.mdx`: added 5 fields (including route checksums)
- `tls.mdx`: entire `tls_server_name` section was missing
- `circuit-breaker-thresholds.mdx`: added global/route/internal cluster layering explanation

### Removed fake env vars for per-route settings
- `additional-login-redirect-hosts.mdx`, `enable-google-cloud-serverless-authentication.mdx`, `tls.mdx`

### Incorrect descriptions
- `cluster-name.mdx`: full rewrite -- was "Cluster Name", now accurately describes `name` setting
- `show-error-details.mdx`: removed incorrect branding claim
- `address.mdx`: "HTTP" -> "HTTPS"
- `databroker.mdx`: connection string only required for postgres, not file

## Test plan

- [x] `npx prettier --check` -- passed
- [x] `npx cspell` -- passed (0 issues)
- [x] `yarn build` -- passed (pre-existing broken anchors in unrelated pages only)
- [x] Codex independently verified 20 key code claims

## AI disclosure

AI drafted all changes across 10 parallel audit agents. Each agent read the doc page, the corresponding Go struct/mapstructure tags, default values, and consumption sites, then compared and fixed. Codex independently verified findings against the code. Human reviewed agent summaries, consolidated reference.json updates, and approved the final diff.