### PR TITLE
docs: add architecture and capabilities diagrams to MCP overview

### DIFF
--- a/content/docs/capabilities/mcp.mdx
+++ b/content/docs/capabilities/mcp.mdx
@@ -19,7 +19,17 @@ keywords:
 
 Pomerium provides secure access to [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers, enabling AI agents and applications to safely interact with your internal resources through standardized interfaces.
 
+## Architecture
+
+Pomerium sits between MCP clients and your internal servers, handling authentication, authorization, and observability for every request.
+
+![Pomerium MCP gateway architecture: MCP clients connect through Pomerium's authentication, authorization, and observability layers to internal MCP servers and upstream APIs](./mcp/img/mcp-overview/architecture.svg)
+
 ## Key Capabilities
+
+Pomerium provides a unified control plane for MCP traffic across your organization:
+
+![Pomerium MCP capabilities: authentication and identity, governance and access control, observability, and developer experience](./mcp/img/mcp-overview/capabilities.svg)
 
 ### Secure MCP Gateway
 

--- a/content/docs/capabilities/mcp/img/mcp-overview/architecture.d2
+++ b/content/docs/capabilities/mcp/img/mcp-overview/architecture.d2
@@ -1,0 +1,104 @@
+# Pomerium MCP Gateway — Inside the Gateway
+#
+# Regenerate:  d2 architecture.d2 architecture.svg
+
+direction: right
+
+vars: {
+  d2-config: {
+    pad: 40
+  }
+}
+
+classes: {
+  endpoint: {
+    # Transparent rectangle so arrows stop short of the text label
+    shape: rectangle
+    width: 260
+    height: 100
+    style: {
+      fill: transparent
+      stroke: transparent
+      font-size: 40
+      bold: true
+      font-color: "#0F172A"
+    }
+  }
+  capability: {
+    shape: rectangle
+    width: 280
+    height: 90
+    style: {
+      fill: "#FFFFFF"
+      stroke: "#6F43E7"
+      stroke-width: 2
+      border-radius: 12
+      font-size: 28
+      bold: true
+      font-color: "#2E1065"
+    }
+  }
+}
+
+clients: "MCP Clients" {
+  class: endpoint
+}
+
+pomerium: "Pomerium Gateway" {
+  grid-columns: 3
+  grid-gap: 32
+
+  style: {
+    fill: "#F3EEFF"
+    stroke: "#6F43E7"
+    stroke-width: 4
+    border-radius: 22
+    font-size: 44
+    bold: true
+    font-color: "#2E1065"
+    shadow: true
+  }
+
+  # Column-major fill: [col1-top, col1-bottom, col2-top, col2-bottom, col3-top, col3-bottom]
+  signon: "Single Sign-On" {
+    class: capability
+  }
+
+  audit: "Audit Logs" {
+    class: capability
+  }
+
+  policies: "Access Policies" {
+    class: capability
+  }
+
+  toolperm: "Tool Permissions" {
+    class: capability
+  }
+
+  proxy: "Secure Proxy" {
+    class: capability
+  }
+
+  tunnels: "Dev Tunnels" {
+    class: capability
+  }
+}
+
+servers: "MCP Servers" {
+  class: endpoint
+}
+
+clients <-> pomerium {
+  style: {
+    stroke: "#475569"
+    stroke-width: 3
+  }
+}
+
+pomerium <-> servers {
+  style: {
+    stroke: "#475569"
+    stroke-width: 3
+  }
+}

--- a/content/docs/capabilities/mcp/img/mcp-overview/architecture.d2
+++ b/content/docs/capabilities/mcp/img/mcp-overview/architecture.d2
@@ -60,7 +60,7 @@ pomerium: "Pomerium Gateway" {
   }
 
   # Column-major fill: [col1-top, col1-bottom, col2-top, col2-bottom, col3-top, col3-bottom]
-  signon: "Single Sign-On" {
+  sso: "Single Sign-On" {
     class: capability
   }
 
@@ -72,7 +72,7 @@ pomerium: "Pomerium Gateway" {
     class: capability
   }
 
-  toolperm: "Tool Permissions" {
+  tools: "Tool Permissions" {
     class: capability
   }
 

--- a/content/docs/capabilities/mcp/img/mcp-overview/architecture.svg
+++ b/content/docs/capabilities/mcp/img/mcp-overview/architecture.svg
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" data-d2-version="0.7.1" preserveAspectRatio="xMinYMin meet" viewBox="0 0 1770 399"><svg class="d2-359035160 d2-svg" width="1770" height="399" viewBox="-41 -42 1770 399"><rect x="-41.000000" y="-42.000000" width="1770.000000" height="399.000000" rx="0.000000" fill="#FFFFFF" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
-.d2-359035160 .text-bold {
-	font-family: "d2-359035160-font-bold";
+<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" data-d2-version="0.7.1" preserveAspectRatio="xMinYMin meet" viewBox="0 0 1770 399"><svg class="d2-265081934 d2-svg" width="1770" height="399" viewBox="-41 -42 1770 399"><rect x="-41.000000" y="-42.000000" width="1770.000000" height="399.000000" rx="0.000000" fill="#FFFFFF" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
+.d2-265081934 .text-bold {
+	font-family: "d2-265081934-font-bold";
 }
 @font-face {
-	font-family: d2-359035160-font-bold;
+	font-family: d2-265081934-font-bold;
 	src: url("data:application/font-woff;base64,d09GRgABAAAAAA4YAAoAAAAAFYwAAguFAAAAAAAAAAAAAAAAAAAAAAAAAABPUy8yAAAA9AAAAGAAAABgXxHXrmNtYXAAAAFUAAAAoQAAANIDuwRjZ2x5ZgAAAfgAAAeUAAAKHC3qjCBoZWFkAAAJjAAAADYAAAA2G38e1GhoZWEAAAnEAAAAJAAAACQKfwXgaG10eAAACegAAACEAAAAhEH7BRdsb2NhAAAKbAAAAEQAAABEKlwtDG1heHAAAAqwAAAAIAAAACAAOQD3bmFtZQAACtAAAAMoAAAIKgjwVkFwb3N0AAAN+AAAAB0AAAAg/9EAMgADAioCvAAFAAACigJYAAAASwKKAlgAAAFeADIBKQAAAgsHAwMEAwICBGAAAvcAAAADAAAAAAAAAABBREJPACAAIP//Au7/BgAAA9gBESAAAZ8AAAAAAfAClAAAACAAA3icfM1LKgcBAMfxz5i/998Y7/fkAg4hajZEcYFJklLKzn0kjwOIhdi4hyM4wU9N1r7bz+KLQqnA0MAXGrVSZduOXftah46d6py7cOnabcKf72kdOHKic9b7lZsk3/nJZz7ynre85iXPecpjHnKfu/72X4XGiNLAqDHjJkyaMm1oRmVWbc68BYuWLFuxas26DZu2+AUAAP//AQAA///IfSgGAAAAeJyEVllsE/kZ//5/T2biyeQYj8djO77/8YyP2Ek8PnI7Ic5BiHM4kASRg43oLhAIKRtKukLlBapq14gtYatQKnqoVVVp9wGhSu1KtFIfdovKG2z3advtIR72YdddRasuSuxqxg4EWqkPnr9leb7vd33fDFTBJABexjfBAEaoBxOIACrv5f2qohAmpaZSRDKkFMQzk9hU/MXPlSAVDFIhz5b7jaUllF3EN3fPHMsuL3+11NVVvPPb94vX0OvvA+DSUwA8gPNgBB5AYFRFlhVC0wZBFYhCmCcNb9XXNtZSnO3pw7sPfxT4MIBGu7vbVtX42eJVnN9dv30bAABBtLSNW/EWNAJU+WQ5EU8m1ZhFYmSZ+GhaNFvUWDIl0Wgh9+b0kWu59AnvuC1Fmg+GZ0YCaet4jht75+yZW1Oqb1FyxhYPnFhrss0fBwxZADyG88CWGasxi0U00zRR1FgymYjLMiHZ35y4MTV5/XjE0T4djU63O3A+c31t7cbwxcD8+PhR/zN8GbwF7v+FrwIvQRIqT9Po7NHvH5l9e3b4VU/W1h4aOz5/zCxzZz73fbMCMu5dtLjWlk+ssezaRvGxNwpIw4n+jvNQpaPkvWJ2E2Gc3y1cKuuj8XgP57X+Kq8KFoukJpMpQeWJBiVFGIYoCnFhUcz+9BRrYimWZ1/7yXcZo4FKLEwtxCmqmsH54l8cvS5XrwP5dte/8ExMum9//fVt9+SE5wsArHP8Dt6C+pdc0BVTYppcZbJoZu7qoUNX58rXgfHxgYHxcS536/TKOxMTPzh9+lbu8vry8urq8vI6VDxoxXngwPyCB0Tk1ZhWlGQ/HbkwNLQ+ODWy0dedwXllfmJsueUTlDuphsr8SWkbs3gLQjoyJWXRFE/EZUWJ4v8yQ5LKHZC573LsMJkJRCNq+Ii3W+46lWlfCx3y9ClypCN0uGuoc5VrjX7DJfucbqepqa5lqCU5F28OLdga3Q6Xi/dZDw8m59sBgQ0ACzgPjMaAJLwi4R/eQ0/v4YZLl3YLGkYModI2eox2wAYEQPJp8qV0SIyiAxR5os1GSouKnunfZSavbGISdPc1JVpWOpde3WAp93C1zS+Md7u52fT4XL1XsYqvOJtWzxf/qTrIeUmYZcNOq6Rr0lTaRvfRDthfzuTzSEo0jWyD5/pHvpWJDjsGiSeRTrdao0Knf4bruZCbXu9xSUvOsf6+rFh/3NNY5qGUttEOvg8CePZ46IWVhLqPwZ7YX86f61qKB9tt9OYGS9mHsFUxCWEzSbZwb3176kKvwzr2q92BNjvZMNv+ZKobGD44CFjH/je0A9aXJkrzjfFq7mrYDaoeOeQePn9g4EzX8EILhYsfs0NtiWSbvPjDe0qzL8n1ruem1tPplYzgNyZV71G7C3UGEy0aFwP4ShHMoB1ogS4Y1dnIibgGXjMnsddWUkVSCaVP0bXT7DLTtGFf6oXyd+KT9b982bnYPiw0eqz2YOdiotn76wnGGJ9LOd0mX3By/pXMpVGnojidihKM9Sl+1eblGnse2dubuwNUbcDdGGugTJlw90SAW6nxmTtGm9h6i2DqGlCnouhBKKgEA4FgqLjZZJMaDAarzeEEgFIJUgDwCX6EZU03YMADb+pZ6C9tIxO+D/Vlx3iVfxaAP451bfLGKoY2cX7u2CFMdj+WTAidrWK0+wAMTrQDXn0ytaWiOb0XV17jzjw7+7V8DrUl+gXvaNvkoU2nx9+qXVpQoc8dCQd8bSsLxYfImwy0Fu9WjnIPDGinMv2VHnvV6XJZTzY2dXDT6XEErKiQdkX2Ctmk4l0o50X38f/vJkv6XCZzLp1ezWRW05FoNBKNRCpZ71mfzl3ouZjt6x/TIg9lbOg62gHTC/zLm6SMrHFMFh2stdbW4Ogxo8JsrK2q6jJFBWPFTwGBWNpGP0Y7oOi6P99LcnkvPSumbSUXFs30o7bX5AO+tNvrckbtrq7AqSMds+4D9ri9o0P29ARPcrJ73tYoCbxFYLmmjuDgjGKdM1sUq62uhnREBxbK+5AvbaNVvA6SrkYiQRKplCqqItk3+DA/kRnj37h4kTg5GysJKe70zIOz9JUrr38Y8tPUCs2Va3WXttG/UUHz54Xs8JVx//PUwU2XxyFbNjdqDO5RbmUBxYt/TQTtTjRSbBj0NwMCDgCVUAFqAVSDKlWeTynVcO+XN/tYgaWMAtt/7Weo8Jk/qyhZ/2fFBr23FQAXUEHP3/779lUglXcKhrl56UYrzdIUU2tMXW431jMUY2Ravnfx3QhTy1BMDdOMCk/8I7I8Sp7o54j/SbHhAzIUCAyRD/R+dQBoGxW0fa4Kyr42jPS8T93W9TvNrIWlqk3Vvq23b91p5SSOMpqNCsKfT4phUQyLk6V/5cRmUQxbclpdrtSLdlFBS+fzHKRSL0hRhzcs3no7Y6r2B1jm9zeHa0wsVc0bu6+9K7VP/IGm1lBVk9OO/vGRb8hPhslHxZreI5XnXxgeIC9qAwNAKqGK4a8enDxZyS88RgXtd+29oX8TFYoNgErv4Q6Yxo+gBoDXN3h5ofmjUb8/GsUdIUJC2gf+AwAA//8BAAD//xiXF00AAQAAAAILhU2KBqVfDzz1AAED6AAAAADYXaCEAAAAAN1mLzb+N/7ECG0D8QABAAMAAgAAAAAAAAABAAAD2P7vAAAImP43/jcIbQABAAAAAAAAAAAAAAAAAAAAIQKyAFAAyAAAAj3/+gJGAC4CewBNAn4ALgIGAE0C+gBNAqwALgJUAE0CLAAjAiwAGQIPACoB0wAkAj0AJwIGACQCFgAiARQANwEeAEEDWQBBAjwAQQIrACQBjgBBAbsAFQF/ABECOAA8AgsADAMIABgCAgAOAgkADAFMACsBFABBAAD/rQAAACwALABQAHwAoADQAOABEgE+AWABoAGyAeoCFgJIAnwC5ALwAwwDPgNgA4wDrAPoBA4EMARMBIQEsATgBOwE+AUOAAEAAAAhAJAADABjAAcAAQAAAAAAAAAAAAAAAAAEAAN4nJyUz24bVRTGf05s0wrBAkVVuonugkWR6NhUSdU2K4fUikUUB48LQkJIE8/4jzKeGXkmDuEJWPMWvEVXPATPgVij+Xzs2AXRJoqSfHfu+fOdc75zgR3+ZptK9SHwRz0xXGGvfm54iwf1E8PbtOtbhqs8qf1puEZYmxuu83mtZ/gj3lZ/M/yA/epPhh+yW20b/phn1R3Dn2w7/jL8Kfu8XeAKvOBXwxV2yQxvscOPhrd5hMWsVHlE03CNz9gzXGcP6DOhIGZCwgjHkAkjrpgRkeMTMWPCkIgQR4cWMYW+JgRCjtF/fg3wKZgRKOKYAkeMT0xAztgi/iKvlHNlHOo0s7sWBWMCLuRxSUCCI2VESkLEpeIUFGS8okGDnIH4ZhTkeORMiPFImTGiQZc2p/QZMyHH0VakkplPypCCawLld2ZRdmZAREJurK5ICMXTiV8k7w6nOLpksl2PfLoR4Usc38m75JbK9is8/bo1Zpt5l2wC5upnrK7EurnWBMe6LfO2+Fa44BXuXv3ZZPL+HoX6XyjyBVeaf6hJJWKS4NwuLXwpyHePcRzp3MFXR76nQ58Turyhr3OLHj1anNGnw2v5dunh+JouZxzLoyO8uGtLMWf8gOMbOrIpY0fWn8XEIn4mM3Xn4jhTHVMy9bxk7qnWSBXefcLlDqUb6sjlM9AelZZO80u0ZwEjU0UmhlP1cqmN3PoXmiKmqqWc7e19uQ1z273lFt+QaodLtS44lZNbMHrfVL13NHOtH4+AkJQLWQxImdKg4Ea8zwm4IsZxrO6daEsKWiufMs+NVBIxFYMOieLMyPQ3MN34xn2woXtnb0ko/5Lp5aqq+2Rx6tXtjN6oe8s737ocrU2gYVNN19Q0ENfEtB9pp9b5+/LN9bqlPOWIlJjwXy/AMzya7HPAIWNlGOhmbq9DUy9Ek5ccqvpLIlkNpefIIhzg8ZwDDnjJ83f6uGTijItbcVnP3eKYI7ocflAVC/suR7xeffv/rL+LaVO1OJ6uTi/uPcUnd1DrF9qz2/eyp4mVk5hbtNutOCNgWnJxu+s1ucd4/wAAAP//AQAA///0t09ReJxiYGYAg//nGIwYsAAAAAAA//8BAAD//y8BAgMAAAA=");
 }]]></style><style type="text/css"><![CDATA[.shape {
   shape-rendering: geometricPrecision;
@@ -18,78 +18,78 @@
   opacity: 0.5;
 }
 
-		.d2-359035160 .fill-N1{fill:#0A0F25;}
-		.d2-359035160 .fill-N2{fill:#676C7E;}
-		.d2-359035160 .fill-N3{fill:#9499AB;}
-		.d2-359035160 .fill-N4{fill:#CFD2DD;}
-		.d2-359035160 .fill-N5{fill:#DEE1EB;}
-		.d2-359035160 .fill-N6{fill:#EEF1F8;}
-		.d2-359035160 .fill-N7{fill:#FFFFFF;}
-		.d2-359035160 .fill-B1{fill:#0D32B2;}
-		.d2-359035160 .fill-B2{fill:#0D32B2;}
-		.d2-359035160 .fill-B3{fill:#E3E9FD;}
-		.d2-359035160 .fill-B4{fill:#E3E9FD;}
-		.d2-359035160 .fill-B5{fill:#EDF0FD;}
-		.d2-359035160 .fill-B6{fill:#F7F8FE;}
-		.d2-359035160 .fill-AA2{fill:#4A6FF3;}
-		.d2-359035160 .fill-AA4{fill:#EDF0FD;}
-		.d2-359035160 .fill-AA5{fill:#F7F8FE;}
-		.d2-359035160 .fill-AB4{fill:#EDF0FD;}
-		.d2-359035160 .fill-AB5{fill:#F7F8FE;}
-		.d2-359035160 .stroke-N1{stroke:#0A0F25;}
-		.d2-359035160 .stroke-N2{stroke:#676C7E;}
-		.d2-359035160 .stroke-N3{stroke:#9499AB;}
-		.d2-359035160 .stroke-N4{stroke:#CFD2DD;}
-		.d2-359035160 .stroke-N5{stroke:#DEE1EB;}
-		.d2-359035160 .stroke-N6{stroke:#EEF1F8;}
-		.d2-359035160 .stroke-N7{stroke:#FFFFFF;}
-		.d2-359035160 .stroke-B1{stroke:#0D32B2;}
-		.d2-359035160 .stroke-B2{stroke:#0D32B2;}
-		.d2-359035160 .stroke-B3{stroke:#E3E9FD;}
-		.d2-359035160 .stroke-B4{stroke:#E3E9FD;}
-		.d2-359035160 .stroke-B5{stroke:#EDF0FD;}
-		.d2-359035160 .stroke-B6{stroke:#F7F8FE;}
-		.d2-359035160 .stroke-AA2{stroke:#4A6FF3;}
-		.d2-359035160 .stroke-AA4{stroke:#EDF0FD;}
-		.d2-359035160 .stroke-AA5{stroke:#F7F8FE;}
-		.d2-359035160 .stroke-AB4{stroke:#EDF0FD;}
-		.d2-359035160 .stroke-AB5{stroke:#F7F8FE;}
-		.d2-359035160 .background-color-N1{background-color:#0A0F25;}
-		.d2-359035160 .background-color-N2{background-color:#676C7E;}
-		.d2-359035160 .background-color-N3{background-color:#9499AB;}
-		.d2-359035160 .background-color-N4{background-color:#CFD2DD;}
-		.d2-359035160 .background-color-N5{background-color:#DEE1EB;}
-		.d2-359035160 .background-color-N6{background-color:#EEF1F8;}
-		.d2-359035160 .background-color-N7{background-color:#FFFFFF;}
-		.d2-359035160 .background-color-B1{background-color:#0D32B2;}
-		.d2-359035160 .background-color-B2{background-color:#0D32B2;}
-		.d2-359035160 .background-color-B3{background-color:#E3E9FD;}
-		.d2-359035160 .background-color-B4{background-color:#E3E9FD;}
-		.d2-359035160 .background-color-B5{background-color:#EDF0FD;}
-		.d2-359035160 .background-color-B6{background-color:#F7F8FE;}
-		.d2-359035160 .background-color-AA2{background-color:#4A6FF3;}
-		.d2-359035160 .background-color-AA4{background-color:#EDF0FD;}
-		.d2-359035160 .background-color-AA5{background-color:#F7F8FE;}
-		.d2-359035160 .background-color-AB4{background-color:#EDF0FD;}
-		.d2-359035160 .background-color-AB5{background-color:#F7F8FE;}
-		.d2-359035160 .color-N1{color:#0A0F25;}
-		.d2-359035160 .color-N2{color:#676C7E;}
-		.d2-359035160 .color-N3{color:#9499AB;}
-		.d2-359035160 .color-N4{color:#CFD2DD;}
-		.d2-359035160 .color-N5{color:#DEE1EB;}
-		.d2-359035160 .color-N6{color:#EEF1F8;}
-		.d2-359035160 .color-N7{color:#FFFFFF;}
-		.d2-359035160 .color-B1{color:#0D32B2;}
-		.d2-359035160 .color-B2{color:#0D32B2;}
-		.d2-359035160 .color-B3{color:#E3E9FD;}
-		.d2-359035160 .color-B4{color:#E3E9FD;}
-		.d2-359035160 .color-B5{color:#EDF0FD;}
-		.d2-359035160 .color-B6{color:#F7F8FE;}
-		.d2-359035160 .color-AA2{color:#4A6FF3;}
-		.d2-359035160 .color-AA4{color:#EDF0FD;}
-		.d2-359035160 .color-AA5{color:#F7F8FE;}
-		.d2-359035160 .color-AB4{color:#EDF0FD;}
-		.d2-359035160 .color-AB5{color:#F7F8FE;}.appendix text.text{fill:#0A0F25}.md{--color-fg-default:#0A0F25;--color-fg-muted:#676C7E;--color-fg-subtle:#9499AB;--color-canvas-default:#FFFFFF;--color-canvas-subtle:#EEF1F8;--color-border-default:#0D32B2;--color-border-muted:#0D32B2;--color-neutral-muted:#EEF1F8;--color-accent-fg:#0D32B2;--color-accent-emphasis:#0D32B2;--color-attention-subtle:#676C7E;--color-danger-fg:red;}.sketch-overlay-B1{fill:url(#streaks-darker-d2-359035160);mix-blend-mode:lighten}.sketch-overlay-B2{fill:url(#streaks-darker-d2-359035160);mix-blend-mode:lighten}.sketch-overlay-B3{fill:url(#streaks-bright-d2-359035160);mix-blend-mode:darken}.sketch-overlay-B4{fill:url(#streaks-bright-d2-359035160);mix-blend-mode:darken}.sketch-overlay-B5{fill:url(#streaks-bright-d2-359035160);mix-blend-mode:darken}.sketch-overlay-B6{fill:url(#streaks-bright-d2-359035160);mix-blend-mode:darken}.sketch-overlay-AA2{fill:url(#streaks-dark-d2-359035160);mix-blend-mode:overlay}.sketch-overlay-AA4{fill:url(#streaks-bright-d2-359035160);mix-blend-mode:darken}.sketch-overlay-AA5{fill:url(#streaks-bright-d2-359035160);mix-blend-mode:darken}.sketch-overlay-AB4{fill:url(#streaks-bright-d2-359035160);mix-blend-mode:darken}.sketch-overlay-AB5{fill:url(#streaks-bright-d2-359035160);mix-blend-mode:darken}.sketch-overlay-N1{fill:url(#streaks-darker-d2-359035160);mix-blend-mode:lighten}.sketch-overlay-N2{fill:url(#streaks-dark-d2-359035160);mix-blend-mode:overlay}.sketch-overlay-N3{fill:url(#streaks-normal-d2-359035160);mix-blend-mode:color-burn}.sketch-overlay-N4{fill:url(#streaks-normal-d2-359035160);mix-blend-mode:color-burn}.sketch-overlay-N5{fill:url(#streaks-bright-d2-359035160);mix-blend-mode:darken}.sketch-overlay-N6{fill:url(#streaks-bright-d2-359035160);mix-blend-mode:darken}.sketch-overlay-N7{fill:url(#streaks-bright-d2-359035160);mix-blend-mode:darken}.light-code{display: block}.dark-code{display: none}]]></style><defs>
+		.d2-265081934 .fill-N1{fill:#0A0F25;}
+		.d2-265081934 .fill-N2{fill:#676C7E;}
+		.d2-265081934 .fill-N3{fill:#9499AB;}
+		.d2-265081934 .fill-N4{fill:#CFD2DD;}
+		.d2-265081934 .fill-N5{fill:#DEE1EB;}
+		.d2-265081934 .fill-N6{fill:#EEF1F8;}
+		.d2-265081934 .fill-N7{fill:#FFFFFF;}
+		.d2-265081934 .fill-B1{fill:#0D32B2;}
+		.d2-265081934 .fill-B2{fill:#0D32B2;}
+		.d2-265081934 .fill-B3{fill:#E3E9FD;}
+		.d2-265081934 .fill-B4{fill:#E3E9FD;}
+		.d2-265081934 .fill-B5{fill:#EDF0FD;}
+		.d2-265081934 .fill-B6{fill:#F7F8FE;}
+		.d2-265081934 .fill-AA2{fill:#4A6FF3;}
+		.d2-265081934 .fill-AA4{fill:#EDF0FD;}
+		.d2-265081934 .fill-AA5{fill:#F7F8FE;}
+		.d2-265081934 .fill-AB4{fill:#EDF0FD;}
+		.d2-265081934 .fill-AB5{fill:#F7F8FE;}
+		.d2-265081934 .stroke-N1{stroke:#0A0F25;}
+		.d2-265081934 .stroke-N2{stroke:#676C7E;}
+		.d2-265081934 .stroke-N3{stroke:#9499AB;}
+		.d2-265081934 .stroke-N4{stroke:#CFD2DD;}
+		.d2-265081934 .stroke-N5{stroke:#DEE1EB;}
+		.d2-265081934 .stroke-N6{stroke:#EEF1F8;}
+		.d2-265081934 .stroke-N7{stroke:#FFFFFF;}
+		.d2-265081934 .stroke-B1{stroke:#0D32B2;}
+		.d2-265081934 .stroke-B2{stroke:#0D32B2;}
+		.d2-265081934 .stroke-B3{stroke:#E3E9FD;}
+		.d2-265081934 .stroke-B4{stroke:#E3E9FD;}
+		.d2-265081934 .stroke-B5{stroke:#EDF0FD;}
+		.d2-265081934 .stroke-B6{stroke:#F7F8FE;}
+		.d2-265081934 .stroke-AA2{stroke:#4A6FF3;}
+		.d2-265081934 .stroke-AA4{stroke:#EDF0FD;}
+		.d2-265081934 .stroke-AA5{stroke:#F7F8FE;}
+		.d2-265081934 .stroke-AB4{stroke:#EDF0FD;}
+		.d2-265081934 .stroke-AB5{stroke:#F7F8FE;}
+		.d2-265081934 .background-color-N1{background-color:#0A0F25;}
+		.d2-265081934 .background-color-N2{background-color:#676C7E;}
+		.d2-265081934 .background-color-N3{background-color:#9499AB;}
+		.d2-265081934 .background-color-N4{background-color:#CFD2DD;}
+		.d2-265081934 .background-color-N5{background-color:#DEE1EB;}
+		.d2-265081934 .background-color-N6{background-color:#EEF1F8;}
+		.d2-265081934 .background-color-N7{background-color:#FFFFFF;}
+		.d2-265081934 .background-color-B1{background-color:#0D32B2;}
+		.d2-265081934 .background-color-B2{background-color:#0D32B2;}
+		.d2-265081934 .background-color-B3{background-color:#E3E9FD;}
+		.d2-265081934 .background-color-B4{background-color:#E3E9FD;}
+		.d2-265081934 .background-color-B5{background-color:#EDF0FD;}
+		.d2-265081934 .background-color-B6{background-color:#F7F8FE;}
+		.d2-265081934 .background-color-AA2{background-color:#4A6FF3;}
+		.d2-265081934 .background-color-AA4{background-color:#EDF0FD;}
+		.d2-265081934 .background-color-AA5{background-color:#F7F8FE;}
+		.d2-265081934 .background-color-AB4{background-color:#EDF0FD;}
+		.d2-265081934 .background-color-AB5{background-color:#F7F8FE;}
+		.d2-265081934 .color-N1{color:#0A0F25;}
+		.d2-265081934 .color-N2{color:#676C7E;}
+		.d2-265081934 .color-N3{color:#9499AB;}
+		.d2-265081934 .color-N4{color:#CFD2DD;}
+		.d2-265081934 .color-N5{color:#DEE1EB;}
+		.d2-265081934 .color-N6{color:#EEF1F8;}
+		.d2-265081934 .color-N7{color:#FFFFFF;}
+		.d2-265081934 .color-B1{color:#0D32B2;}
+		.d2-265081934 .color-B2{color:#0D32B2;}
+		.d2-265081934 .color-B3{color:#E3E9FD;}
+		.d2-265081934 .color-B4{color:#E3E9FD;}
+		.d2-265081934 .color-B5{color:#EDF0FD;}
+		.d2-265081934 .color-B6{color:#F7F8FE;}
+		.d2-265081934 .color-AA2{color:#4A6FF3;}
+		.d2-265081934 .color-AA4{color:#EDF0FD;}
+		.d2-265081934 .color-AA5{color:#F7F8FE;}
+		.d2-265081934 .color-AB4{color:#EDF0FD;}
+		.d2-265081934 .color-AB5{color:#F7F8FE;}.appendix text.text{fill:#0A0F25}.md{--color-fg-default:#0A0F25;--color-fg-muted:#676C7E;--color-fg-subtle:#9499AB;--color-canvas-default:#FFFFFF;--color-canvas-subtle:#EEF1F8;--color-border-default:#0D32B2;--color-border-muted:#0D32B2;--color-neutral-muted:#EEF1F8;--color-accent-fg:#0D32B2;--color-accent-emphasis:#0D32B2;--color-attention-subtle:#676C7E;--color-danger-fg:red;}.sketch-overlay-B1{fill:url(#streaks-darker-d2-265081934);mix-blend-mode:lighten}.sketch-overlay-B2{fill:url(#streaks-darker-d2-265081934);mix-blend-mode:lighten}.sketch-overlay-B3{fill:url(#streaks-bright-d2-265081934);mix-blend-mode:darken}.sketch-overlay-B4{fill:url(#streaks-bright-d2-265081934);mix-blend-mode:darken}.sketch-overlay-B5{fill:url(#streaks-bright-d2-265081934);mix-blend-mode:darken}.sketch-overlay-B6{fill:url(#streaks-bright-d2-265081934);mix-blend-mode:darken}.sketch-overlay-AA2{fill:url(#streaks-dark-d2-265081934);mix-blend-mode:overlay}.sketch-overlay-AA4{fill:url(#streaks-bright-d2-265081934);mix-blend-mode:darken}.sketch-overlay-AA5{fill:url(#streaks-bright-d2-265081934);mix-blend-mode:darken}.sketch-overlay-AB4{fill:url(#streaks-bright-d2-265081934);mix-blend-mode:darken}.sketch-overlay-AB5{fill:url(#streaks-bright-d2-265081934);mix-blend-mode:darken}.sketch-overlay-N1{fill:url(#streaks-darker-d2-265081934);mix-blend-mode:lighten}.sketch-overlay-N2{fill:url(#streaks-dark-d2-265081934);mix-blend-mode:overlay}.sketch-overlay-N3{fill:url(#streaks-normal-d2-265081934);mix-blend-mode:color-burn}.sketch-overlay-N4{fill:url(#streaks-normal-d2-265081934);mix-blend-mode:color-burn}.sketch-overlay-N5{fill:url(#streaks-bright-d2-265081934);mix-blend-mode:darken}.sketch-overlay-N6{fill:url(#streaks-bright-d2-265081934);mix-blend-mode:darken}.sketch-overlay-N7{fill:url(#streaks-bright-d2-265081934);mix-blend-mode:darken}.light-code{display: block}.dark-code{display: none}]]></style><defs>
 	<filter id="shadow-filter" width="200%" height="200%" x="-50%" y="-50%">
 		<feGaussianBlur stdDeviation="1.7 " in="SourceGraphic"></feGaussianBlur>
 		<feFlood flood-color="#3d4574" flood-opacity="0.4" result="ShadowFeFlood" in="SourceGraphic"></feFlood>
@@ -97,7 +97,7 @@
 		<feOffset dx="3" dy="5" result="ShadowFeOffset" in="ShadowFeComposite"></feOffset>
 		<feBlend in="SourceGraphic" in2="ShadowFeOffset" mode="normal" result="ShadowFeBlend"></feBlend>
 	</filter>
-</defs><g class="Y2xpZW50cw== endpoint"><g class="shape" ><rect x="0.000000" y="105.000000" width="260.000000" height="100.000000" stroke="transparent" fill="transparent" style="stroke-width:2;" /></g><text x="130.000000" y="169.500000" fill="#0F172A" class="text-bold" style="text-anchor:middle;font-size:40px">MCP Clients</text></g><g class="cG9tZXJpdW0="><g class="shape" filter="url(#shadow-filter)" ><rect x="360.000000" y="0.000000" width="968.000000" height="310.000000" rx="22.000000" stroke="#6F43E7" fill="#F3EEFF" style="stroke-width:4;" /></g><text x="844.000000" y="49.000000" fill="#2E1065" class="text-bold" style="text-anchor:middle;font-size:44px">Pomerium Gateway</text></g><g class="c2VydmVycw== endpoint"><g class="shape" ><rect x="1428.000000" y="105.000000" width="260.000000" height="100.000000" stroke="transparent" fill="transparent" style="stroke-width:2;" /></g><text x="1558.000000" y="169.500000" fill="#0F172A" class="text-bold" style="text-anchor:middle;font-size:40px">MCP Servers</text></g><g class="cG9tZXJpdW0uc2lnbm9u capability"><g class="shape" ><rect x="392.000000" y="66.000000" width="280.000000" height="90.000000" rx="12.000000" stroke="#6F43E7" fill="#FFFFFF" style="stroke-width:2;" /></g><text x="532.000000" y="121.000000" fill="#2E1065" class="text-bold" style="text-anchor:middle;font-size:28px">Single Sign-On</text></g><g class="cG9tZXJpdW0uYXVkaXQ= capability"><g class="shape" ><rect x="392.000000" y="188.000000" width="280.000000" height="90.000000" rx="12.000000" stroke="#6F43E7" fill="#FFFFFF" style="stroke-width:2;" /></g><text x="532.000000" y="243.000000" fill="#2E1065" class="text-bold" style="text-anchor:middle;font-size:28px">Audit Logs</text></g><g class="cG9tZXJpdW0ucG9saWNpZXM= capability"><g class="shape" ><rect x="704.000000" y="66.000000" width="280.000000" height="90.000000" rx="12.000000" stroke="#6F43E7" fill="#FFFFFF" style="stroke-width:2;" /></g><text x="844.000000" y="121.000000" fill="#2E1065" class="text-bold" style="text-anchor:middle;font-size:28px">Access Policies</text></g><g class="cG9tZXJpdW0udG9vbHBlcm0= capability"><g class="shape" ><rect x="704.000000" y="188.000000" width="280.000000" height="90.000000" rx="12.000000" stroke="#6F43E7" fill="#FFFFFF" style="stroke-width:2;" /></g><text x="844.000000" y="243.000000" fill="#2E1065" class="text-bold" style="text-anchor:middle;font-size:28px">Tool Permissions</text></g><g class="cG9tZXJpdW0ucHJveHk= capability"><g class="shape" ><rect x="1016.000000" y="66.000000" width="280.000000" height="90.000000" rx="12.000000" stroke="#6F43E7" fill="#FFFFFF" style="stroke-width:2;" /></g><text x="1156.000000" y="121.000000" fill="#2E1065" class="text-bold" style="text-anchor:middle;font-size:28px">Secure Proxy</text></g><g class="cG9tZXJpdW0udHVubmVscw== capability"><g class="shape" ><rect x="1016.000000" y="188.000000" width="280.000000" height="90.000000" rx="12.000000" stroke="#6F43E7" fill="#FFFFFF" style="stroke-width:2;" /></g><text x="1156.000000" y="243.000000" fill="#2E1065" class="text-bold" style="text-anchor:middle;font-size:28px">Dev Tunnels</text></g><g class="KGNsaWVudHMgJmx0Oy0mZ3Q7IHBvbWVyaXVtKVswXQ=="><marker id="mk-d2-359035160-327084376" markerWidth="13.000000" markerHeight="16.000000" refX="4.500000" refY="8.000000" viewBox="0.000000 0.000000 13.000000 16.000000" orient="auto" markerUnits="userSpaceOnUse"> <polygon points="13.000000,0.000000 0.000000,8.000000 13.000000,16.000000" fill="#475569" class="connection" stroke-width="3" /> </marker><marker id="mk-d2-359035160-128836843" markerWidth="13.000000" markerHeight="16.000000" refX="8.500000" refY="8.000000" viewBox="0.000000 0.000000 13.000000 16.000000" orient="auto" markerUnits="userSpaceOnUse"> <polygon points="0.000000,0.000000 13.000000,8.000000 0.000000,16.000000" fill="#475569" class="connection" stroke-width="3" /> </marker><path d="M 265.500000 155.000000 C 300.000000 155.000000 320.000000 155.000000 353.500000 155.000000" stroke="#475569" fill="none" class="connection" style="stroke-width:3;" marker-start="url(#mk-d2-359035160-327084376)" marker-end="url(#mk-d2-359035160-128836843)" mask="url(#d2-359035160)" /></g><g class="KHBvbWVyaXVtICZsdDstJmd0OyBzZXJ2ZXJzKVswXQ=="><path d="M 1334.500000 155.000000 C 1368.000000 155.000000 1388.000000 155.000000 1422.500000 155.000000" stroke="#475569" fill="none" class="connection" style="stroke-width:3;" marker-start="url(#mk-d2-359035160-327084376)" marker-end="url(#mk-d2-359035160-128836843)" mask="url(#d2-359035160)" /></g><mask id="d2-359035160" maskUnits="userSpaceOnUse" x="-41" y="-42" width="1770" height="399">
+</defs><g class="Y2xpZW50cw== endpoint"><g class="shape" ><rect x="0.000000" y="105.000000" width="260.000000" height="100.000000" stroke="transparent" fill="transparent" style="stroke-width:2;" /></g><text x="130.000000" y="169.500000" fill="#0F172A" class="text-bold" style="text-anchor:middle;font-size:40px">MCP Clients</text></g><g class="cG9tZXJpdW0="><g class="shape" filter="url(#shadow-filter)" ><rect x="360.000000" y="0.000000" width="968.000000" height="310.000000" rx="22.000000" stroke="#6F43E7" fill="#F3EEFF" style="stroke-width:4;" /></g><text x="844.000000" y="49.000000" fill="#2E1065" class="text-bold" style="text-anchor:middle;font-size:44px">Pomerium Gateway</text></g><g class="c2VydmVycw== endpoint"><g class="shape" ><rect x="1428.000000" y="105.000000" width="260.000000" height="100.000000" stroke="transparent" fill="transparent" style="stroke-width:2;" /></g><text x="1558.000000" y="169.500000" fill="#0F172A" class="text-bold" style="text-anchor:middle;font-size:40px">MCP Servers</text></g><g class="cG9tZXJpdW0uc3Nv capability"><g class="shape" ><rect x="392.000000" y="66.000000" width="280.000000" height="90.000000" rx="12.000000" stroke="#6F43E7" fill="#FFFFFF" style="stroke-width:2;" /></g><text x="532.000000" y="121.000000" fill="#2E1065" class="text-bold" style="text-anchor:middle;font-size:28px">Single Sign-On</text></g><g class="cG9tZXJpdW0uYXVkaXQ= capability"><g class="shape" ><rect x="392.000000" y="188.000000" width="280.000000" height="90.000000" rx="12.000000" stroke="#6F43E7" fill="#FFFFFF" style="stroke-width:2;" /></g><text x="532.000000" y="243.000000" fill="#2E1065" class="text-bold" style="text-anchor:middle;font-size:28px">Audit Logs</text></g><g class="cG9tZXJpdW0ucG9saWNpZXM= capability"><g class="shape" ><rect x="704.000000" y="66.000000" width="280.000000" height="90.000000" rx="12.000000" stroke="#6F43E7" fill="#FFFFFF" style="stroke-width:2;" /></g><text x="844.000000" y="121.000000" fill="#2E1065" class="text-bold" style="text-anchor:middle;font-size:28px">Access Policies</text></g><g class="cG9tZXJpdW0udG9vbHM= capability"><g class="shape" ><rect x="704.000000" y="188.000000" width="280.000000" height="90.000000" rx="12.000000" stroke="#6F43E7" fill="#FFFFFF" style="stroke-width:2;" /></g><text x="844.000000" y="243.000000" fill="#2E1065" class="text-bold" style="text-anchor:middle;font-size:28px">Tool Permissions</text></g><g class="cG9tZXJpdW0ucHJveHk= capability"><g class="shape" ><rect x="1016.000000" y="66.000000" width="280.000000" height="90.000000" rx="12.000000" stroke="#6F43E7" fill="#FFFFFF" style="stroke-width:2;" /></g><text x="1156.000000" y="121.000000" fill="#2E1065" class="text-bold" style="text-anchor:middle;font-size:28px">Secure Proxy</text></g><g class="cG9tZXJpdW0udHVubmVscw== capability"><g class="shape" ><rect x="1016.000000" y="188.000000" width="280.000000" height="90.000000" rx="12.000000" stroke="#6F43E7" fill="#FFFFFF" style="stroke-width:2;" /></g><text x="1156.000000" y="243.000000" fill="#2E1065" class="text-bold" style="text-anchor:middle;font-size:28px">Dev Tunnels</text></g><g class="KGNsaWVudHMgJmx0Oy0mZ3Q7IHBvbWVyaXVtKVswXQ=="><marker id="mk-d2-265081934-327084376" markerWidth="13.000000" markerHeight="16.000000" refX="4.500000" refY="8.000000" viewBox="0.000000 0.000000 13.000000 16.000000" orient="auto" markerUnits="userSpaceOnUse"> <polygon points="13.000000,0.000000 0.000000,8.000000 13.000000,16.000000" fill="#475569" class="connection" stroke-width="3" /> </marker><marker id="mk-d2-265081934-128836843" markerWidth="13.000000" markerHeight="16.000000" refX="8.500000" refY="8.000000" viewBox="0.000000 0.000000 13.000000 16.000000" orient="auto" markerUnits="userSpaceOnUse"> <polygon points="0.000000,0.000000 13.000000,8.000000 0.000000,16.000000" fill="#475569" class="connection" stroke-width="3" /> </marker><path d="M 265.500000 155.000000 C 300.000000 155.000000 320.000000 155.000000 353.500000 155.000000" stroke="#475569" fill="none" class="connection" style="stroke-width:3;" marker-start="url(#mk-d2-265081934-327084376)" marker-end="url(#mk-d2-265081934-128836843)" mask="url(#d2-265081934)" /></g><g class="KHBvbWVyaXVtICZsdDstJmd0OyBzZXJ2ZXJzKVswXQ=="><path d="M 1334.500000 155.000000 C 1368.000000 155.000000 1388.000000 155.000000 1422.500000 155.000000" stroke="#475569" fill="none" class="connection" style="stroke-width:3;" marker-start="url(#mk-d2-265081934-327084376)" marker-end="url(#mk-d2-265081934-128836843)" mask="url(#d2-265081934)" /></g><mask id="d2-265081934" maskUnits="userSpaceOnUse" x="-41" y="-42" width="1770" height="399">
 <rect x="-41" y="-42" width="1770" height="399" fill="white"></rect>
 
 </mask></svg></svg>

--- a/content/docs/capabilities/mcp/img/mcp-overview/architecture.svg
+++ b/content/docs/capabilities/mcp/img/mcp-overview/architecture.svg
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" data-d2-version="0.7.1" preserveAspectRatio="xMinYMin meet" viewBox="0 0 1770 399"><svg class="d2-359035160 d2-svg" width="1770" height="399" viewBox="-41 -42 1770 399"><rect x="-41.000000" y="-42.000000" width="1770.000000" height="399.000000" rx="0.000000" fill="#FFFFFF" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
+.d2-359035160 .text-bold {
+	font-family: "d2-359035160-font-bold";
+}
+@font-face {
+	font-family: d2-359035160-font-bold;
+	src: url("data:application/font-woff;base64,d09GRgABAAAAAA4YAAoAAAAAFYwAAguFAAAAAAAAAAAAAAAAAAAAAAAAAABPUy8yAAAA9AAAAGAAAABgXxHXrmNtYXAAAAFUAAAAoQAAANIDuwRjZ2x5ZgAAAfgAAAeUAAAKHC3qjCBoZWFkAAAJjAAAADYAAAA2G38e1GhoZWEAAAnEAAAAJAAAACQKfwXgaG10eAAACegAAACEAAAAhEH7BRdsb2NhAAAKbAAAAEQAAABEKlwtDG1heHAAAAqwAAAAIAAAACAAOQD3bmFtZQAACtAAAAMoAAAIKgjwVkFwb3N0AAAN+AAAAB0AAAAg/9EAMgADAioCvAAFAAACigJYAAAASwKKAlgAAAFeADIBKQAAAgsHAwMEAwICBGAAAvcAAAADAAAAAAAAAABBREJPACAAIP//Au7/BgAAA9gBESAAAZ8AAAAAAfAClAAAACAAA3icfM1LKgcBAMfxz5i/998Y7/fkAg4hajZEcYFJklLKzn0kjwOIhdi4hyM4wU9N1r7bz+KLQqnA0MAXGrVSZduOXftah46d6py7cOnabcKf72kdOHKic9b7lZsk3/nJZz7ynre85iXPecpjHnKfu/72X4XGiNLAqDHjJkyaMm1oRmVWbc68BYuWLFuxas26DZu2+AUAAP//AQAA///IfSgGAAAAeJyEVllsE/kZ//5/T2biyeQYj8djO77/8YyP2Ek8PnI7Ic5BiHM4kASRg43oLhAIKRtKukLlBapq14gtYatQKnqoVVVp9wGhSu1KtFIfdovKG2z3advtIR72YdddRasuSuxqxg4EWqkPnr9leb7vd33fDFTBJABexjfBAEaoBxOIACrv5f2qohAmpaZSRDKkFMQzk9hU/MXPlSAVDFIhz5b7jaUllF3EN3fPHMsuL3+11NVVvPPb94vX0OvvA+DSUwA8gPNgBB5AYFRFlhVC0wZBFYhCmCcNb9XXNtZSnO3pw7sPfxT4MIBGu7vbVtX42eJVnN9dv30bAABBtLSNW/EWNAJU+WQ5EU8m1ZhFYmSZ+GhaNFvUWDIl0Wgh9+b0kWu59AnvuC1Fmg+GZ0YCaet4jht75+yZW1Oqb1FyxhYPnFhrss0fBwxZADyG88CWGasxi0U00zRR1FgymYjLMiHZ35y4MTV5/XjE0T4djU63O3A+c31t7cbwxcD8+PhR/zN8GbwF7v+FrwIvQRIqT9Po7NHvH5l9e3b4VU/W1h4aOz5/zCxzZz73fbMCMu5dtLjWlk+ssezaRvGxNwpIw4n+jvNQpaPkvWJ2E2Gc3y1cKuuj8XgP57X+Kq8KFoukJpMpQeWJBiVFGIYoCnFhUcz+9BRrYimWZ1/7yXcZo4FKLEwtxCmqmsH54l8cvS5XrwP5dte/8ExMum9//fVt9+SE5wsArHP8Dt6C+pdc0BVTYppcZbJoZu7qoUNX58rXgfHxgYHxcS536/TKOxMTPzh9+lbu8vry8urq8vI6VDxoxXngwPyCB0Tk1ZhWlGQ/HbkwNLQ+ODWy0dedwXllfmJsueUTlDuphsr8SWkbs3gLQjoyJWXRFE/EZUWJ4v8yQ5LKHZC573LsMJkJRCNq+Ii3W+46lWlfCx3y9ClypCN0uGuoc5VrjX7DJfucbqepqa5lqCU5F28OLdga3Q6Xi/dZDw8m59sBgQ0ACzgPjMaAJLwi4R/eQ0/v4YZLl3YLGkYModI2eox2wAYEQPJp8qV0SIyiAxR5os1GSouKnunfZSavbGISdPc1JVpWOpde3WAp93C1zS+Md7u52fT4XL1XsYqvOJtWzxf/qTrIeUmYZcNOq6Rr0lTaRvfRDthfzuTzSEo0jWyD5/pHvpWJDjsGiSeRTrdao0Knf4bruZCbXu9xSUvOsf6+rFh/3NNY5qGUttEOvg8CePZ46IWVhLqPwZ7YX86f61qKB9tt9OYGS9mHsFUxCWEzSbZwb3176kKvwzr2q92BNjvZMNv+ZKobGD44CFjH/je0A9aXJkrzjfFq7mrYDaoeOeQePn9g4EzX8EILhYsfs0NtiWSbvPjDe0qzL8n1ruem1tPplYzgNyZV71G7C3UGEy0aFwP4ShHMoB1ogS4Y1dnIibgGXjMnsddWUkVSCaVP0bXT7DLTtGFf6oXyd+KT9b982bnYPiw0eqz2YOdiotn76wnGGJ9LOd0mX3By/pXMpVGnojidihKM9Sl+1eblGnse2dubuwNUbcDdGGugTJlw90SAW6nxmTtGm9h6i2DqGlCnouhBKKgEA4FgqLjZZJMaDAarzeEEgFIJUgDwCX6EZU03YMADb+pZ6C9tIxO+D/Vlx3iVfxaAP451bfLGKoY2cX7u2CFMdj+WTAidrWK0+wAMTrQDXn0ytaWiOb0XV17jzjw7+7V8DrUl+gXvaNvkoU2nx9+qXVpQoc8dCQd8bSsLxYfImwy0Fu9WjnIPDGinMv2VHnvV6XJZTzY2dXDT6XEErKiQdkX2Ctmk4l0o50X38f/vJkv6XCZzLp1ezWRW05FoNBKNRCpZ71mfzl3ouZjt6x/TIg9lbOg62gHTC/zLm6SMrHFMFh2stdbW4Ogxo8JsrK2q6jJFBWPFTwGBWNpGP0Y7oOi6P99LcnkvPSumbSUXFs30o7bX5AO+tNvrckbtrq7AqSMds+4D9ri9o0P29ARPcrJ73tYoCbxFYLmmjuDgjGKdM1sUq62uhnREBxbK+5AvbaNVvA6SrkYiQRKplCqqItk3+DA/kRnj37h4kTg5GysJKe70zIOz9JUrr38Y8tPUCs2Va3WXttG/UUHz54Xs8JVx//PUwU2XxyFbNjdqDO5RbmUBxYt/TQTtTjRSbBj0NwMCDgCVUAFqAVSDKlWeTynVcO+XN/tYgaWMAtt/7Weo8Jk/qyhZ/2fFBr23FQAXUEHP3/779lUglXcKhrl56UYrzdIUU2tMXW431jMUY2Ravnfx3QhTy1BMDdOMCk/8I7I8Sp7o54j/SbHhAzIUCAyRD/R+dQBoGxW0fa4Kyr42jPS8T93W9TvNrIWlqk3Vvq23b91p5SSOMpqNCsKfT4phUQyLk6V/5cRmUQxbclpdrtSLdlFBS+fzHKRSL0hRhzcs3no7Y6r2B1jm9zeHa0wsVc0bu6+9K7VP/IGm1lBVk9OO/vGRb8hPhslHxZreI5XnXxgeIC9qAwNAKqGK4a8enDxZyS88RgXtd+29oX8TFYoNgErv4Q6Yxo+gBoDXN3h5ofmjUb8/GsUdIUJC2gf+AwAA//8BAAD//xiXF00AAQAAAAILhU2KBqVfDzz1AAED6AAAAADYXaCEAAAAAN1mLzb+N/7ECG0D8QABAAMAAgAAAAAAAAABAAAD2P7vAAAImP43/jcIbQABAAAAAAAAAAAAAAAAAAAAIQKyAFAAyAAAAj3/+gJGAC4CewBNAn4ALgIGAE0C+gBNAqwALgJUAE0CLAAjAiwAGQIPACoB0wAkAj0AJwIGACQCFgAiARQANwEeAEEDWQBBAjwAQQIrACQBjgBBAbsAFQF/ABECOAA8AgsADAMIABgCAgAOAgkADAFMACsBFABBAAD/rQAAACwALABQAHwAoADQAOABEgE+AWABoAGyAeoCFgJIAnwC5ALwAwwDPgNgA4wDrAPoBA4EMARMBIQEsATgBOwE+AUOAAEAAAAhAJAADABjAAcAAQAAAAAAAAAAAAAAAAAEAAN4nJyUz24bVRTGf05s0wrBAkVVuonugkWR6NhUSdU2K4fUikUUB48LQkJIE8/4jzKeGXkmDuEJWPMWvEVXPATPgVij+Xzs2AXRJoqSfHfu+fOdc75zgR3+ZptK9SHwRz0xXGGvfm54iwf1E8PbtOtbhqs8qf1puEZYmxuu83mtZ/gj3lZ/M/yA/epPhh+yW20b/phn1R3Dn2w7/jL8Kfu8XeAKvOBXwxV2yQxvscOPhrd5hMWsVHlE03CNz9gzXGcP6DOhIGZCwgjHkAkjrpgRkeMTMWPCkIgQR4cWMYW+JgRCjtF/fg3wKZgRKOKYAkeMT0xAztgi/iKvlHNlHOo0s7sWBWMCLuRxSUCCI2VESkLEpeIUFGS8okGDnIH4ZhTkeORMiPFImTGiQZc2p/QZMyHH0VakkplPypCCawLld2ZRdmZAREJurK5ICMXTiV8k7w6nOLpksl2PfLoR4Usc38m75JbK9is8/bo1Zpt5l2wC5upnrK7EurnWBMe6LfO2+Fa44BXuXv3ZZPL+HoX6XyjyBVeaf6hJJWKS4NwuLXwpyHePcRzp3MFXR76nQ58Turyhr3OLHj1anNGnw2v5dunh+JouZxzLoyO8uGtLMWf8gOMbOrIpY0fWn8XEIn4mM3Xn4jhTHVMy9bxk7qnWSBXefcLlDqUb6sjlM9AelZZO80u0ZwEjU0UmhlP1cqmN3PoXmiKmqqWc7e19uQ1z273lFt+QaodLtS44lZNbMHrfVL13NHOtH4+AkJQLWQxImdKg4Ea8zwm4IsZxrO6daEsKWiufMs+NVBIxFYMOieLMyPQ3MN34xn2woXtnb0ko/5Lp5aqq+2Rx6tXtjN6oe8s737ocrU2gYVNN19Q0ENfEtB9pp9b5+/LN9bqlPOWIlJjwXy/AMzya7HPAIWNlGOhmbq9DUy9Ek5ccqvpLIlkNpefIIhzg8ZwDDnjJ83f6uGTijItbcVnP3eKYI7ocflAVC/suR7xeffv/rL+LaVO1OJ6uTi/uPcUnd1DrF9qz2/eyp4mVk5hbtNutOCNgWnJxu+s1ucd4/wAAAP//AQAA///0t09ReJxiYGYAg//nGIwYsAAAAAAA//8BAAD//y8BAgMAAAA=");
+}]]></style><style type="text/css"><![CDATA[.shape {
+  shape-rendering: geometricPrecision;
+  stroke-linejoin: round;
+}
+.connection {
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.blend {
+  mix-blend-mode: multiply;
+  opacity: 0.5;
+}
+
+		.d2-359035160 .fill-N1{fill:#0A0F25;}
+		.d2-359035160 .fill-N2{fill:#676C7E;}
+		.d2-359035160 .fill-N3{fill:#9499AB;}
+		.d2-359035160 .fill-N4{fill:#CFD2DD;}
+		.d2-359035160 .fill-N5{fill:#DEE1EB;}
+		.d2-359035160 .fill-N6{fill:#EEF1F8;}
+		.d2-359035160 .fill-N7{fill:#FFFFFF;}
+		.d2-359035160 .fill-B1{fill:#0D32B2;}
+		.d2-359035160 .fill-B2{fill:#0D32B2;}
+		.d2-359035160 .fill-B3{fill:#E3E9FD;}
+		.d2-359035160 .fill-B4{fill:#E3E9FD;}
+		.d2-359035160 .fill-B5{fill:#EDF0FD;}
+		.d2-359035160 .fill-B6{fill:#F7F8FE;}
+		.d2-359035160 .fill-AA2{fill:#4A6FF3;}
+		.d2-359035160 .fill-AA4{fill:#EDF0FD;}
+		.d2-359035160 .fill-AA5{fill:#F7F8FE;}
+		.d2-359035160 .fill-AB4{fill:#EDF0FD;}
+		.d2-359035160 .fill-AB5{fill:#F7F8FE;}
+		.d2-359035160 .stroke-N1{stroke:#0A0F25;}
+		.d2-359035160 .stroke-N2{stroke:#676C7E;}
+		.d2-359035160 .stroke-N3{stroke:#9499AB;}
+		.d2-359035160 .stroke-N4{stroke:#CFD2DD;}
+		.d2-359035160 .stroke-N5{stroke:#DEE1EB;}
+		.d2-359035160 .stroke-N6{stroke:#EEF1F8;}
+		.d2-359035160 .stroke-N7{stroke:#FFFFFF;}
+		.d2-359035160 .stroke-B1{stroke:#0D32B2;}
+		.d2-359035160 .stroke-B2{stroke:#0D32B2;}
+		.d2-359035160 .stroke-B3{stroke:#E3E9FD;}
+		.d2-359035160 .stroke-B4{stroke:#E3E9FD;}
+		.d2-359035160 .stroke-B5{stroke:#EDF0FD;}
+		.d2-359035160 .stroke-B6{stroke:#F7F8FE;}
+		.d2-359035160 .stroke-AA2{stroke:#4A6FF3;}
+		.d2-359035160 .stroke-AA4{stroke:#EDF0FD;}
+		.d2-359035160 .stroke-AA5{stroke:#F7F8FE;}
+		.d2-359035160 .stroke-AB4{stroke:#EDF0FD;}
+		.d2-359035160 .stroke-AB5{stroke:#F7F8FE;}
+		.d2-359035160 .background-color-N1{background-color:#0A0F25;}
+		.d2-359035160 .background-color-N2{background-color:#676C7E;}
+		.d2-359035160 .background-color-N3{background-color:#9499AB;}
+		.d2-359035160 .background-color-N4{background-color:#CFD2DD;}
+		.d2-359035160 .background-color-N5{background-color:#DEE1EB;}
+		.d2-359035160 .background-color-N6{background-color:#EEF1F8;}
+		.d2-359035160 .background-color-N7{background-color:#FFFFFF;}
+		.d2-359035160 .background-color-B1{background-color:#0D32B2;}
+		.d2-359035160 .background-color-B2{background-color:#0D32B2;}
+		.d2-359035160 .background-color-B3{background-color:#E3E9FD;}
+		.d2-359035160 .background-color-B4{background-color:#E3E9FD;}
+		.d2-359035160 .background-color-B5{background-color:#EDF0FD;}
+		.d2-359035160 .background-color-B6{background-color:#F7F8FE;}
+		.d2-359035160 .background-color-AA2{background-color:#4A6FF3;}
+		.d2-359035160 .background-color-AA4{background-color:#EDF0FD;}
+		.d2-359035160 .background-color-AA5{background-color:#F7F8FE;}
+		.d2-359035160 .background-color-AB4{background-color:#EDF0FD;}
+		.d2-359035160 .background-color-AB5{background-color:#F7F8FE;}
+		.d2-359035160 .color-N1{color:#0A0F25;}
+		.d2-359035160 .color-N2{color:#676C7E;}
+		.d2-359035160 .color-N3{color:#9499AB;}
+		.d2-359035160 .color-N4{color:#CFD2DD;}
+		.d2-359035160 .color-N5{color:#DEE1EB;}
+		.d2-359035160 .color-N6{color:#EEF1F8;}
+		.d2-359035160 .color-N7{color:#FFFFFF;}
+		.d2-359035160 .color-B1{color:#0D32B2;}
+		.d2-359035160 .color-B2{color:#0D32B2;}
+		.d2-359035160 .color-B3{color:#E3E9FD;}
+		.d2-359035160 .color-B4{color:#E3E9FD;}
+		.d2-359035160 .color-B5{color:#EDF0FD;}
+		.d2-359035160 .color-B6{color:#F7F8FE;}
+		.d2-359035160 .color-AA2{color:#4A6FF3;}
+		.d2-359035160 .color-AA4{color:#EDF0FD;}
+		.d2-359035160 .color-AA5{color:#F7F8FE;}
+		.d2-359035160 .color-AB4{color:#EDF0FD;}
+		.d2-359035160 .color-AB5{color:#F7F8FE;}.appendix text.text{fill:#0A0F25}.md{--color-fg-default:#0A0F25;--color-fg-muted:#676C7E;--color-fg-subtle:#9499AB;--color-canvas-default:#FFFFFF;--color-canvas-subtle:#EEF1F8;--color-border-default:#0D32B2;--color-border-muted:#0D32B2;--color-neutral-muted:#EEF1F8;--color-accent-fg:#0D32B2;--color-accent-emphasis:#0D32B2;--color-attention-subtle:#676C7E;--color-danger-fg:red;}.sketch-overlay-B1{fill:url(#streaks-darker-d2-359035160);mix-blend-mode:lighten}.sketch-overlay-B2{fill:url(#streaks-darker-d2-359035160);mix-blend-mode:lighten}.sketch-overlay-B3{fill:url(#streaks-bright-d2-359035160);mix-blend-mode:darken}.sketch-overlay-B4{fill:url(#streaks-bright-d2-359035160);mix-blend-mode:darken}.sketch-overlay-B5{fill:url(#streaks-bright-d2-359035160);mix-blend-mode:darken}.sketch-overlay-B6{fill:url(#streaks-bright-d2-359035160);mix-blend-mode:darken}.sketch-overlay-AA2{fill:url(#streaks-dark-d2-359035160);mix-blend-mode:overlay}.sketch-overlay-AA4{fill:url(#streaks-bright-d2-359035160);mix-blend-mode:darken}.sketch-overlay-AA5{fill:url(#streaks-bright-d2-359035160);mix-blend-mode:darken}.sketch-overlay-AB4{fill:url(#streaks-bright-d2-359035160);mix-blend-mode:darken}.sketch-overlay-AB5{fill:url(#streaks-bright-d2-359035160);mix-blend-mode:darken}.sketch-overlay-N1{fill:url(#streaks-darker-d2-359035160);mix-blend-mode:lighten}.sketch-overlay-N2{fill:url(#streaks-dark-d2-359035160);mix-blend-mode:overlay}.sketch-overlay-N3{fill:url(#streaks-normal-d2-359035160);mix-blend-mode:color-burn}.sketch-overlay-N4{fill:url(#streaks-normal-d2-359035160);mix-blend-mode:color-burn}.sketch-overlay-N5{fill:url(#streaks-bright-d2-359035160);mix-blend-mode:darken}.sketch-overlay-N6{fill:url(#streaks-bright-d2-359035160);mix-blend-mode:darken}.sketch-overlay-N7{fill:url(#streaks-bright-d2-359035160);mix-blend-mode:darken}.light-code{display: block}.dark-code{display: none}]]></style><defs>
+	<filter id="shadow-filter" width="200%" height="200%" x="-50%" y="-50%">
+		<feGaussianBlur stdDeviation="1.7 " in="SourceGraphic"></feGaussianBlur>
+		<feFlood flood-color="#3d4574" flood-opacity="0.4" result="ShadowFeFlood" in="SourceGraphic"></feFlood>
+		<feComposite in="ShadowFeFlood" in2="SourceAlpha" operator="in" result="ShadowFeComposite"></feComposite>
+		<feOffset dx="3" dy="5" result="ShadowFeOffset" in="ShadowFeComposite"></feOffset>
+		<feBlend in="SourceGraphic" in2="ShadowFeOffset" mode="normal" result="ShadowFeBlend"></feBlend>
+	</filter>
+</defs><g class="Y2xpZW50cw== endpoint"><g class="shape" ><rect x="0.000000" y="105.000000" width="260.000000" height="100.000000" stroke="transparent" fill="transparent" style="stroke-width:2;" /></g><text x="130.000000" y="169.500000" fill="#0F172A" class="text-bold" style="text-anchor:middle;font-size:40px">MCP Clients</text></g><g class="cG9tZXJpdW0="><g class="shape" filter="url(#shadow-filter)" ><rect x="360.000000" y="0.000000" width="968.000000" height="310.000000" rx="22.000000" stroke="#6F43E7" fill="#F3EEFF" style="stroke-width:4;" /></g><text x="844.000000" y="49.000000" fill="#2E1065" class="text-bold" style="text-anchor:middle;font-size:44px">Pomerium Gateway</text></g><g class="c2VydmVycw== endpoint"><g class="shape" ><rect x="1428.000000" y="105.000000" width="260.000000" height="100.000000" stroke="transparent" fill="transparent" style="stroke-width:2;" /></g><text x="1558.000000" y="169.500000" fill="#0F172A" class="text-bold" style="text-anchor:middle;font-size:40px">MCP Servers</text></g><g class="cG9tZXJpdW0uc2lnbm9u capability"><g class="shape" ><rect x="392.000000" y="66.000000" width="280.000000" height="90.000000" rx="12.000000" stroke="#6F43E7" fill="#FFFFFF" style="stroke-width:2;" /></g><text x="532.000000" y="121.000000" fill="#2E1065" class="text-bold" style="text-anchor:middle;font-size:28px">Single Sign-On</text></g><g class="cG9tZXJpdW0uYXVkaXQ= capability"><g class="shape" ><rect x="392.000000" y="188.000000" width="280.000000" height="90.000000" rx="12.000000" stroke="#6F43E7" fill="#FFFFFF" style="stroke-width:2;" /></g><text x="532.000000" y="243.000000" fill="#2E1065" class="text-bold" style="text-anchor:middle;font-size:28px">Audit Logs</text></g><g class="cG9tZXJpdW0ucG9saWNpZXM= capability"><g class="shape" ><rect x="704.000000" y="66.000000" width="280.000000" height="90.000000" rx="12.000000" stroke="#6F43E7" fill="#FFFFFF" style="stroke-width:2;" /></g><text x="844.000000" y="121.000000" fill="#2E1065" class="text-bold" style="text-anchor:middle;font-size:28px">Access Policies</text></g><g class="cG9tZXJpdW0udG9vbHBlcm0= capability"><g class="shape" ><rect x="704.000000" y="188.000000" width="280.000000" height="90.000000" rx="12.000000" stroke="#6F43E7" fill="#FFFFFF" style="stroke-width:2;" /></g><text x="844.000000" y="243.000000" fill="#2E1065" class="text-bold" style="text-anchor:middle;font-size:28px">Tool Permissions</text></g><g class="cG9tZXJpdW0ucHJveHk= capability"><g class="shape" ><rect x="1016.000000" y="66.000000" width="280.000000" height="90.000000" rx="12.000000" stroke="#6F43E7" fill="#FFFFFF" style="stroke-width:2;" /></g><text x="1156.000000" y="121.000000" fill="#2E1065" class="text-bold" style="text-anchor:middle;font-size:28px">Secure Proxy</text></g><g class="cG9tZXJpdW0udHVubmVscw== capability"><g class="shape" ><rect x="1016.000000" y="188.000000" width="280.000000" height="90.000000" rx="12.000000" stroke="#6F43E7" fill="#FFFFFF" style="stroke-width:2;" /></g><text x="1156.000000" y="243.000000" fill="#2E1065" class="text-bold" style="text-anchor:middle;font-size:28px">Dev Tunnels</text></g><g class="KGNsaWVudHMgJmx0Oy0mZ3Q7IHBvbWVyaXVtKVswXQ=="><marker id="mk-d2-359035160-327084376" markerWidth="13.000000" markerHeight="16.000000" refX="4.500000" refY="8.000000" viewBox="0.000000 0.000000 13.000000 16.000000" orient="auto" markerUnits="userSpaceOnUse"> <polygon points="13.000000,0.000000 0.000000,8.000000 13.000000,16.000000" fill="#475569" class="connection" stroke-width="3" /> </marker><marker id="mk-d2-359035160-128836843" markerWidth="13.000000" markerHeight="16.000000" refX="8.500000" refY="8.000000" viewBox="0.000000 0.000000 13.000000 16.000000" orient="auto" markerUnits="userSpaceOnUse"> <polygon points="0.000000,0.000000 13.000000,8.000000 0.000000,16.000000" fill="#475569" class="connection" stroke-width="3" /> </marker><path d="M 265.500000 155.000000 C 300.000000 155.000000 320.000000 155.000000 353.500000 155.000000" stroke="#475569" fill="none" class="connection" style="stroke-width:3;" marker-start="url(#mk-d2-359035160-327084376)" marker-end="url(#mk-d2-359035160-128836843)" mask="url(#d2-359035160)" /></g><g class="KHBvbWVyaXVtICZsdDstJmd0OyBzZXJ2ZXJzKVswXQ=="><path d="M 1334.500000 155.000000 C 1368.000000 155.000000 1388.000000 155.000000 1422.500000 155.000000" stroke="#475569" fill="none" class="connection" style="stroke-width:3;" marker-start="url(#mk-d2-359035160-327084376)" marker-end="url(#mk-d2-359035160-128836843)" mask="url(#d2-359035160)" /></g><mask id="d2-359035160" maskUnits="userSpaceOnUse" x="-41" y="-42" width="1770" height="399">
+<rect x="-41" y="-42" width="1770" height="399" fill="white"></rect>
+
+</mask></svg></svg>

--- a/content/docs/capabilities/mcp/img/mcp-overview/capabilities.d2
+++ b/content/docs/capabilities/mcp/img/mcp-overview/capabilities.d2
@@ -1,0 +1,96 @@
+# Pomerium MCP Gateway — Capabilities at a Glance
+#
+# Regenerate:  d2 capabilities.d2 capabilities.svg
+
+grid-rows: 2
+grid-gap: 24
+
+vars: {
+  d2-config: {
+    pad: 10
+  }
+}
+
+auth: |md
+  ### Authentication & Identity
+
+  OAuth 2.1 through your IdP
+
+  Per-user upstream OAuth connections
+
+  Delegated identity for AI agents
+| {
+  shape: rectangle
+  width: 440
+  height: 220
+  style: {
+    fill: "#EEF2FF"
+    stroke: "#4F46E5"
+    stroke-width: 2
+    border-radius: 14
+    font-color: "#1E1B4B"
+  }
+}
+
+gov: |md
+  ### Governance & Access Control
+
+  Fine-grained tool-level RBAC
+
+  Upstream OAuth bridging
+
+  Service accounts for automation
+| {
+  shape: rectangle
+  width: 440
+  height: 220
+  style: {
+    fill: "#FDF2F8"
+    stroke: "#BE185D"
+    stroke-width: 2
+    border-radius: 14
+    font-color: "#500724"
+  }
+}
+
+obs: |md
+  ### Observability
+
+  Audit log for every tool call
+
+  Method, tool, and parameters captured
+
+  Cross-team usage metrics
+| {
+  shape: rectangle
+  width: 440
+  height: 220
+  style: {
+    fill: "#F0FDF4"
+    stroke: "#16A34A"
+    stroke-width: 2
+    border-radius: 14
+    font-color: "#14532D"
+  }
+}
+
+dev: |md
+  ### Developer Experience
+
+  SSH reverse tunnel for local dev
+
+  Server discovery API
+
+  Self-service connection portal
+| {
+  shape: rectangle
+  width: 440
+  height: 220
+  style: {
+    fill: "#FFF7ED"
+    stroke: "#EA580C"
+    stroke-width: 2
+    border-radius: 14
+    font-color: "#7C2D12"
+  }
+}

--- a/content/docs/capabilities/mcp/img/mcp-overview/capabilities.svg
+++ b/content/docs/capabilities/mcp/img/mcp-overview/capabilities.svg
@@ -1,0 +1,850 @@
+<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" data-d2-version="0.7.1" preserveAspectRatio="xMinYMin meet" viewBox="0 0 926 486"><svg class="d2-470764359 d2-svg" width="926" height="486" viewBox="-11 -11 926 486"><rect x="-11.000000" y="-11.000000" width="926.000000" height="486.000000" rx="0.000000" fill="#FFFFFF" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
+.d2-470764359 .text {
+	font-family: "d2-470764359-font-regular";
+}
+@font-face {
+	font-family: d2-470764359-font-regular;
+	src: url("data:application/font-woff;base64,d09GRgABAAAAABGMAAoAAAAAGmwAAguFAAAAAAAAAAAAAAAAAAAAAAAAAABPUy8yAAAA9AAAAGAAAABgXd/Vo2NtYXAAAAFUAAAAtwAAAPYEqQY8Z2x5ZgAAAgwAAAqvAAAOnOa7Z4JoZWFkAAAMvAAAADYAAAA2G4Ue32hoZWEAAAz0AAAAJAAAACQKhAXxaG10eAAADRgAAACuAAAAvFfbCm1sb2NhAAANyAAAAGAAAABgVbJZoG1heHAAAA4oAAAAIAAAACAARwD2bmFtZQAADkgAAAMjAAAIFAbDVU1wb3N0AAARbAAAAB0AAAAg/9EAMgADAgkBkAAFAAACigJYAAAASwKKAlgAAAFeADIBIwAAAgsFAwMEAwICBGAAAvcAAAADAAAAAAAAAABBREJPAEAAIP//Au7/BgAAA9gBESAAAZ8AAAAAAeYClAAAACAAA3icfM25LgQBHIDx39hxLOu+72FZ15iEN1AqJoTMAyglClEI74ToHYlH0XoAjcRfMoVyv+ZrvuRDoiFBS+oLmUxau61jX+HQsdKpc5VL127dR/wXucKBI6UTZyoXrty4i4hPTeI3fuI7PuI93uI1XuI5nuIxHupndxK5jl17dmzZ1qMh1atPvwFNg4a0DBsxasy4CZOmTJsxa868BYuWLFuxKrNmXduGTf4AAAD//wEAAP//IyEo0AB4nHxWbXAb1bl+z5EsJZH8sdbHSrI+d22t9WXJWu2ubcmSrQ/bsS3LXtlx7MQOSZw4TiA3cS7JhGuSYRJC5jKXK0oYGBoo0zLToaWllBlCJ9M/UKgpgQ5TBgp0Mkx/uMxAS3HdToF61dmV7DhM2x875/w4+573ed7nfd4DNTAFgDl8BVSwHeqhEUwALOEhWjwMQ2sFVhBoUiUwiNBOod9JJYR2xtQ8r25Pf5o+e/482n0OX1m/s+vi/Pxrs2fOSP+38okURW9/AhhUANiBS7AdCACDlmW8XobWaFQG1kAztPZN12uuRneDut794c3Zm1PJz1Pov+bmhLs6O++SpnFp/cTyMgCACqYBcDMuAQE2oOXc2KjZbDJqtCZl0dAqNspzMS9NExub6Vczhzrbw/Gh1InBc/vHB/P5Q4sTszO7FnHJ3dfVXqhX60ayPbv86GxXtDOyvpZKd3cCAIJYeQ034avgAKihvF4uxvNs1ExqvV6a0mhMRrOZjfICqdEgUbxvaPhiMbHXHrKl/ckZNronGR50tTEH9GOPHzv6uNju5u1U72lRPJtupWKhKABgBUsMl2CbzImCxGTU0Mxm3s88/tSTj04MnTp16tQQLj179ckfZx9cWrpfyW0aAN3EJdAp9TF5TKyJNnlM0+ge6YMvv0TtuNT3dv+f+jfPvqtwf+ssoZz86itc6rvZJ324ideLr4L73+GV4XI0xxIaDdq769LwyOXJ7Iy9zZqOpg9wJxfoHsOD77sWqpBZJ29r7j0tLj1savxhTvrME6jmgqMbecvKYgma8BDTRdQ+Pi79GpekPyLD+gnESW9u5A4/wiVZP/L56aIshmqce3FJrg1LsAazmWR5XjDI0WK8QGtVtIqhzWYTMT13Tk/q1XqTfunQyDaVOrYkLMXUKi0uSd+lchSVo9Ds+gm0EDwWeFR6Do0/GjgWlB5T6iPzcQhfhfpvKEARGhPllTJRihDQsHi+v/+8WDw3MHCuGJ+MHN29+2hkt378iYWFx8bGHltYeGJ8Z+aseM9DD90jns3AZv11ChfGLUqmaeKWdK8PHk9euvPOA7uKk7tmcal5YmB+TvoHGujt6xc2Y7hxCeqA3NoNBlq1NcxbmSPx0ez3Z586czwvivnjuESPZYdnCOn3yCR9iqZSPb0xUPj2l9fQ5/gqhBTEjKBonIt5vQzThm9XhIybJJ1YZgM15E4HovQ+tnfA0e6adXX7uNl4fI4OOXe2CRlP1Dbj7W7m5/RcsKslFI9QrfY6X60/HYkWQqFm3uGJBV0+m661IdTbHpuIAoLJ8hpuwyXZfxTmCZao9BuvbDUalMkcSxZ9uUCwzzeaPKrnlxbQfdK9hT1e754CuiCdX1jiKzVEL6BVsEEzAEnJJRRiSvpaRgFjImjZiBhZ2orIX+ke+/9vE4FW/6DDTR3smhrNalXUmJlO0mf3R/U7e0cnCFcH7TZ2mn137ZHe67L705TrgfpE2NcCGMTyGvoaL4Oh2kUMraUJ1qSt3FXRTUU2smMhH7XTrdKmRewptO47EN/XlyjEc64e2p3SexxRvPzKbgdz6WTxdDI3Pz16kHKX7WSlTm3lNfQ8WgX7f+pV2Zoae44keo8lIzmr3xR2BHNMMUN1mZs9o/rE4qi4mKBI3mAJT3QU5x1GweGRNRUur6EPNjBUOFOCMxy7QZbAbV709z3H4/sFf9KtLma1KvuwtSfh6nQyKW+f/v6zhVNJp614fb2j0+7LZSQ7GS52TB4ErOT/K7QKFnDdhkAWr2fTWFUehSpE9h5NpuaEmUMISy/XTPbR8SaHq/AmUqc62TF992JhdDG5dKTWuj2/10TwRifyDuYLCk9OAJTC71bmGM0JXKzKE02ZFB+8I53O7ST9DY1N9uz8PPpesiY/OLldm9LP5jPSjDJzQmU3+gytQjt0Q35TRZx3y6IEZU10dQhRTKUG1ZqroreswlDtScpbOfO3qRNeT6OVMliY6Hi7sbn22TmCjIxGGaq2saV9dmIicXzY350IBBLdfN84Gx6v8zTYLEMfZ1OuTrNa12p3tdWqjdkAN+LX1qQaOFds2EfomoykU+gODYfRCymOSyQ4LiVd7vZSNrXa4DcxbQo3IgB6Hy9X3WdDo7KDKvokRFFF56P5fjEYaYm34OVX5jzh/TPSDeTLJr0t0tNQLkMOAF7EL2Gv7Biggbalij7F8hr8Fi9DfYUvpX2rRX22zSfWbVdrtbptZn0nhw+vXzEQCCXV6kpO+Au0Ch4lJ9nUZWZvy0y7uYpZrco9HOhI1XtHgkM7xWAbnxWDYT6LVvrocHvQF9tId0h6urps4EarVdzVO7bizmpV9MgmcCXYbbir+v0zWoV6aPqXs2Gz3qg+Pp9KzccTh1Opw4lUPp9KjoxUey+xKI4uJrLzxfEjR8aL86D4B4u+RqvV3ruVnaIqL0OaDFv9Q87UUwjMHojv66AyFD6j2Eeq2ZN8C7/YYW994KR4Oum0TTyDNN/wD5mDWbRafXlUbqm6R4UA64DPQTbojfWujBWt7G7jdwyo1dGktFz5315eQxfQKviV+m6dE8qY+MaUqAyJd2KztM+dDUQiHraJSvunCqERe6uVd7cFnJEmOhvyFfSMXbB6Qi4rRe6o9XC+eMFNxgwWv510mHS1HqGNSbcq91vKayiHj8tTT9EXzQkCqzT0ps4+HekeGN6Ru3DB46916huMYf30AKpN1ly+nJFWQ+3b1UmtTok1VF5Db6MVWQ+3aZWo2t3H+YFiIOKNUzIv1LB+/wyKSe9nk0wATUm24dYIINADoF+iFagFYFVb3iOq689P7NWROrWO3LF37Dm0In3WPEDTA83IKNkAQR0A+glaASsAKzAsWf1RYLUkXX0ja7V133lkqldnqVXrzLr4rkeemuqvtdWpay36tPTJMYPfaPQbjn3x15PmoMkUIE8qmPTlsJJP09b6CMJtqdXh6QaHvmGbcbuPr9e9OnFQZ9WpdcYdk6PXiHDuHY26F9fEQ83oD9JfXAOUZ8CNatdXI8Mh2RPd5TUs4qugAw56AQxGuUkrwjRUu0HYauoarVk+IbCVndYr2x9T4VnZ/5yoC2UcnpZgIL4n2tJFGUlvLtSdDWZa3LvbnOH6vKGToZJNZirf2jL70yGeStkjUzQVwbipy+nsDTgC/PobYZELZnnSl28O9vkGugLZjqboPsa3v6PnTIx0b8vuaLFTvutC2m71z3H2bkBQAEDX8Dm5fqw83jg5R4I1Fb7138FeW+piFr3HbSMb1l/PVnTfDIB+gf9X5pXlkrjaiswtmDzPsqbWOy71Jbpbs/Zw657k1OHM3cO2DuvP2u94+G5W6Au5w0FufiLxPw8UsLofEPSW1+BlWJTfxJXZUol1r5WmrRaa1tNNDpp2NNHy/eHyLngdFqERgGR4ntFQ9JZfMsZABGENttDNVndL3w8ihlQrctibXLFQz34lfx98hOqRTX5PCxxr8q18lErJviMH/42CyyUrkeYqH6tVPhOtfLRAaw2sQE9bRycbJ/aSHHm/hbOMyXsrZ7lodV9svHij80rXtWvXrnVd6bxx4waqubLpN/AMWtl4x4siWpH1X34DD4KAX5KxE1uAWFwui8XlwoMOq8XptFgd8E8AAAD//wEAAP//Z8wNaQAAAQAAAAILhV4rx4VfDzz1AAMD6AAAAADYXaChAAAAAN1mLzb+Ov7bCG8DyAAAAAMAAgAAAAAAAAABAAAD2P7vAAAImP46/joIbwABAAAAAAAAAAAAAAAAAAAAL3icHMqhSgRRGIbh9/s2WESbGGQ5sFtWcaccFBGDwaQg/EX8TSbxQmza7d6HecwG70KcMsykEU1PefzCLS24MPMV6VOqH0hvk/om/Uj1M6kN0l+kX6k+In1Ceod9P3GjgeoVoZa1D2j0w1pL5ho4dCHouWAiZmeEF4Tn/y90R+iNPQW7Llzqk029s/Wn7ynquFbHkpFzRhods1LHgp6A6eMXAAD//wEAAP//XZkkhwAAAAAALAAsAFAAhgC2ANQA6gD+ATABSAFUAYYBtgHYAgACRAJoAqAC1AMCAzQDaAOKA/YEGAQkBEAEcgSUBMAE9AUUBVQFegWcBbgF5AYUBngGkAa6BtAG8Ab8BywHOAdOAAEAAAAvAIwADABmAAcAAQAAAAAAAAAAAAAAAAAEAAN4nJyU3U4bVxSFPwfbbVQ1FxWKyA06l22VjN0IogSuTAmKVYRTj9Mfqao0eMY/Yjwz8gxQqj5Ar/sWfYtc9Tn6EFWvq7O8DTaqFIEQsM6cvfdZZ6+1D7DJv2xQqz8E/mr+YLjGdnPP8AMeNZ8a3uC48bfh+kpMg7jxm+EmXzb6hj/iff0Pwx+zU//Z8EO26keGP+F5fdPwpxuOfww/Yof3C1yDl/xuuMYWheEHbPKT4Q0eYzVrdR7TNtzgM7YNN9kGBkypSJmSMcYxYsqYc+YklIQkzJkyIiHG0aVDSqWvGZGQY/y/XyNCKuZEqjihwpESkhJRMrGKvyor561OHGk1t70OFRMiTpVxRkSGI2dMTkbCmepUVBTs0aJFyVB8CypKAkqmpATkzBnToscRxwyYMKXEcaRKnllIzoiKSyKd7yzCd2ZIQkZprM7JiMXTiV+i7C7HOHoUil2tfLxW4SmO75TtueWK/YpAv26F2fq5SzYRF+pnqq6k2rmUghPt+nM7fCtcsYe7V3/WmXy4R7H+V6p8yrn0j6VUJiYZzm3RIZSDQvcEx4HWXUJ15Hu6DHhDj3cMtO7Qp0+HEwZ0ea3cHn0cX9PjhENldIUXe0dyzAk/4viGrmJ87cT6s1As4RcKc3cpjnPdY0ahnnvmge6a6IZ3V9jPUL7mjlI5Q82Rj3TSL9OcRYzNFYUYztTLpTdK619sjpjpLl7bm30/DRc2e8spviLXDHu3Ljh55RaMPqRqcMszl/oJiIjJOVXEkJwZLSquxPstEeekOA7VvTeakorOdY4/50ouSZiJQZdMdeYU+huZb0LjPlzzvbO3JFa+Z3p2fav7nOLUqxuN3ql7y73QupysKNAyVfMVNw3FNTPvJ5qpVf6hcku9bjnP6JNI9VQ3uP0OPCegzQ677DPROUPtXNgb0dY70eYV++rBGYmiRnJ1YhV2CXjBLru84sVazQ6HHNBj/w4cF1k9Dnh9a2ddp2UVZ3X+FJu2+DqeXa9e3luvz+/gyy80UTcvY1/a+G5fWLUb/58QMfNc3NbqndwTgv8AAAD//wEAAP//B1tMMAB4nGJgZgCD/+cYjBiwAAAAAAD//wEAAP//LwECAwAAAA==");
+}
+@font-face {
+	font-family: d2-470764359-font-semibold;
+	src: url("data:application/font-woff;base64,d09GRgABAAAAABGgAAoAAAAAGpQAAguFAAAAAAAAAAAAAAAAAAAAAAAAAABPUy8yAAAA9AAAAGAAAABgXqrWeWNtYXAAAAFUAAAAtwAAAPYEqQY8Z2x5ZgAAAgwAAAqRAAAOaMLEzbBoZWFkAAAMoAAAADYAAAA2FnoA72hoZWEAAAzYAAAAJAAAACQKgQXvaG10eAAADPwAAACxAAAAvFqkCXdsb2NhAAANsAAAAGAAAABgVHJYTm1heHAAAA4QAAAAIAAAACAARwD2bmFtZQAADjAAAANOAAAIcCYSZQ5wb3N0AAARgAAAAB0AAAAg/9EAMgADAhoCWAAFAAACigJYAAAASwKKAlgAAAFeADIBJgAAAgsGAwMEAwICBGAAAvcAAAADAAAAAAAAAABBREJPAAAAIP//Au7/BgAAA9gBESAAAZ8AAAAAAesClAAAACAAA3icfM25LgQBHIDx39hxLOu+72FZ15iEN1AqJoTMAyglClEI74ToHYlH0XoAjcRfMoVyv+ZrvuRDoiFBS+oLmUxau61jX+HQsdKpc5VL127dR/wXucKBI6UTZyoXrty4i4hPTeI3fuI7PuI93uI1XuI5nuIxHupndxK5jl17dmzZ1qMh1atPvwFNg4a0DBsxasy4CZOmTJsxa868BYuWLFuxKrNmXduGTf4AAAD//wEAAP//IyEo0AB4nIxXf2wb5f3+vK8dX5M4Py72+WI7/nn2XRIntnPn88VJ7NiJm8TO7zhJmzQ/2rQUmrZJ26QU+LbiW4pY1YFVECpQVdrEpHVoWjf4oxPapkGLNDZNIDpAAgaaBmgamWBoGWHTcp7uzmlTtj/2x/ku0t37Ps/zeT7P+wmUwDgAHsBPgw5KoQpqgAIQSA/pFziOISRBkhhaJ3GIJMbR1/LlW61BfSikD4ZfbXloeRnllvDTm0f67ztw4KO5qSn50ptvyXvRd98CwAUZAIdxHkqBBDARAseyHGMw6EyCieEY4j36Kl3tqNRXONbeOf/OQ8LvBTQzMhJZikpH5WM4v3nixRcBAHSQK65Dgg0YBZvAWyyU2UBQ6s3A6AQ+KkZYhiG3HnJvpQ/Fw4Fob+pE31IunUgmJxb6hgayCzjv7O0IjlbpjYNdqckG9P98Y7heZkUpEgIABC2Fdcziy1AHUOJlWTESjQq8hSZYlvEaDJTZIvBRiTYY0O6xx4ZHz48l9roS1jgr5kILY03pukT9vcahZ44cfm6U9/TbXLHF7LGH/c5MsAUAqzySOA87FD1UFpTZwHC3Mf/40g++/1RK2H/kyH4B559//ntX51YefGBJxZUDQH/CeShXa0N5KIFiKA+VQxfkz9bWkBvnF64uvLpw+92PVN3vvEvm0LflP3/+Oc4vvLwgf3GbaxRfBtd/41qkKjKiQBoM6J7dj4+MPb6rZ59CN7jr8MGFOr769Ceeo0W6gru/1vPw0rGHqyqfmJf/4GnWcOD0FmbFUQLJkB4yt4pKV1flDZyX/4GIzRPIK3+0hRt+hfOg097PrSomKK5zCecVnAIpmCwWWohGJZOyWiQalRhCx+g4xokpMndutZwq05eby44/eriE0OnFwzuPRPQ6ogTn5VdcKbc75ULJzRMo4Mpknc/K7yP2WWc245LfUeqj6HECX4YqsN+liGoyTquSKgwanXgkk3lkYlL5nRycmRkcnJkx5p5bXLw0MnJpcfG53D3nlpbOnFlaOrdVdyfOgxHM29xrYBiKFHit9G9kTnR1Heudm7jYnxnFeXb3QN9c8K9o8FRCsWVxjTach0qgt3eAidEx5B3Xf5g+2tnbfuWRJw7Mdvf2ds/ivG8i0z9jlr9AUAA0E5Nam0HVmi2so018GQIqU06yWLRFOC6I/8MIFprWIKOarv8LpZnp5ta2WNO0O87F9idji2y7a2djMOYI26fasq2HjHxw2NMQZBt8Jq6yKR2O5Fqa2azN2eCzeuhyv3W0V9wtKhhGCuu4E+eVvFHVJgXSrOKIqo8GA+rrPxZf9XRw9XFmuWPZ2PHoYbQsn+/NMUyuFz0gP3n40Q7AECqso5toA6xKOtBepWySCp3gVCIUySi5wyl2Vnv4leTohWcQx/t2ehob7m2b2TO/Q+/pJ5wtdQeG6o0jyeFd1VyszjxoY4/eK38YrWOnHdalCsHvcaq1yBTWcSm+ATXgVJBzDMGQAkVoe22zipJPSOpJ6sr2rOhcWf/MwY754ZYuvjXSahOMyQi+cX3M7j1/fPxU5/xkLjsmfWoxKbo0FNbRdbTxDRfe3ZdKBFm6D3emj6dCPfZWUz3d3p9pcwhUyDtujK+Mjq3E3XQ/aZrOZqat5IDTCRgChXW0hm+ASekkTSd1YU4UthSSxK1N/j6z1L5XbGyv06/M79Db+4xS2MpbQ91txvMPjqwmHNbhlzYTop2dlz6layYGh8c1nyrY30UbUPuNVLFQZsJj2YKuE9RWQvb0UjJ1X6x7Olgiv75jqN0t2Tlm8qX3eT7QrbAYWU20H9rpM6f6TGQf7UThWKpT868dAE3jN7SzihElMVLUiPFSat7NdnUN7LKFqy12e2LvXnRxskQY3F9GTBpz4h75mHqu1Bc49E+0ATwkYEBVhBUjigKKgcQ7wgsUU+xYL8tph0Cx0rptoWAqNqGXU/5ab5sVe0xWD2XlolOC2V/1k2ljNT8eqfaS5RVM866pPcn7swzf4vPxfLg929zYXW9n0+/VxQLxJr2x3ukIVelN6UBsqIEomagM2KL9rIEoM5NUbSwZHg6iX0RCQYEPhSJyPuxymAmHz+NXdMkAoL/gG8Wk2TKlkpRqQ5CZFb1rgB/uW/E1uFtc+Mb1eUfzwVn5t8gf511O+QUoFCABAK/j1zALSlgQEIRzquaZwjp8hW9AleYetV2LBX05LqxUl+oJoqrMZcwmcXrzOkUiNKk3aJh0O9AGeFRMSngrqt6FjLh9z8zv0LsywWiKZAaDQ9lVPxuMrfi5YAytdXuCoQaW34Ibl18o3rZ4o40i7+Ie23krLT50mzha63IH7+Jd9O6/0Mb/kP818cWursV4QvlNRBOJaDQeL3ZdfGVsdCU+N53JTiu9p+VFApeijWLf3UFXdBRNmbYFhsp/sH7mno55yZ106vZrgWHnb+AfRWzs+RPjpxIO69hlRN2JjCL/U2ijOFloOxQTQyNvy3IMZa6wVDuSNFrbFRbKDuj1za3y21o/1RbW0ZNoA+rV2t45D1jtPLgrf2gnpsyGW/wBX9TT5a9nXWGbu7N+71hkzCnaRIff11HvTQYWjJwja3V6rZSdKjMyUkNqzEf3mGgX7XBWGpnWYOcUIDAX1tE0Pg4WzVMiI0qSoA435qK1vpro7Rmo3HvmzM6KujKzWTDuH/5ssuSxx/Z8NknoJ4hyDX+6sI4+RmtK/e/yJlmMtg+Uyte7W+pW5kp17gHjwVkUkT+I824fGpGpPjYICIwA6hoVAIJOoItzhiTofvrDk0NlylxBlQ0tX0VrBV+WZbO+gkype1cCoN+hNbACCCZu24cEzRRnXoKovPLUaamcLteXmktDp568crrDaK3Ql1nKIwjWZs0Bszlgnv36b/ssTRQVoPcp6xoLURWPbXtNJOkuaAbDotlZSRGmUi5kLH315EQ5Va4vNZVml19y7f6NQT+NS0J+F/r0S3cv4+31fLlZyO1Tsq+usI6X8GUoBxFSACaz0pCawU1F50u3G0BxKmFR3pAE7YlglSTkNI3V5zcrjQ2ttQ4X50zN8UzMY7Y0ZPnuwYaUzznYaA9ULNa0su4Om8M/2sAtfCfZYhetgRF3HYO+toRttihr8wU3323JRZrTEQvb523ONg0mAt2StX7I7dslxFcEU13JXCljc7O/DLZSNf7xJgsPCLIA6Nf4tFI7QTnGRAUjKVDZ/MlQj3PyzBx6vq/UWrP5xznNJx4A9DY+r3S4ICawxnhrTlBoRqOCQLFTZ3uigj9uSzbNpWaOdh7qtLbRV7onv7Uc5jsaHcmQsDjVevKhblyyAAg6C+vwNlxU5lztVNXWuuBqanK5GxuNTV5vk3Ip+4cKWfgELkINAM1Fo5zXy2z7pM/aIiJcgh3NQVdD89j1TlPK7/e6uURr5qiGvxFuoVrEKjOyJApU4+e3xpV/35TJB32ML4BdnZIlRtQugVAvilEvRmIIkyAxu2sHJ6pH91h2UifpNDUyVT0xR/fQJ2vd91fff3Pg7MC1a9euDZwduHnzJqo6C1v5Aj9Ha1uzeWYFrckUoMLPcAp24tcU7uQ2Ii6WdblYFqd8TofP53D64N8AAAD//wEAAP//geIG7AAAAAABAAAAAguFbO8bV18PPPUAAwPoAAAAANhdoKsAAAAA2F4RM/44/s8IbgPdAAAAAwACAAAAAAAAAAEAAAPY/u8AAAiY/jj+OAhuAAEAAAAAAAAAAAAAAAAAAAAveJwcyj8uxwAYxvHv85DGIAw1SFkaIYq0GlZ/IiJ5WZq8HMIoYXYEo1VcwAFcwOQORpMDSFrxmz7Lxy9c8wFup9E3pE/pfUe6IjWSvqf3M6mK9DfpV3pfkB5I12z5icHzdD4g9EnjQ3b1S6Mj1rzAtltCBcdaJuauCO8T3py90AOhN1Z1y4r3ONcPi/pi6V8/sm5xaVGr5EQlnc7YsdhQQcD0/gcAAP//AQAA//9ayR5iAAAAAAAALAAsAFAAhgC0ANIA6AD8ASwBRAFQAYQBsAHSAfoCPAJgApgCyAL0AyYDWgN8A+YECAQUBDAEYgSEBLAE4gUCBT4FYgWEBaAFzAX6Bl4GdgagBrYG1gbiBxIHHgc0AAEAAAAvAI4ADABkAAcAAQAAAAAAAAAAAAAAAAAEAAN4nJyUQW8bRRzFf2unNhUiKghFqYSqOYLUrpMoqdrmgkMa1SKygzcFcdzEa3sVe9faXSeEj8FH4MYX4MypH4EDRz4ABw6c0byZxHVAkEaVmreemTfv//5v/sBasEqdYOU+8AY8Dtjgjcc1VvnL4zrdYMXjlbf23GMQ9D1u8Dj42eMmvwS/e/we27UfPb7Peu1Xj99nq/aHxx/UTd14vMp243OPH/CoUXn8IQ8aPzgcwLOG5wwC1hu/eVzj48afHtdZazY8XmGt+YnH9/ioueVxg0fNfX7CsMUGm2xgeHL99QxDmwE5JyQYIi4pqUiYUmLokHFKTsFM/8daG2D4lDEVFTNe0KLFhf6FxNdsoU5OafEZjzFckFIxxtAnoSSh4NyzHZCTUWHoEjO1Wsw6ETlzCk5JzEPCt7+lNSaTyiMKcv1idaeckDNhoHtGzJkQU7BFyAbb7LBLm3326LG7xHnF6Pie/IPPneuxx0u+lv6SVMrNEvuYnErVZ5xj2NRaKPefs8uUmDMS7RqS8J3qsQw7hDxlhx2e8/SdtC17k8qXGEOlrg2027pwhiFneOe+p6rW9tGee02mrrq1iMrvdLdnDGjpvFGtY3lmxDxXvwtS7Q7vpOaIWN017BNieOVZb5/MiktmJBwz9p4tkhjJp4oL+bZwdUIqlzNl2NY9V6WutitnIjocYuiJP1tiPlxisG/jZpo2lRZb00LZ8r2LHp8TkyrjJ0y0snhpse5t85VwxQvMDXdKTtWFGZX6UIorlM8jWvQ44PCGkv/3aKC/rr8nzK8T4qqzybDvu02k7kbmIYY9fXeI5Mg3dDjmFT1ec6zvNn36tOlyTIeXOtujj+ELenTZ14mOsFs7UMq7fIvhSzraY7kT74/rmH1/M6kvpd3lNWXKTJ5b5aGfLsmdOmwYetars6XOnJIy1E6j/mWaVjEjn4qZFE7l5VU2Fi/LJWKqWmxvF+sjck3WQq/Tshou/XywaXWa3BSobtHV8E6Z+e9pfXN+HemmoVQXPi1tqbO5jik5c7khV30ZCWeURHKulK/2zPdiyDWLCr2MkdRbt9pMlETri5sh1st/+3UkfYX643httqzTk2tHh+Keu+T8DQAA//8BAAD//9kvXF8AAHicYmBmAIP/5xiMGLAAAAAAAP//AQAA//8vAQIDAAAA");
+}]]></style><style type="text/css"><![CDATA[.shape {
+  shape-rendering: geometricPrecision;
+  stroke-linejoin: round;
+}
+.connection {
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.blend {
+  mix-blend-mode: multiply;
+  opacity: 0.5;
+}
+
+		.d2-470764359 .fill-N1{fill:#0A0F25;}
+		.d2-470764359 .fill-N2{fill:#676C7E;}
+		.d2-470764359 .fill-N3{fill:#9499AB;}
+		.d2-470764359 .fill-N4{fill:#CFD2DD;}
+		.d2-470764359 .fill-N5{fill:#DEE1EB;}
+		.d2-470764359 .fill-N6{fill:#EEF1F8;}
+		.d2-470764359 .fill-N7{fill:#FFFFFF;}
+		.d2-470764359 .fill-B1{fill:#0D32B2;}
+		.d2-470764359 .fill-B2{fill:#0D32B2;}
+		.d2-470764359 .fill-B3{fill:#E3E9FD;}
+		.d2-470764359 .fill-B4{fill:#E3E9FD;}
+		.d2-470764359 .fill-B5{fill:#EDF0FD;}
+		.d2-470764359 .fill-B6{fill:#F7F8FE;}
+		.d2-470764359 .fill-AA2{fill:#4A6FF3;}
+		.d2-470764359 .fill-AA4{fill:#EDF0FD;}
+		.d2-470764359 .fill-AA5{fill:#F7F8FE;}
+		.d2-470764359 .fill-AB4{fill:#EDF0FD;}
+		.d2-470764359 .fill-AB5{fill:#F7F8FE;}
+		.d2-470764359 .stroke-N1{stroke:#0A0F25;}
+		.d2-470764359 .stroke-N2{stroke:#676C7E;}
+		.d2-470764359 .stroke-N3{stroke:#9499AB;}
+		.d2-470764359 .stroke-N4{stroke:#CFD2DD;}
+		.d2-470764359 .stroke-N5{stroke:#DEE1EB;}
+		.d2-470764359 .stroke-N6{stroke:#EEF1F8;}
+		.d2-470764359 .stroke-N7{stroke:#FFFFFF;}
+		.d2-470764359 .stroke-B1{stroke:#0D32B2;}
+		.d2-470764359 .stroke-B2{stroke:#0D32B2;}
+		.d2-470764359 .stroke-B3{stroke:#E3E9FD;}
+		.d2-470764359 .stroke-B4{stroke:#E3E9FD;}
+		.d2-470764359 .stroke-B5{stroke:#EDF0FD;}
+		.d2-470764359 .stroke-B6{stroke:#F7F8FE;}
+		.d2-470764359 .stroke-AA2{stroke:#4A6FF3;}
+		.d2-470764359 .stroke-AA4{stroke:#EDF0FD;}
+		.d2-470764359 .stroke-AA5{stroke:#F7F8FE;}
+		.d2-470764359 .stroke-AB4{stroke:#EDF0FD;}
+		.d2-470764359 .stroke-AB5{stroke:#F7F8FE;}
+		.d2-470764359 .background-color-N1{background-color:#0A0F25;}
+		.d2-470764359 .background-color-N2{background-color:#676C7E;}
+		.d2-470764359 .background-color-N3{background-color:#9499AB;}
+		.d2-470764359 .background-color-N4{background-color:#CFD2DD;}
+		.d2-470764359 .background-color-N5{background-color:#DEE1EB;}
+		.d2-470764359 .background-color-N6{background-color:#EEF1F8;}
+		.d2-470764359 .background-color-N7{background-color:#FFFFFF;}
+		.d2-470764359 .background-color-B1{background-color:#0D32B2;}
+		.d2-470764359 .background-color-B2{background-color:#0D32B2;}
+		.d2-470764359 .background-color-B3{background-color:#E3E9FD;}
+		.d2-470764359 .background-color-B4{background-color:#E3E9FD;}
+		.d2-470764359 .background-color-B5{background-color:#EDF0FD;}
+		.d2-470764359 .background-color-B6{background-color:#F7F8FE;}
+		.d2-470764359 .background-color-AA2{background-color:#4A6FF3;}
+		.d2-470764359 .background-color-AA4{background-color:#EDF0FD;}
+		.d2-470764359 .background-color-AA5{background-color:#F7F8FE;}
+		.d2-470764359 .background-color-AB4{background-color:#EDF0FD;}
+		.d2-470764359 .background-color-AB5{background-color:#F7F8FE;}
+		.d2-470764359 .color-N1{color:#0A0F25;}
+		.d2-470764359 .color-N2{color:#676C7E;}
+		.d2-470764359 .color-N3{color:#9499AB;}
+		.d2-470764359 .color-N4{color:#CFD2DD;}
+		.d2-470764359 .color-N5{color:#DEE1EB;}
+		.d2-470764359 .color-N6{color:#EEF1F8;}
+		.d2-470764359 .color-N7{color:#FFFFFF;}
+		.d2-470764359 .color-B1{color:#0D32B2;}
+		.d2-470764359 .color-B2{color:#0D32B2;}
+		.d2-470764359 .color-B3{color:#E3E9FD;}
+		.d2-470764359 .color-B4{color:#E3E9FD;}
+		.d2-470764359 .color-B5{color:#EDF0FD;}
+		.d2-470764359 .color-B6{color:#F7F8FE;}
+		.d2-470764359 .color-AA2{color:#4A6FF3;}
+		.d2-470764359 .color-AA4{color:#EDF0FD;}
+		.d2-470764359 .color-AA5{color:#F7F8FE;}
+		.d2-470764359 .color-AB4{color:#EDF0FD;}
+		.d2-470764359 .color-AB5{color:#F7F8FE;}.appendix text.text{fill:#0A0F25}.md{--color-fg-default:#0A0F25;--color-fg-muted:#676C7E;--color-fg-subtle:#9499AB;--color-canvas-default:#FFFFFF;--color-canvas-subtle:#EEF1F8;--color-border-default:#0D32B2;--color-border-muted:#0D32B2;--color-neutral-muted:#EEF1F8;--color-accent-fg:#0D32B2;--color-accent-emphasis:#0D32B2;--color-attention-subtle:#676C7E;--color-danger-fg:red;}.sketch-overlay-B1{fill:url(#streaks-darker-d2-470764359);mix-blend-mode:lighten}.sketch-overlay-B2{fill:url(#streaks-darker-d2-470764359);mix-blend-mode:lighten}.sketch-overlay-B3{fill:url(#streaks-bright-d2-470764359);mix-blend-mode:darken}.sketch-overlay-B4{fill:url(#streaks-bright-d2-470764359);mix-blend-mode:darken}.sketch-overlay-B5{fill:url(#streaks-bright-d2-470764359);mix-blend-mode:darken}.sketch-overlay-B6{fill:url(#streaks-bright-d2-470764359);mix-blend-mode:darken}.sketch-overlay-AA2{fill:url(#streaks-dark-d2-470764359);mix-blend-mode:overlay}.sketch-overlay-AA4{fill:url(#streaks-bright-d2-470764359);mix-blend-mode:darken}.sketch-overlay-AA5{fill:url(#streaks-bright-d2-470764359);mix-blend-mode:darken}.sketch-overlay-AB4{fill:url(#streaks-bright-d2-470764359);mix-blend-mode:darken}.sketch-overlay-AB5{fill:url(#streaks-bright-d2-470764359);mix-blend-mode:darken}.sketch-overlay-N1{fill:url(#streaks-darker-d2-470764359);mix-blend-mode:lighten}.sketch-overlay-N2{fill:url(#streaks-dark-d2-470764359);mix-blend-mode:overlay}.sketch-overlay-N3{fill:url(#streaks-normal-d2-470764359);mix-blend-mode:color-burn}.sketch-overlay-N4{fill:url(#streaks-normal-d2-470764359);mix-blend-mode:color-burn}.sketch-overlay-N5{fill:url(#streaks-bright-d2-470764359);mix-blend-mode:darken}.sketch-overlay-N6{fill:url(#streaks-bright-d2-470764359);mix-blend-mode:darken}.sketch-overlay-N7{fill:url(#streaks-bright-d2-470764359);mix-blend-mode:darken}.light-code{display: block}.dark-code{display: none}]]></style><style type="text/css">.d2-470764359 .md em,
+.d2-470764359 .md dfn {
+  font-family: "d2-470764359-font-italic";
+}
+
+.d2-470764359 .md b,
+.d2-470764359 .md strong {
+  font-family: "d2-470764359-font-bold";
+}
+
+.d2-470764359 .md code,
+.d2-470764359 .md kbd,
+.d2-470764359 .md pre,
+.d2-470764359 .md samp {
+  font-family: "d2-470764359-font-mono";
+  font-size: 1em;
+}
+
+.d2-470764359 .md {
+  tab-size: 4;
+}
+
+/* variables are provided in d2renderers/d2svg/d2svg.go */
+
+.d2-470764359 .md {
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  background-color: transparent; /* we don't want to define the background color */
+  font-family: "d2-470764359-font-regular";
+  font-size: 16px;
+  line-height: 1.5;
+  word-wrap: break-word;
+}
+
+.d2-470764359 .md details,
+.d2-470764359 .md figcaption,
+.d2-470764359 .md figure {
+  display: block;
+}
+
+.d2-470764359 .md summary {
+  display: list-item;
+}
+
+.d2-470764359 .md [hidden] {
+  display: none !important;
+}
+
+.d2-470764359 .md a {
+  background-color: transparent;
+  color: var(--color-accent-fg);
+  text-decoration: none;
+}
+
+.d2-470764359 .md a:active,
+.d2-470764359 .md a:hover {
+  outline-width: 0;
+}
+
+.d2-470764359 .md abbr[title] {
+  border-bottom: none;
+  text-decoration: underline dotted;
+}
+
+.d2-470764359 .md dfn {
+  font-style: italic;
+}
+
+.d2-470764359 .md h1 {
+  margin: 0.67em 0;
+  padding-bottom: 0.3em;
+  font-size: 2em;
+  border-bottom: 1px solid var(--color-border-muted);
+}
+
+.d2-470764359 .md mark {
+  background-color: var(--color-attention-subtle);
+  color: var(--color-text-primary);
+}
+
+.d2-470764359 .md small {
+  font-size: 90%;
+}
+
+.d2-470764359 .md sub,
+.d2-470764359 .md sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+.d2-470764359 .md sub {
+  bottom: -0.25em;
+}
+
+.d2-470764359 .md sup {
+  top: -0.5em;
+}
+
+.d2-470764359 .md img {
+  border-style: none;
+  max-width: 100%;
+  box-sizing: content-box;
+  background-color: var(--color-canvas-default);
+}
+
+.d2-470764359 .md figure {
+  margin: 1em 40px;
+}
+
+.d2-470764359 .md hr {
+  box-sizing: content-box;
+  overflow: hidden;
+  background: transparent;
+  border-bottom: 1px solid var(--color-border-muted);
+  height: 0.25em;
+  padding: 0;
+  margin: 24px 0;
+  background-color: var(--color-border-default);
+  border: 0;
+}
+
+.d2-470764359 .md input {
+  font: inherit;
+  margin: 0;
+  overflow: visible;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.d2-470764359 .md [type="button"],
+.d2-470764359 .md [type="reset"],
+.d2-470764359 .md [type="submit"] {
+  -webkit-appearance: button;
+}
+
+.d2-470764359 .md [type="button"]::-moz-focus-inner,
+.d2-470764359 .md [type="reset"]::-moz-focus-inner,
+.d2-470764359 .md [type="submit"]::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+.d2-470764359 .md [type="button"]:-moz-focusring,
+.d2-470764359 .md [type="reset"]:-moz-focusring,
+.d2-470764359 .md [type="submit"]:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+.d2-470764359 .md [type="checkbox"],
+.d2-470764359 .md [type="radio"] {
+  box-sizing: border-box;
+  padding: 0;
+}
+
+.d2-470764359 .md [type="number"]::-webkit-inner-spin-button,
+.d2-470764359 .md [type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+.d2-470764359 .md [type="search"] {
+  -webkit-appearance: textfield;
+  outline-offset: -2px;
+}
+
+.d2-470764359 .md [type="search"]::-webkit-search-cancel-button,
+.d2-470764359 .md [type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.d2-470764359 .md ::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54;
+}
+
+.d2-470764359 .md ::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+
+.d2-470764359 .md a:hover {
+  text-decoration: underline;
+}
+
+.d2-470764359 .md hr::before {
+  display: table;
+  content: "";
+}
+
+.d2-470764359 .md hr::after {
+  display: table;
+  clear: both;
+  content: "";
+}
+
+.d2-470764359 .md table {
+  border-spacing: 0;
+  border-collapse: collapse;
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow: auto;
+}
+
+.d2-470764359 .md td,
+.d2-470764359 .md th {
+  padding: 0;
+}
+
+.d2-470764359 .md details summary {
+  cursor: pointer;
+}
+
+.d2-470764359 .md details:not([open]) > *:not(summary) {
+  display: none !important;
+}
+
+.d2-470764359 .md kbd {
+  display: inline-block;
+  padding: 3px 5px;
+  color: var(--color-fg-default);
+  vertical-align: middle;
+  background-color: var(--color-canvas-subtle);
+  border: solid 1px var(--color-neutral-muted);
+  border-bottom-color: var(--color-neutral-muted);
+  border-radius: 6px;
+  box-shadow: inset 0 -1px 0 var(--color-neutral-muted);
+}
+
+.d2-470764359 .md h1,
+.d2-470764359 .md h2,
+.d2-470764359 .md h3,
+.d2-470764359 .md h4,
+.d2-470764359 .md h5,
+.d2-470764359 .md h6 {
+  margin-top: 24px;
+  margin-bottom: 16px;
+  font-weight: 400;
+  line-height: 1.25;
+  font-family: "d2-470764359-font-semibold";
+}
+
+.d2-470764359 .md h2 {
+  padding-bottom: 0.3em;
+  font-size: 1.5em;
+  border-bottom: 1px solid var(--color-border-muted);
+}
+
+.d2-470764359 .md h3 {
+  font-size: 1.25em;
+}
+
+.d2-470764359 .md h4 {
+  font-size: 1em;
+}
+
+.d2-470764359 .md h5 {
+  font-size: 0.875em;
+}
+
+.d2-470764359 .md h6 {
+  font-size: 0.85em;
+  color: var(--color-fg-muted);
+}
+
+.d2-470764359 .md p {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+.d2-470764359 .md blockquote {
+  margin: 0;
+  padding: 0 1em;
+  color: var(--color-fg-muted);
+  border-left: 0.25em solid var(--color-border-default);
+}
+
+.d2-470764359 .md ul,
+.d2-470764359 .md ol {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-left: 2em;
+}
+
+.d2-470764359 .md ol ol,
+.d2-470764359 .md ul ol {
+  list-style-type: lower-roman;
+}
+
+.d2-470764359 .md ul ul ol,
+.d2-470764359 .md ul ol ol,
+.d2-470764359 .md ol ul ol,
+.d2-470764359 .md ol ol ol {
+  list-style-type: lower-alpha;
+}
+
+.d2-470764359 .md dd {
+  margin-left: 0;
+}
+
+.d2-470764359 .md pre {
+  margin-top: 0;
+  margin-bottom: 0;
+  word-wrap: normal;
+}
+
+.d2-470764359 .md ::placeholder {
+  color: var(--color-fg-subtle);
+  opacity: 1;
+}
+
+.d2-470764359 .md input::-webkit-outer-spin-button,
+.d2-470764359 .md input::-webkit-inner-spin-button {
+  margin: 0;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.d2-470764359 .md::before {
+  display: table;
+  content: "";
+}
+
+.d2-470764359 .md::after {
+  display: table;
+  clear: both;
+  content: "";
+}
+
+.d2-470764359 .md > *:first-child {
+  margin-top: 0 !important;
+}
+
+.d2-470764359 .md > *:last-child {
+  margin-bottom: 0 !important;
+}
+
+.d2-470764359 .md a:not([href]) {
+  color: inherit;
+  text-decoration: none;
+}
+
+.d2-470764359 .md .absent {
+  color: var(--color-danger-fg);
+}
+
+.d2-470764359 .md .anchor {
+  float: left;
+  padding-right: 4px;
+  margin-left: -20px;
+  line-height: 1;
+}
+
+.d2-470764359 .md .anchor:focus {
+  outline: none;
+}
+
+.d2-470764359 .md p,
+.d2-470764359 .md blockquote,
+.d2-470764359 .md ul,
+.d2-470764359 .md ol,
+.d2-470764359 .md dl,
+.d2-470764359 .md table,
+.d2-470764359 .md pre,
+.d2-470764359 .md details {
+  margin-top: 0;
+  margin-bottom: 16px;
+}
+
+.d2-470764359 .md blockquote > :first-child {
+  margin-top: 0;
+}
+
+.d2-470764359 .md blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+.d2-470764359 .md sup > a::before {
+  content: "[";
+}
+
+.d2-470764359 .md sup > a::after {
+  content: "]";
+}
+
+.d2-470764359 .md h1:hover .anchor,
+.d2-470764359 .md h2:hover .anchor,
+.d2-470764359 .md h3:hover .anchor,
+.d2-470764359 .md h4:hover .anchor,
+.d2-470764359 .md h5:hover .anchor,
+.d2-470764359 .md h6:hover .anchor {
+  text-decoration: none;
+}
+
+.d2-470764359 .md h1 tt,
+.d2-470764359 .md h1 code,
+.d2-470764359 .md h2 tt,
+.d2-470764359 .md h2 code,
+.d2-470764359 .md h3 tt,
+.d2-470764359 .md h3 code,
+.d2-470764359 .md h4 tt,
+.d2-470764359 .md h4 code,
+.d2-470764359 .md h5 tt,
+.d2-470764359 .md h5 code,
+.d2-470764359 .md h6 tt,
+.d2-470764359 .md h6 code {
+  padding: 0 0.2em;
+  font-size: inherit;
+}
+
+.d2-470764359 .md ul.no-list,
+.d2-470764359 .md ol.no-list {
+  padding: 0;
+  list-style-type: none;
+}
+
+.d2-470764359 .md ol[type="1"] {
+  list-style-type: decimal;
+}
+
+.d2-470764359 .md ol[type="a"] {
+  list-style-type: lower-alpha;
+}
+
+.d2-470764359 .md ol[type="i"] {
+  list-style-type: lower-roman;
+}
+
+.d2-470764359 .md div > ol:not([type]) {
+  list-style-type: decimal;
+}
+
+.d2-470764359 .md ul ul,
+.d2-470764359 .md ul ol,
+.d2-470764359 .md ol ol,
+.d2-470764359 .md ol ul {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.d2-470764359 .md li > p {
+  margin-top: 16px;
+}
+
+.d2-470764359 .md li + li {
+  margin-top: 0.25em;
+}
+
+.d2-470764359 .md dl {
+  padding: 0;
+}
+
+.d2-470764359 .md dl dt {
+  padding: 0;
+  margin-top: 16px;
+  font-size: 1em;
+  font-style: italic;
+  font-family: "d2-470764359-font-semibold";
+}
+
+.d2-470764359 .md dl dd {
+  padding: 0 16px;
+  margin-bottom: 16px;
+}
+
+.d2-470764359 .md table th {
+  font-family: "d2-470764359-font-semibold";
+}
+
+.d2-470764359 .md table th,
+.d2-470764359 .md table td {
+  padding: 6px 13px;
+  border: 1px solid var(--color-border-default);
+}
+
+.d2-470764359 .md table tr {
+  background-color: var(--color-canvas-default);
+  border-top: 1px solid var(--color-border-muted);
+}
+
+.d2-470764359 .md table tr:nth-child(2n) {
+  background-color: var(--color-canvas-subtle);
+}
+
+.d2-470764359 .md table img {
+  background-color: transparent;
+}
+
+.d2-470764359 .md img[align="right"] {
+  padding-left: 20px;
+}
+
+.d2-470764359 .md img[align="left"] {
+  padding-right: 20px;
+}
+
+.d2-470764359 .md span.frame {
+  display: block;
+  overflow: hidden;
+}
+
+.d2-470764359 .md span.frame > span {
+  display: block;
+  float: left;
+  width: auto;
+  padding: 7px;
+  margin: 13px 0 0;
+  overflow: hidden;
+  border: 1px solid var(--color-border-default);
+}
+
+.d2-470764359 .md span.frame span img {
+  display: block;
+  float: left;
+}
+
+.d2-470764359 .md span.frame span span {
+  display: block;
+  padding: 5px 0 0;
+  clear: both;
+  color: var(--color-fg-default);
+}
+
+.d2-470764359 .md span.align-center {
+  display: block;
+  overflow: hidden;
+  clear: both;
+}
+
+.d2-470764359 .md span.align-center > span {
+  display: block;
+  margin: 13px auto 0;
+  overflow: hidden;
+  text-align: center;
+}
+
+.d2-470764359 .md span.align-center span img {
+  margin: 0 auto;
+  text-align: center;
+}
+
+.d2-470764359 .md span.align-right {
+  display: block;
+  overflow: hidden;
+  clear: both;
+}
+
+.d2-470764359 .md span.align-right > span {
+  display: block;
+  margin: 13px 0 0;
+  overflow: hidden;
+  text-align: right;
+}
+
+.d2-470764359 .md span.align-right span img {
+  margin: 0;
+  text-align: right;
+}
+
+.d2-470764359 .md span.float-left {
+  display: block;
+  float: left;
+  margin-right: 13px;
+  overflow: hidden;
+}
+
+.d2-470764359 .md span.float-left span {
+  margin: 13px 0 0;
+}
+
+.d2-470764359 .md span.float-right {
+  display: block;
+  float: right;
+  margin-left: 13px;
+  overflow: hidden;
+}
+
+.d2-470764359 .md span.float-right > span {
+  display: block;
+  margin: 13px auto 0;
+  overflow: hidden;
+  text-align: right;
+}
+
+.d2-470764359 .md code,
+.d2-470764359 .md tt {
+  padding: 0.2em 0.4em;
+  margin: 0;
+  font-size: 85%;
+  background-color: var(--color-neutral-muted);
+  border-radius: 6px;
+}
+
+.d2-470764359 .md code br,
+.d2-470764359 .md tt br {
+  display: none;
+}
+
+.d2-470764359 .md del code {
+  text-decoration: inherit;
+}
+
+.d2-470764359 .md pre code {
+  font-size: 100%;
+}
+
+.d2-470764359 .md pre > code {
+  padding: 0;
+  margin: 0;
+  word-break: normal;
+  white-space: pre;
+  background: transparent;
+  border: 0;
+}
+
+.d2-470764359 .md .highlight {
+  margin-bottom: 16px;
+}
+
+.d2-470764359 .md .highlight pre {
+  margin-bottom: 0;
+  word-break: normal;
+}
+
+.d2-470764359 .md .highlight pre,
+.d2-470764359 .md pre {
+  padding: 16px;
+  overflow: auto;
+  font-size: 85%;
+  line-height: 1.45;
+  background-color: var(--color-canvas-subtle);
+  border-radius: 6px;
+}
+
+.d2-470764359 .md pre code,
+.d2-470764359 .md pre tt {
+  display: inline;
+  max-width: auto;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  line-height: inherit;
+  word-wrap: normal;
+  background-color: transparent;
+  border: 0;
+}
+
+.d2-470764359 .md .csv-data td,
+.d2-470764359 .md .csv-data th {
+  padding: 5px;
+  overflow: hidden;
+  font-size: 12px;
+  line-height: 1;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.d2-470764359 .md .csv-data .blob-num {
+  padding: 10px 8px 9px;
+  text-align: right;
+  background: var(--color-canvas-default);
+  border: 0;
+}
+
+.d2-470764359 .md .csv-data tr {
+  border-top: 0;
+}
+
+.d2-470764359 .md .csv-data th {
+  font-family: "d2-470764359-font-semibold";
+  background: var(--color-canvas-subtle);
+  border-top: 0;
+}
+
+.d2-470764359 .md .footnotes {
+  font-size: 12px;
+  color: var(--color-fg-muted);
+  border-top: 1px solid var(--color-border-default);
+}
+
+.d2-470764359 .md .footnotes ol {
+  padding-left: 16px;
+}
+
+.d2-470764359 .md .footnotes li {
+  position: relative;
+}
+
+.d2-470764359 .md .footnotes li:target::before {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  bottom: -8px;
+  left: -24px;
+  pointer-events: none;
+  content: "";
+  border: 2px solid var(--color-accent-emphasis);
+  border-radius: 6px;
+}
+
+.d2-470764359 .md .footnotes li:target {
+  color: var(--color-fg-default);
+}
+
+.d2-470764359 .md .task-list-item {
+  list-style-type: none;
+}
+
+.d2-470764359 .md .task-list-item label {
+  font-weight: 400;
+}
+
+.d2-470764359 .md .task-list-item.enabled label {
+  cursor: pointer;
+}
+
+.d2-470764359 .md .task-list-item + .task-list-item {
+  margin-top: 3px;
+}
+
+.d2-470764359 .md .task-list-item .handle {
+  display: none;
+}
+
+.d2-470764359 .md .task-list-item-checkbox {
+  margin: 0 0.2em 0.25em -1.6em;
+  vertical-align: middle;
+}
+
+.d2-470764359 .md .contains-task-list:dir(rtl) .task-list-item-checkbox {
+  margin: 0 -1.6em 0.25em 0.2em;
+}
+</style><g class="YXV0aA=="><g class="shape" ><rect x="0.000000" y="0.000000" width="440.000000" height="220.000000" rx="14.000000" stroke="#4F46E5" fill="#EEF2FF" style="stroke-width:2;" /></g><g><foreignObject requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" x="92.000000" y="37.000000" width="256" height="146"><div xmlns="http://www.w3.org/1999/xhtml" class="md" style="background-color:#EEF2FF;color:#1E1B4B"><h3>Authentication &amp; Identity</h3>
+<p>OAuth 2.1 through your IdP</p>
+<p>Per-user upstream OAuth connections</p>
+<p>Delegated identity for AI agents</p>
+</div></foreignObject></g></g><g class="Z292"><g class="shape" ><rect x="464.000000" y="0.000000" width="440.000000" height="220.000000" rx="14.000000" stroke="#BE185D" fill="#FDF2F8" style="stroke-width:2;" /></g><g><foreignObject requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" x="559.000000" y="37.000000" width="250" height="146"><div xmlns="http://www.w3.org/1999/xhtml" class="md" style="background-color:#FDF2F8;color:#500724"><h3>Governance &amp; Access Control</h3>
+<p>Fine-grained tool-level RBAC</p>
+<p>Upstream OAuth bridging</p>
+<p>Service accounts for automation</p>
+</div></foreignObject></g></g><g class="b2Jz"><g class="shape" ><rect x="0.000000" y="244.000000" width="440.000000" height="220.000000" rx="14.000000" stroke="#16A34A" fill="#F0FDF4" style="stroke-width:2;" /></g><g><foreignObject requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" x="88.500000" y="281.000000" width="263" height="146"><div xmlns="http://www.w3.org/1999/xhtml" class="md" style="background-color:#F0FDF4;color:#14532D"><h3>Observability</h3>
+<p>Audit log for every tool call</p>
+<p>Method, tool, and parameters captured</p>
+<p>Cross-team usage metrics</p>
+</div></foreignObject></g></g><g class="ZGV2"><g class="shape" ><rect x="464.000000" y="244.000000" width="440.000000" height="220.000000" rx="14.000000" stroke="#EA580C" fill="#FFF7ED" style="stroke-width:2;" /></g><g><foreignObject requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" x="577.500000" y="281.000000" width="213" height="146"><div xmlns="http://www.w3.org/1999/xhtml" class="md" style="background-color:#FFF7ED;color:#7C2D12"><h3>Developer Experience</h3>
+<p>SSH reverse tunnel for local dev</p>
+<p>Server discovery API</p>
+<p>Self-service connection portal</p>
+</div></foreignObject></g></g><mask id="d2-470764359" maskUnits="userSpaceOnUse" x="-11" y="-11" width="926" height="486">
+<rect x="-11" y="-11" width="926" height="486" fill="white"></rect>
+
+</mask></svg></svg>


### PR DESCRIPTION
## Summary

- Adds an **architecture diagram** to the top-level MCP capabilities page showing Pomerium as the gateway between MCP clients and internal servers, with its six gateway functions (Single Sign-On, Access Policies, Secure Proxy, Audit Logs, Tool Permissions, Dev Tunnels)
- Adds a **capabilities diagram** summarizing the four pillars — Authentication & Identity, Governance & Access Control, Observability, Developer Experience — with their concrete technical features
- Diagrams are authored in [D2](https://d2lang.com) and rendered to SVG; source files are committed alongside the output so they can be regenerated or edited later

## Regenerating the SVGs

\`\`\`bash
cd content/docs/capabilities/mcp/img/mcp-overview
d2 architecture.d2 architecture.svg
d2 capabilities.d2 capabilities.svg
\`\`\`

## Test plan

- [ ] \`npm start\` renders the MCP overview page with both SVG diagrams visible
- [ ] \`npm run build\` completes without errors and bundles both SVGs
- [ ] Diagrams remain legible at typical docs page width