### PR TITLE
documentation: update rbac docs

### DIFF
--- a/content/docs/internals/namespacing.mdx
+++ b/content/docs/internals/namespacing.mdx
@@ -49,7 +49,7 @@ Namespaces are central to how Pomerium Enterprise controls who can do what in th
 
 **Guest (no assigned role)**
 
-- Can authenticate into Pomerium but only see a list of namespaces.
+- Can authenticate into Pomerium.
 - Cannot modify or view details of any resources.
 
 **Viewer**
@@ -59,7 +59,8 @@ Namespaces are central to how Pomerium Enterprise controls who can do what in th
 
 **Manager**
 
-- Can create, edit, and delete routes, policies, and certificates for a namespace (and its children).
+- Can create, edit, and delete changesets, namespaces, service accounts, routes, and policies for a namespace (and its children).
+- Can view sessions for a cluster.
 - Can reference policies and certificates from parent namespaces.
 
 :::caution
@@ -70,8 +71,8 @@ Managers can create routes to a given upstream path in **their** namespace, but 
 
 **Admin**
 
-- Can manage the namespace (and its child namespaces) where the role is assigned.
-- Has access to settings, sessions, and [service accounts](/docs/capabilities/service-accounts) within their administrative scope.
+- Can create, edit and delete clusters, certificates, external data sources, namespace permissions and settings.
+- Can manage sessions for a cluster.
 - When assigned in the Global namespace, can manage all namespaces and global settings, and see organization-wide events and runtime data.
 
-With these roles, Namespaces provide a powerful way to control who can view or modify Pomerium Enterprise resources, while still allowing each team the freedom to manage its own space.
+With these roles, namespaces provide a powerful way to control who can view or modify Pomerium Enterprise resources, while still allowing each team the freedom to manage its own space.


### PR DESCRIPTION
Update the RBAC docs for enterprise console roles. 

For [ENG-2349](https://linear.app/pomerium/issue/ENG-2349/terraform-document-enterprise-namespace-permission-roles)