### PR TITLE
docs: update guide-review skill with style rules, diagram guidelines, and rubric refinements

### DIFF
--- a/.agents/skills/guide-review/SKILL.md
+++ b/.agents/skills/guide-review/SKILL.md
@@ -118,6 +118,18 @@ When a guide needs diagrams, follow these rules:
 
 If Excalidraw MCP is not enabled for your account, enable it before generating non-swim-lane diagrams. Mermaid is an acceptable fallback only when Excalidraw is unavailable.
 
+## Screenshots
+
+When creating a guide, capture relevant screenshots of Pomerium Zero as you navigate through the steps the guide describes. Screenshots ground abstract instructions in what the user will actually see and are especially valuable for UI-heavy flows.
+
+**How to capture screenshots:** Guide creation most commonly happens in Claude.ai or the Claude Code desktop app (Cowork), where Pomerium Zero is navigated via the Claude browser extension. Although the browser extension can take screenshots, those screenshots are confined to the browser sandbox and cannot be written to the repository. Use the **Chrome DevTools MCP** instead which you have access to — it captures screenshots outside the sandbox and allows them to be placed directly in the guide's `img/` directory.
+
+- Place screenshots in the guide's `img/{guide-name}/` directory alongside any diagrams, for example `content/docs/guides/img/grafana/`.
+- Use descriptive, lowercase, hyphenated filenames that match the step they illustrate, for example `route-config-tls-settings.png`.
+- Crop screenshots to the relevant UI area. Avoid full-browser captures that bury the relevant element in surrounding UI noise.
+- After placing a screenshot, reference it in the guide with a descriptive `alt` attribute.
+- If the Chrome DevTools MCP is not available, note where screenshots should go and describe what each should show so they can be added in a follow-up pass.
+
 ## Pre-publish validation
 
 After drafting or revising a guide, run these checks before marking it publish-ready:

--- a/.agents/skills/guide-review/SKILL.md
+++ b/.agents/skills/guide-review/SKILL.md
@@ -51,14 +51,17 @@ A guide is **not** publish-ready if any publish blocker is present, regardless o
 A guide is not publish-ready if any of the following are true:
 
 - Missing prerequisites section
+- Prerequisites section does not include a working Pomerium Zero cluster (with link to [Quickstart](/docs/get-started/quickstart)) or an equivalent self-hosted deploy prereq
 - No verification steps or success criteria
 - No troubleshooting section
 - No security caveats for externally exposed services or identity-sensitive flows
-- No rollback, cleanup, or teardown path where changes are made
+- No rollback, cleanup, or teardown path where changes are made **and** where Operations + Lifecycle Management is applicable (see dimension 9 in the rubric — guides that only configure a managed control plane are exempt)
 - Commands, config snippets, or manifests contain unresolved placeholders
 - Steps depend on unexplained environment assumptions
 - Moved or deprecated content is listed as an active guide without clear labeling
 - The guide cannot be followed without guessing at key values, sequence, or expected outcomes
+- Prose contains em dashes (`—`, `–`) or emojis (see **Style rules** below)
+- An acronym is used before being defined (see **Style rules** below). Well-known internet-infrastructure acronyms are exempt; product-specific and guide-local acronyms are not.
 
 ## Minimum evidence requirements
 
@@ -66,12 +69,12 @@ Every guide should include, at minimum:
 
 - 1 explicit "what this guide does" statement
 - 1 explicit "when to use this guide" statement
-- 1 prerequisites section
+- 1 prerequisites section, which must include an explicit "working Pomerium Zero cluster" prereq linking to [/docs/get-started/quickstart](/docs/get-started/quickstart) (self-hosted guides may substitute an equivalent deploy link, but a running cluster must still be stated as a prereq)
 - 1 architecture or request-flow explanation
 - 3 verification checkpoints
 - 3 troubleshooting entries
 - 2 security caveats
-- 1 operations section covering rollback and cleanup
+- 1 operations section covering rollback and cleanup — **only when Operations + Lifecycle Management is applicable** (see dimension 9 in the rubric). Guides that only configure a managed control plane (for example, Pomerium Zero route/policy/settings changes) are exempt and do not need a dedicated Operations section. Upgrade guidance within that section is itself only required when the guide installs or pins a Pomerium component whose version the reader controls.
 - Copy-pasteable commands and config examples
 - Consistent variable and placeholder naming
 - At least one clear expected end-state or definition of done
@@ -88,12 +91,44 @@ Every guide should include, at minimum:
 | Verification + Checkpoints |  | 2 |  |  |
 | Troubleshooting + Failure Modes |  | 2 |  |  |
 | Security + Risk Posture |  | 2 |  |  |
