### PR TITLE
[backport to 0-32-0] docs: document unified upstream OAuth pipeline for MCP

### DIFF
--- a/content/docs/capabilities/mcp.mdx
+++ b/content/docs/capabilities/mcp.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Model Context Protocol (MCP) Support"
-sidebar_label: "Model Context Protocol (MCP)"
+title: 'Model Context Protocol (MCP) Support'
+sidebar_label: 'Model Context Protocol (MCP)'
 lang: en-US
-description: "Secure access to Model Context Protocol servers through Pomerium, enabling AI agents to safely interact with internal resources via standardized interfaces."
+description: 'Secure access to Model Context Protocol servers through Pomerium, enabling AI agents to safely interact with internal resources via standardized interfaces.'
 keywords:
   [
     MCP,
@@ -29,16 +29,19 @@ See [Protect an MCP Server](/docs/capabilities/mcp/protect-mcp-server) for setup
 
 ### MCP Bridging
 
-Pomerium acts as an **MCP-aware bridge** between your clients and remote third-party MCP servers that have their own authentication and authorization. Rather than exposing upstream credentials to each client, Pomerium sits in the middle and handles the full upstream OAuth lifecycle on the user's behalf.
+Pomerium acts as an **MCP-aware bridge** that manages upstream OAuth on behalf of your users. This applies to two scenarios:
+
+- **Third-party hosted MCP servers** (GitHub, Linear, Notion, Google) that enforce their own OAuth — Pomerium handles the upstream auth flow transparently.
+- **Self-hosted MCP servers** that call upstream APIs — your server receives a valid upstream access token on every proxied request without implementing OAuth itself.
 
 When a client connects to a Pomerium-fronted MCP route, Pomerium:
 
 - **Authenticates the user** through your identity provider (downstream OAuth 2.1)
-- **Authenticates with the upstream MCP server** by managing the upstream OAuth flow — acquiring, caching, and automatically refreshing access tokens
+- **Authenticates with the upstream service** by managing the upstream OAuth flow — acquiring, caching, and automatically refreshing access tokens
 - **Enforces authorization policies** on every request, including fine-grained tool-level access control
-- **Injects the upstream token** into proxied requests transparently — your MCP server receives a valid bearer token without the client ever seeing it
+- **Injects the upstream token** into proxied requests transparently — clients never see upstream credentials
 
-This means third-party MCP servers with their own auth (GitHub, Linear, Notion, Google, and others) can be securely bridged through Pomerium. Clients authenticate once with Pomerium and never handle upstream credentials directly. Pomerium supports both static OAuth2 configuration (where you register client credentials) and automatic [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) discovery for MCP servers that advertise their own authorization requirements.
+Pomerium uses a unified upstream OAuth pipeline that adapts to what you configure — from pre-registered credentials for providers that require manual app registration (GitHub, Google), to full auto-discovery via [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) for MCP servers that advertise their own authorization requirements.
 
 See [MCP + Upstream OAuth](/docs/capabilities/mcp/mcp-upstream-oauth) for setup instructions.
 
@@ -75,12 +78,12 @@ See [Tunnel to ChatGPT During Development](/docs/capabilities/mcp/tunnel-to-chat
 
 ## Blueprints
 
-| Blueprint                                                                   | Description                                                                                |
-| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| [Protect an MCP Server](/docs/capabilities/mcp/protect-mcp-server)          | Proxy an internal MCP server through Pomerium — no auth logic needed on the server side    |
-| [MCP + Upstream OAuth](/docs/capabilities/mcp/mcp-upstream-oauth)           | Bridge to upstream OAuth2 APIs like GitHub, Google Drive, or Notion                        |
-| [Tunnel to ChatGPT](/docs/capabilities/mcp/tunnel-to-chatgpt)               | Expose a local MCP server to ChatGPT for development and testing                           |
-| [Limit MCP Tool Calling](/docs/capabilities/mcp/limit-mcp-tools)            | Control which MCP tools each user or group can call with PPL policies                      |
-| [Develop an MCP App](/docs/capabilities/mcp/develop-mcp-app)                | Build interactive ChatGPT Apps with custom widgets and tools                               |
-| [Delegate MCP Access to an LLM](/docs/capabilities/mcp/delegate-mcp-to-llm) | Pass the user's token to an LLM so it can call MCP servers on their behalf                 |
-| [MCP Full Reference](/docs/capabilities/mcp/reference)                      | Configuration options, token types, security details, session lifecycle, and observability |
+| Blueprint | Description |
+| --- | --- |
+| [Protect an MCP Server](/docs/capabilities/mcp/protect-mcp-server) | Proxy an internal MCP server through Pomerium — no auth logic needed on the server side |
+| [MCP + Upstream OAuth](/docs/capabilities/mcp/mcp-upstream-oauth) | Bridge to upstream OAuth2 APIs like GitHub, Google Drive, or Notion |
+| [Tunnel to ChatGPT](/docs/capabilities/mcp/tunnel-to-chatgpt) | Expose a local MCP server to ChatGPT for development and testing |
+| [Limit MCP Tool Calling](/docs/capabilities/mcp/limit-mcp-tools) | Control which MCP tools each user or group can call with PPL policies |
+| [Develop an MCP App](/docs/capabilities/mcp/develop-mcp-app) | Build interactive ChatGPT Apps with custom widgets and tools |
+| [Delegate MCP Access to an LLM](/docs/capabilities/mcp/delegate-mcp-to-llm) | Pass the user's token to an LLM so it can call MCP servers on their behalf |
+| [MCP Full Reference](/docs/capabilities/mcp/reference) | Configuration options, token types, security details, session lifecycle, and observability |

--- a/content/docs/capabilities/mcp/mcp-upstream-oauth.mdx
+++ b/content/docs/capabilities/mcp/mcp-upstream-oauth.mdx
@@ -1,9 +1,9 @@
 ---
-title: "MCP + Upstream OAuth"
-sidebar_label: "MCP + Upstream OAuth"
+title: 'MCP + Upstream OAuth'
+sidebar_label: 'MCP + Upstream OAuth'
 sidebar_position: 2
 lang: en-US
-description: "Bridge MCP servers that have their own authentication — using static OAuth2 credentials or automatic RFC 9728 discovery."
+description: 'Bridge MCP servers that have their own authentication — using static OAuth2 credentials or automatic RFC 9728 discovery.'
 keywords:
   [
     MCP,
@@ -20,14 +20,20 @@ keywords:
 
 # MCP + Upstream OAuth
 
-Many MCP servers require their own authentication — either because they front an upstream API (GitHub, Google Drive, Notion) or because the MCP server itself enforces OAuth. Pomerium manages the entire upstream OAuth flow and token lifecycle so your clients never handle upstream credentials directly.
+Upstream OAuth applies to two scenarios:
 
-Pomerium supports two modes:
+- **Third-party hosted MCP servers** (Notion, Linear, Google) that enforce their own OAuth — Pomerium handles the upstream auth flow so your users authenticate once and tool calls are proxied with valid tokens.
+- **Self-hosted MCP servers** that call upstream APIs under the hood — your server receives a valid upstream access token in the `Authorization: Bearer` header on every proxied request, so it never needs to implement OAuth itself.
 
-- **Static OAuth2** — you register client credentials and endpoints in your route config. Best for upstream APIs where you control the OAuth app registration (GitHub Apps, Google Cloud, etc.).
-- **Auto-discovery** — Pomerium automatically discovers the server's authorization requirements at runtime using [RFC 9728 Protected Resource Metadata](https://datatracker.ietf.org/doc/html/rfc9728). Best for third-party MCP servers that advertise their own OAuth configuration.
+In both cases, external MCP clients only hold a Pomerium-issued token (TE) and never see upstream credentials.
 
-In both modes, your MCP server receives a valid upstream token on every proxied request — no OAuth logic needed on the server side. External clients only hold a Pomerium-issued external token (TE) and never see the upstream token.
+Pomerium uses a unified upstream OAuth pipeline that adapts based on what you configure. The [MCP authorization spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization) defines a priority order for how clients identify themselves to upstream authorization servers:
+
+1. **Pre-registered credentials** — use when the upstream authorization server requires manual app registration and does not support automatic client registration. You supply `client_id` and `client_secret` (and optionally endpoints) in your route config.
+2. **[CIMD](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document)** — the recommended automatic mechanism. Pomerium publishes its client metadata at an HTTPS URL that serves as its `client_id`. The upstream AS fetches metadata on demand.
+3. **[DCR](https://datatracker.ietf.org/doc/html/rfc7591)** — a fallback for authorization servers that support dynamic registration but not CIMD.
+
+When no `upstream_oauth2` config is present, Pomerium tries CIMD first, then falls back to DCR. When `client_id` and `client_secret` are provided, Pomerium uses them directly and skips automatic registration. When endpoints are also provided, Pomerium skips [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) discovery as well.
 
 ## Architecture
 
@@ -55,7 +61,7 @@ sequenceDiagram
 
 ## Static OAuth2
 
-Use static OAuth2 when you have pre-registered OAuth credentials for the upstream service.
+Use static OAuth2 when you have pre-registered OAuth credentials and know the provider's endpoints.
 
 ### Configuration
 
@@ -72,10 +78,14 @@ routes:
         upstream_oauth2:
           client_id: xxxxxxxxxxxx
           client_secret: yyyyyyyyy
-          scopes: ["read:user", "user:email"]
+          scopes: ['read:user', 'user:email']
           endpoint:
-            auth_url: "https://github.com/login/oauth/authorize"
-            token_url: "https://github.com/login/oauth/access_token"
+            auth_url: 'https://github.com/login/oauth/authorize'
+            token_url: 'https://github.com/login/oauth/access_token'
+          # Optional: extra query parameters for the authorization URL
+          # authorization_url_params:
+          #   access_type: 'offline'
+          #   prompt: 'consent'
     policy:
       allow:
         and:
@@ -84,7 +94,7 @@ routes:
       deny:
         and:
           - mcp_tool:
-              starts_with: "admin_"
+              starts_with: 'admin_'
 ```
 
 :::warning Experimental Feature
@@ -100,7 +110,7 @@ MCP support is currently an experimental feature only available in the `main` br
 Register an OAuth application with the upstream service. For GitHub:
 
 1. Go to **Settings → Developer settings → OAuth Apps → New OAuth App**
-2. Set the authorization callback URL to your Pomerium authenticate service URL
+2. Set the **authorization callback URL** to `https://<your-route-from-domain>/.pomerium/mcp/client/oauth/callback` — for example, if your route's `from` is `https://github.your-domain.com`, the callback URL is `https://github.your-domain.com/.pomerium/mcp/client/oauth/callback`
 3. Note the **Client ID** and **Client Secret**
 
 For other providers, refer to their OAuth documentation. You need:
@@ -108,6 +118,7 @@ For other providers, refer to their OAuth documentation. You need:
 - `client_id` and `client_secret`
 - `auth_url` and `token_url` endpoints
 - The appropriate `scopes` for your use-case
+- The **redirect/callback URI** set to `https://<your-route-from-domain>/.pomerium/mcp/client/oauth/callback`
 
 #### 2. Configure the route
 
@@ -134,11 +145,54 @@ After both steps, the client receives an external token (TE) and can make tool c
 
 ### Common upstream providers
 
-| Provider | Auth URL                                    | Token URL                                     | Common Scopes                                    |
-| -------- | ------------------------------------------- | --------------------------------------------- | ------------------------------------------------ |
-| GitHub   | `https://github.com/login/oauth/authorize`  | `https://github.com/login/oauth/access_token` | `read:user`, `repo`                              |
-| Google   | `https://accounts.google.com/o/oauth2/auth` | `https://oauth2.googleapis.com/token`         | `https://www.googleapis.com/auth/drive.readonly` |
-| Notion   | `https://api.notion.com/v1/oauth/authorize` | `https://api.notion.com/v1/oauth/token`       | — (configured in integration)                    |
+| Provider | Auth URL | Token URL | Common Scopes |
+| --- | --- | --- | --- |
+| GitHub | `https://github.com/login/oauth/authorize` | `https://github.com/login/oauth/access_token` | `read:user`, `repo` |
+| Google | `https://accounts.google.com/o/oauth2/auth` | `https://oauth2.googleapis.com/token` | `https://www.googleapis.com/auth/drive.readonly` |
+| Notion | `https://api.notion.com/v1/oauth/authorize` | `https://api.notion.com/v1/oauth/token` | — (configured in integration) |
+
+## Pre-Registered Credentials
+
+Use this mode when the upstream authorization server does not support automatic client registration (neither [CIMD](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document) nor [DCR](https://datatracker.ietf.org/doc/html/rfc7591)). You register an OAuth app manually with the provider and supply the credentials in your route config. Pomerium can still discover the authorization and token endpoints automatically via [RFC 9728 PRM](https://datatracker.ietf.org/doc/html/rfc9728) if the upstream advertises them — you only need to provide `endpoint` when it doesn't.
+
+This is the common case for providers like Google Cloud and GitHub, where you must create an OAuth app in their console.
+
+When registering your OAuth app, set the redirect/callback URI to `https://<your-route-from-domain>/.pomerium/mcp/client/oauth/callback`.
+
+### Configuration
+
+{/* spellchecker: disable */}
+
+```yaml
+routes:
+  - from: https://firestore.your-domain.com
+    to: https://firestore.googleapis.com/
+    name: Google Firestore
+    mcp:
+      server:
+        path: /mcp
+        upstream_oauth2:
+          client_id: <your-google-oauth-client-id>
+          client_secret: <your-google-oauth-client-secret>
+          scopes: ['https://www.googleapis.com/auth/datastore']
+          authorization_url_params:
+            access_type: 'offline'
+            prompt: 'consent'
+    policy:
+      allow:
+        and:
+          - domain:
+              is: company.com
+```
+
+{/* spellchecker: enable */}
+
+Note the absence of `endpoint` — Pomerium discovers `accounts.google.com` as the authorization server from the upstream server's [Protected Resource Metadata](https://datatracker.ietf.org/doc/html/rfc9728). You still need to add `accounts.google.com` to `mcp_allowed_as_metadata_domains` since it's a third-party domain not derivable from the route config:
+
+```yaml
+mcp_allowed_as_metadata_domains:
+  - 'accounts.google.com'
+```
 
 ## Auto-Discovery (RFC 9728)
 
@@ -182,10 +236,10 @@ The `mcp.server` block without `upstream_oauth2` tells Pomerium to use auto-disc
 
 **Optional settings:**
 
-| Setting                               | Description                                                               |
-| ------------------------------------- | ------------------------------------------------------------------------- |
-| `mcp.server.path`                     | Sub-path appended to the upstream URL for the MCP endpoint (e.g., `/mcp`) |
-| `mcp.server.authorization_server_url` | Fallback Authorization Server URL if PRM discovery fails. Must be HTTPS.  |
+| Setting | Description |
+| --- | --- |
+| `mcp.server.path` | Sub-path appended to the upstream URL for the MCP endpoint (e.g., `/mcp`) |
+| `mcp.server.authorization_server_url` | Fallback Authorization Server URL if PRM discovery fails. Must be HTTPS. |
 
 **Global settings for auto-discovery:**
 
@@ -194,18 +248,18 @@ Auto-discovery involves fetching metadata documents from URLs that originate in 
 ```yaml
 # Domains allowed to serve Client ID Metadata Documents (CIMD)
 mcp_allowed_client_id_domains:
-  - "vscode.dev"
-  - "*.trusted-provider.com"
+  - 'vscode.dev'
+  - '*.trusted-provider.com'
 
 # Domains allowed for upstream Authorization Server and Protected Resource Metadata fetches
 mcp_allowed_as_metadata_domains:
-  - "auth.example.com"
-  - "*.oauth-provider.com"
+  - 'auth.example.com'
+  - '*.oauth-provider.com'
 ```
 
-| Setting                           | Description                                                                                                                                                                                                       |
-| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `mcp_allowed_client_id_domains`   | Domains that may serve Client ID Metadata Documents. Required when MCP clients use URL-based client IDs. Supports wildcards (e.g. `*.example.com`).                                                               |
+| Setting | Description |
+| --- | --- |
+| `mcp_allowed_client_id_domains` | Domains that may serve Client ID Metadata Documents. Required when MCP clients use URL-based client IDs. Supports wildcards (e.g. `*.example.com`). |
 | `mcp_allowed_as_metadata_domains` | Domains Pomerium may contact during upstream OAuth discovery — this includes `resource_metadata` URLs from `WWW-Authenticate` headers and `authorization_servers` entries from PRM documents. Supports wildcards. |
 
 ### Step-by-step

--- a/content/docs/capabilities/mcp/reference.mdx
+++ b/content/docs/capabilities/mcp/reference.mdx
@@ -171,6 +171,25 @@ mcp_allowed_client_id_domains:
 - Wildcard patterns like `*.example.com` match subdomains (e.g., `app.example.com`) but not the bare domain
 - If a client attempts to use a client ID from a domain not in the allowed list, Pomerium displays a user-friendly error page explaining the restriction, along with the request ID and the attempted client ID for troubleshooting
 
+#### Allowed AS Metadata Domains
+
+When Pomerium performs upstream OAuth discovery (for both auto-discovery and pre-registered credential modes), it fetches metadata documents from URLs that originate in upstream server responses. To protect against SSRF, these URLs are validated against a domain allowlist.
+
+```yaml
+mcp_allowed_as_metadata_domains:
+  - 'accounts.google.com'
+  - '*.oauth-provider.com'
+```
+
+| Setting | Description |
+| --- | --- |
+| `mcp_allowed_as_metadata_domains` | Domains Pomerium may contact during upstream OAuth discovery. This includes `resource_metadata` URLs from `WWW-Authenticate` headers and `authorization_servers` entries from PRM documents. Supports wildcard patterns. |
+
+**What needs to be listed:**
+
+- The route's upstream (`to`) domain is used for PRM fetches and is validated against this list
+- Third-party authorization server domains discovered inside PRM documents (e.g. `accounts.google.com` for Google APIs) must be explicitly added — they cannot be inferred from route config
+
 **Example error scenario:**
 
 If a user tries to authorize with a client ID like `https://untrusted-app.com/oauth/client` and `untrusted-app.com` is not in `mcp_allowed_client_id_domains`, they will see an error page stating:
@@ -195,10 +214,32 @@ mcp:
         token_url: 'https://provider.com/oauth/token'
         auth_style: 'header' # or "params"
       scopes: ['scope1', 'scope2']
+      # Optional: extra query parameters for the authorization URL
+      authorization_url_params:
+        access_type: 'offline' # Google: required for refresh tokens
+        prompt: 'consent' # Google: force re-consent to get new refresh token
 
     # Optional: Maximum request body size (default: 4KiB)
     max_request_bytes: 1048576
+
+    # Optional: Sub-path appended to the upstream URL for the MCP endpoint
+    path: '/mcp'
+
+    # Optional: Fallback AS issuer URL when PRM discovery fails (must be HTTPS)
+    authorization_server_url: 'https://auth.provider.com'
 ```
+
+All `upstream_oauth2` fields are optional. Pomerium uses a unified pipeline that adapts based on what you configure:
+
+| What you provide | What Pomerium does |
+| --- | --- |
+| Everything (`client_id`, `client_secret`, `endpoint`) | Uses your credentials and endpoints directly — no discovery or registration |
+| `client_id` + `client_secret` (no `endpoint`) | Discovers endpoints via [RFC 9728 PRM](https://datatracker.ietf.org/doc/html/rfc9728), uses your credentials — no dynamic registration |
+| Nothing | Full auto-discovery: discovers endpoints, registers as a client via CIMD/DCR, manages the full lifecycle |
+
+`client_secret` is never stored per-user — it is read from the route config at token refresh time.
+
+When using static or pre-registered credentials, set the OAuth app's **redirect/callback URI** to `https://<your-route-from-domain>/.pomerium/mcp/client/oauth/callback`. In auto-discovery mode, this is handled automatically via CIMD or DCR.
 
 ** Tool Call Authorization **
 

--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -1037,6 +1037,14 @@
     "path": "/../capabilities/device-identity",
     "title": "Manage Devices"
   },
+  "mcp-allowed-as-metadata-domains": {
+    "description": "Domains Pomerium may contact during upstream OAuth discovery. Includes resource_metadata URLs from WWW-Authenticate headers and authorization_servers entries from PRM documents. Supports wildcard patterns.",
+    "id": "mcp-allowed-as-metadata-domains",
+    "path": "/../capabilities/mcp/reference#allowed-as-metadata-domains",
+    "services": [],
+    "title": "MCP Allowed AS Metadata Domains",
+    "type": "array of strings"
+  },
   "mcp-allowed-client-id-domains": {
     "description": "List of allowed domain patterns for MCP client ID metadata URLs. Supports wildcard patterns (e.g., *.example.com). Required when using URL-based client IDs.",
     "id": "mcp-allowed-client-id-domains",
@@ -1044,6 +1052,13 @@
     "services": [],
     "title": "MCP Allowed Client ID Domains",
     "type": "array of strings"
+  },
+  "mcp-server-authorization-server-url": {
+    "description": "Fallback Authorization Server URL used when RFC 9728 PRM discovery fails. Must be HTTPS.",
+    "id": "mcp-server-authorization-server-url",
+    "path": "/../capabilities/mcp/reference#mcp-server-configuration",
+    "title": "MCP Server Authorization Server URL",
+    "type": "string"
   },
   "mcp-server-max-request-bytes": {
     "description": "Maximum MCP request size in bytes. Adjust if you are passing some large payloads that cause errors.",
@@ -1079,6 +1094,13 @@
     "path": "/../capabilities/mcp/reference#mcp-server-configuration",
     "title": "MCP Server Upstream OAuth2 Authentication URL",
     "type": "string"
+  },
+  "mcp-server-upstream-oauth2-authorization-url-params": {
+    "description": "Extra query parameters appended to the OAuth authorization URL (e.g., access_type, prompt, audience).",
+    "id": "mcp-server-upstream-oauth2-authorization-url-params",
+    "path": "/../capabilities/mcp/reference#mcp-server-configuration",
+    "title": "MCP Server Upstream OAuth2 Authorization URL Params",
+    "type": "map of strings"
   },
   "mcp-server-upstream-oauth2-client-id": {
     "description": "OAuth client identifier issued by the upstream provider.",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9639,10 +9639,10 @@ postcss@^8.4.21, postcss@^8.4.24, postcss@^8.4.33, postcss@^8.4.45, postcss@^8.5
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
-prettier-plugin-sort-json@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-sort-json/-/prettier-plugin-sort-json-4.1.1.tgz#2cf2e71c5a2174440330b3c72e3bc69112df3ffb"
-  integrity sha512-uJ49wCzwJ/foKKV4tIPxqi4jFFvwUzw4oACMRG2dcmDhBKrxBv0L2wSKkAqHCmxKCvj0xcCZS4jO2kSJO/tRJw==
+prettier-plugin-sort-json@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-sort-json/-/prettier-plugin-sort-json-4.2.0.tgz#94e5e361b9b9998b0cf3daa60d13773c1a91958f"
+  integrity sha512-jK1w3/7otTvHtv1eoLji2U9mEoOGeyl7QQQ/afLnjht1YtRLSUUk8o0rIIC/HUVXhoGPCFe4SVZbRGYjjUVgvA==
 
 prettier@^3.6.2:
   version "3.6.2"


### PR DESCRIPTION
## Summary
Backport of #2109 to the `0-32-0` release branch.

- Documents the unified upstream OAuth pipeline for MCP (static OAuth2, pre-registered credentials, auto-discovery)
- Grounds docs in MCP spec terminology (CIMD, DCR, PRM)
- Adds `authorization_url_params` example and OAuth callback URL guidance
- Adds missing MCP reference entries

## Test plan
- [ ] Verify deploy preview renders correctly
- [ ] Confirm no broken links in MCP docs section