### PR TITLE
documentation/routes: mention support for unix addresses

### DIFF
--- a/content/docs/capabilities/routing.mdx
+++ b/content/docs/capabilities/routing.mdx
@@ -82,11 +82,9 @@ Once a Route is created, the Metric Name field will populate. You can use this n
     - https://b.example.com
 ```
 
+Both `http://` and `https://` URLs are supported, as well as `http+unix:///var/run/example.sock` and `https+unix:///var/run/example.sock` for local unix addresses. If the `from` address starts with `tcp+https://`, use `tcp://` for the upstream. If the `from` address starts with `udp+https://`, use `udp://` for the upstream.
+
 A load balancing weight may be associated with a particular upstream by appending `,[weight]` to the URL. The exact behavior depends on your [`lb_policy`](#load-balancing-method) setting.
-
-> **For more details and examples, see our dedicated [Upstream Load Balancing page](/docs/capabilities/routing).**
-
-Should be `tcp://` if `from` is `tcp+https://`, or `udp://` if `from` is `udp+https://`.
 
 :::warning Be careful with trailing slash.
 

--- a/content/docs/reference/routes/to.mdx
+++ b/content/docs/reference/routes/to.mdx
@@ -27,7 +27,7 @@ import EnterpriseConfiguration from '../../../../src/components/EnterpriseConfig
 
 | **YAML**/**JSON** setting | **Type** | **Usage** | **Schemes** |
 | :-- | :-- | :-- | :-- |
-| `to` | `URL` | **optional** | `http`, `https`, `h2c`, `tcp`, `udp`, `ssh` |
+| `to` | `URL` | **optional** | `http`, `http+unix`, `https`, `https+unix`, `h2c`, `tcp`, `udp`, `ssh` |
 
 ### Examples
 
@@ -43,6 +43,9 @@ import EnterpriseConfiguration from '../../../../src/components/EnterpriseConfig
 
 - from: https://example.com
   to: https://verify.pomerium.com/anything/
+
+- from: https://example.com
+  to: https+unix:///var/run/example.sock
 
 # Native SSH Access
 - from: ssh://ssh.corp.example.com:22


### PR DESCRIPTION
For [ENG-3909](https://linear.app/pomerium/issue/ENG-3909/documentation-update-with-support-for-unix-sockets)

Mention support for unix addresses in the routing documentation.