-| Operations + Lifecycle Management |  | 1 |  |  |
+| Operations + Lifecycle Management (may be N/A) |  | 1 |  |  |
 | Maintainability + Scanability |  | 1 |  |  |
 
-**Total Weighted Score:** \_\_\_\_ / 45
+**Total Weighted Score:** \_\_\_\_ / 45 (or \_\_\_\_ / 42 if Operations + Lifecycle Management is N/A)
 
 **Publish blockers present:** Yes / No **Publish recommendation:** Publish-ready / Needs edits / Major revision
+
+## Style rules
+
+These are hard rules. A guide that violates them is not publish-ready regardless of score.
+
+- **No em dashes (`—`) or en dashes (`–`) in prose.** Use a period, comma, colon, parentheses, or rewrite the sentence. Em dashes are a strong LLM-output tell and read inconsistent across the guides set. This rule applies to body prose, callouts, list items, headings, and table cells. It does not apply to code, config, CLI output, or content quoted from external sources.
+- **No emojis anywhere.** No decorative emojis in headings, no status emojis (✅ ❌ ⚠️ 🎉 🚀 💡 etc.) in prose or lists, no emoji bullets. Use plain Markdown and Docusaurus admonitions (`:::note`, `:::tip`, `:::warning`, `:::danger`, `:::info`) for emphasis and tone instead. Unicode symbols that are not emoji (arrows like `→`, checkmarks inside code examples, mathematical symbols) are fine when they carry meaning.
+- **Expand every acronym on first use.** The first time an acronym appears in the guide, write the full term followed by the acronym in parentheses, for example `Security Information and Event Management (SIEM)`, `Client ID Metadata Document (CIMD)`, `Pomerium Policy Language (PPL)`. Subsequent uses may use the short form. This applies to the body, admonitions, tables, diagrams captions, and front-matter descriptions. Widely-understood internet-infrastructure acronyms where spelling out would read as noise (HTTP, HTTPS, HTML, URL, TLS, DNS, IP, JSON, YAML, API, SDK, CLI, UI, OS, VM, CPU, RAM, UUID, SSO, OAuth, OIDC, SAML, JWT, CSV, PDF, MIME, PKI, CA, CRL, CDN, SaaS, IaaS, PaaS, CI, CD, PR, SQL, REST, gRPC, RPC, RFC) are exempt from this rule. Product-specific or guide-local acronyms (for example TE / TI / AS / PRM / DCR / CIMD / PPL / IdP / SIEM / MCP on first use in that guide) are **not** exempt. When in doubt, expand.
+- **Prefer descriptive nouns over bare acronyms in later paragraphs when the guide spans many sections.** If the guide is long enough that a reader might land on a later section without reading the definition, reintroduce the full form once per major section heading, or reword to use a descriptive noun ("the cached upstream token") instead of the bare acronym ("the cached TI"). Readability beats strict consistency.
+
+When flagging a violation, quote the offending line and suggest a concrete rewrite.
+
+## Diagram guidelines
+
+When a guide needs diagrams, follow these rules:
+
+- **Swim lane charts**: Use Mermaid diagrams. Mermaid is already enabled in Docusaurus and renders natively in fenced code blocks with the `mermaid` language tag.
+- **All other diagrams** (architecture, request flow, topology, sequence, etc.): Prefer the **Excalidraw MCP server**, which is available in the organization. Excalidraw produces clear, hand-drawn-style visuals that are easier to scan than dense box-and-arrow diagrams. Export the diagram as SVG or PNG and place it in the guide's `img/{guide-name}/` directory. For example, a diagram for the `grafana.mdx` guide goes in `content/docs/guides/img/grafana/` where `{guide-name}` is replaced with the actual guide name, e.g. grafana.
+
+If Excalidraw MCP is not enabled for your account, enable it before generating non-swim-lane diagrams. Mermaid is an acceptable fallback only when Excalidraw is unavailable.
+
+## Pre-publish validation
+
+After drafting or revising a guide, run these checks before marking it publish-ready:
+
+1. **Format**: Run `yarn format` to auto-fix formatting issues (Prettier with prose wrap `never`, single quotes, trailing commas).
+2. **Spell check**: Run `yarn cspell` to find unknown words. For intentional Pomerium-specific or guide-specific terms, add them to the `words` array in `cspell.json`. Do not suppress legitimate typos.
+3. **Full check**: Run `yarn check` (runs both `format-check` and `cspell`) to confirm a clean pass.
+4. **Build**: Run `yarn build` to verify there are no broken links. The site is configured with `onBrokenLinks: 'throw'`, so any dead internal links will fail the build.
+5. **Frontmatter**: Verify the guide has all required frontmatter fields: `title`, `sidebar_label`, `description`, `keywords`, and `lang: en-US`.
+
+Fix any issues found and re-run until all checks pass cleanly.
 
 ## Scoring guidance
 

