### PR TITLE
gateway API overview: fix typo

### DIFF
--- a/content/docs/deploy/k8s/gateway-api.mdx
+++ b/content/docs/deploy/k8s/gateway-api.mdx
@@ -89,7 +89,7 @@ To install the Pomerium Ingress Controller with support for Gateway API:
 
    :::info
 
-   You don't need to include any certificates in this global configuration when usnig the Gateway API, as certificates are instead defined on individual Gateway listeners.
+   You don't need to include any certificates in this global configuration when using the Gateway API, as certificates are instead defined on individual Gateway listeners.
 
    :::
 


### PR DESCRIPTION
Fix a typo in the Gateway API overview page.