### PR TITLE
docs: backport v0.32.0 entry to 0-31-0 docVersions.json

### DIFF
--- a/src/components/docVersions.json
+++ b/src/components/docVersions.json
@@ -7,6 +7,10 @@
     "id": "v0.31.x",
     "link": "https://0-31-0.docs.pomerium.com/docs"
   },
+  "0.32.0": {
+    "id": "v0.32.x",
+    "link": "https://0-32-0.docs.pomerium.com/docs"
+  },
   "vNext": {
     "id": "vNext",
     "link": "https://main.docs.pomerium.com/docs"


### PR DESCRIPTION
## Summary

- Backports the v0.32.0 entry to the `0-31-0` branch so visitors on the v0.31.x docs can navigate to v0.32.x
- Cherry-pick of the main PR (#2148)

## AI Disclosure

Drafted by Claude. Bobby reviewed and approved.

Related: ENG-3883