--- a/.agents/skills/guide-review/references/rubric.md
+++ b/.agents/skills/guide-review/references/rubric.md
@@ -13,10 +13,12 @@ Recommended canonical structure:
 7. Verify the setup
 8. Common failure modes
 9. Security considerations
-10. Operations, rollback, and cleanup
+10. Operations, rollback, and cleanup (conditional — see below)
 11. Next steps and related guides
 
 Not every guide will need the same depth in every section, but the structure should remain stable unless there is a strong reason not to.
+
+**Section 10 is conditional.** An Operations, rollback, and cleanup section is only expected when the guide installs, pins, or directly operates a Pomerium component whose version or lifecycle the reader controls, or otherwise produces long-lived artifacts (credentials, infrastructure, binaries, charts, operators) that the reader must later maintain, rotate, or remove by hand. Guides that only configure a managed control plane (for example, Pomerium Zero route/policy/settings changes) — where the control plane pushes changes automatically and a rollback is just editing the same config back — do not need a dedicated Operations section and should not be penalized for omitting it.
 
 ---
 
@@ -78,25 +80,35 @@ Not every guide will need the same depth in every section, but the structure sho
 
 **Weight:** 2x **Question:** Does the guide state the tools, permissions, versions, dependencies, and assumptions required before starting?
 
+**Baseline prerequisite (always required):** Every guide must list a **working Pomerium cluster in Pomerium Zero** as a prerequisite and link to the [Quickstart](/docs/get-started/quickstart) so readers without a cluster have a one-click path to get there. Phrase it as something a reviewer can grep for, for example:
+
+> - A working Pomerium Zero cluster. If you don't have one, follow the [Quickstart](/docs/get-started/quickstart) first.
+
+A guide that omits this baseline prereq fails this dimension and cannot score above 1 regardless of the rest of the prerequisites section. Self-hosted / Core-only guides may substitute a link to the appropriate [Deploy](/docs/deploy) page, but still must explicitly state that a running Pomerium cluster is required.
+
 ### 0 - Missing
 
 - No prerequisites or assumptions listed
+- Baseline Pomerium Zero cluster prereq missing
 
 ### 1 - Weak
 
 - Some prerequisites mentioned
 - Versions, access levels, accounts, DNS/TLS assumptions, or dependencies are incomplete
+- Baseline cluster prereq implied but not explicit, or missing the Quickstart link
 
 ### 2 - Good
 
 - Tools, accounts, permissions, and key environment assumptions are listed
 - Important dependencies are stated before steps begin
+- Baseline cluster prereq is present and links to the Quickstart (or an equivalent deploy page for self-hosted guides)
 
 ### 3 - Excellent
 
 - Prerequisites are complete, specific, and ordered
 - Includes versions or tested ranges where relevant
 - Identifies required permissions, platform assumptions, DNS/TLS expectations, and prerequisite setup the reader must already have
+- Baseline cluster prereq is present and links to the Quickstart (or an equivalent deploy page for self-hosted guides)
 
 ---
 
@@ -233,9 +245,11 @@ Not every guide will need the same depth in every section, but the structure sho
 
 **Weight:** 1x **Question:** Can the reader maintain, roll back, or remove what they built?
 
+**Applicability note:** This dimension — including upgrade, rollback, cleanup, credential rotation, and maintenance guidance — is only expected when the guide installs, pins, or directly operates a Pomerium component whose version or lifecycle the reader controls, or otherwise produces long-lived artifacts (binaries, charts, operators, credentials, infrastructure) that the reader must later maintain, rotate, or remove by hand. Guides that only configure a managed control plane (for example, Pomerium Zero route/policy/settings changes) — where the control plane pushes changes automatically and "rollback" is just editing the same config back — are **not applicable (N/A)** for this dimension and should not be penalized. Mark the dimension N/A in the review worksheet and exclude it from the total (adjust the denominator accordingly, or treat it as the maximum weighted score of 3).
+
 ### 0 - Missing
 
-- No upgrade, rollback, cleanup, or maintenance guidance
+- No rollback, cleanup, or maintenance guidance where such guidance is applicable
 
 ### 1 - Weak
 
@@ -245,11 +259,12 @@ Not every guide will need the same depth in every section, but the structure sho
 ### 2 - Good
 
 - Includes rollback or cleanup path
-- Notes at least one maintenance or upgrade concern
+- Notes at least one maintenance concern (or one upgrade concern, where upgrades are applicable)
 
 ### 3 - Excellent
 
-- Covers upgrades, rollback, cleanup, credential rotation impact, and useful observability or logging checks
+- Covers rollback, cleanup, credential rotation impact, and useful observability or logging checks
+- Covers upgrades where applicable (see applicability note)
 - Sets reader up for real operation, not just one-time setup
 
 ---
@@ -257,6 +272,10 @@ Not every guide will need the same depth in every section, but the structure sho
 ## 10. Maintainability + Scanability
 
 **Weight:** 1x **Question:** Is the guide easy to scan, extract, update, and keep correct over time?
+
+**Style rules (hard fail):** Prose must not contain em dashes (`—`) or en dashes (`–`), and the guide must not contain emojis (decorative, status, or bullets — ✅ ❌ ⚠️ 🎉 🚀 💡 and similar). Use plain punctuation and Docusaurus admonitions (`:::note`, `:::tip`, `:::warning`, `:::danger`, `:::info`) instead. Code, config, CLI output, and quoted external content are exempt. A guide that violates either rule is not publish-ready regardless of its score on this dimension.
+
+**Acronym rule (hard fail):** Every acronym must be expanded on first use in the guide, formatted as full term followed by the acronym in parentheses (for example, `Pomerium Policy Language (PPL)`). Widely-understood internet-infrastructure acronyms (HTTP, HTTPS, URL, TLS, DNS, IP, JSON, YAML, API, SDK, CLI, UI, OS, SSO, OAuth, OIDC, SAML, JWT, CSV, PDF, CDN, SaaS, CI, CD, SQL, REST, RFC, and similar) are exempt. Product-specific or guide-local acronyms (for example TE, TI, AS, PRM, DCR, CIMD, PPL, IdP, SIEM, MCP) are not exempt. For long guides, reintroduce the full form at least once per major section, or substitute a descriptive noun (for example "the cached upstream token" instead of "the cached TI") so that readers who land mid-page are not forced to scroll back to the definition.
 
 ### 0 - Missing
 
@@ -289,7 +308,7 @@ To improve consistency across the full guides set, standardize these across all 
 - Reusable verification callout pattern
 - Reusable troubleshooting table format
 - Reusable security caveats section
-- Reusable operations footer with rollback and cleanup
+- Reusable operations footer with rollback and cleanup (for guides where Operations + Lifecycle Management is applicable — see dimension 9)
 - "Last tested with" metadata where third-party integrations are involved
 - Clear moved/deprecated labeling in the guides index and page body
 
@@ -305,7 +324,9 @@ Before marking a guide ready for review:
 - Verification exists for critical steps
 - At least 3 troubleshooting entries are included
 - At least 2 security caveats are included
-- Rollback or cleanup guidance exists
+- Rollback or cleanup guidance exists (where applicable — see dimension 9)
 - The expected end state is explicit
 - The guide helps the reader decide whether to use this pattern
 - The guide can be skimmed without losing the implementation flow
+- No em dashes (`—`) or en dashes (`–`) in prose, and no emojis anywhere in the guide (see dimension 10 style rules)
+- Every product-specific or guide-local acronym is expanded on first use (see dimension 10 acronym rule)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "yarn format \"$CLAUDE_TOOL_INPUT_FILE_PATH\"",
+            "type": "command"
+          },
+          {
+            "command": "yarn cspell \"$CLAUDE_TOOL_INPUT_FILE_PATH\"",
+            "type": "command"
+          }
+        ],
+        "if": "*.{md,mdx}",
+        "matcher": "Write|Edit"
+      }
+    ]
+  },
+  "mcpServers": {
+    "chrome-devtools": {
+      "args": ["@anthropic-ai/mcp-chrome-devtools@latest"],
+      "command": "npx"
+    }
+  }
+}


### PR DESCRIPTION
Add hard-fail style rules (no em dashes, no emojis, expand acronyms on first use), diagram guidelines (Mermaid for swim lanes, Excalidraw for all other diagrams), and pre-publish validation checklist to SKILL.md.

Refine rubric to make Operations + Lifecycle Management conditional for managed control plane guides, require baseline Pomerium Zero cluster prereq, and add style/acronym rules as hard fails to dimension 10.

Add .claude/settings.json with PostToolUse hooks to auto-format and spell-check .md/.mdx files on write/edit.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
