### PR TITLE
docs: reconcile docVersions.json and navbar to live set

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,3 +123,13 @@ Follow the pattern: `docs: description of change (#PR)` or `docs(scope): descrip
 - The `content/docs/deploy/k8s/reference.md` file is excluded from Prettier formatting (auto-generated).
 - Prose wrap is set to `never` — Prettier won't reflow markdown text.
 - API docs are auto-generated from an OpenAPI spec via `redocusaurus` at `/docs/api/`.
+
+## Cutting a new docs version
+
+Policy: keep the current release and the one before it live at their versioned docs subdomains; everything older redirects to canonical docs. A release cut touches three places and is not complete until all three land together.
+
+1. **Version subdomain + TLS** — coordinate with ops to register the new version's hostname so it resolves and serves a valid cert; at the same time, demote the oldest live version to a redirect. Ops owns this in an internal runbook.
+2. **`src/components/docVersions.json`** — update to the new live set (current release + previous release + `vNext`).
+3. **Navbar dropdown** in `docusaurus.config.ts` (`themeConfig.navbar.items[*].dropdownItemsAfter`) — match the live set in `docVersions.json`. Run `yarn format` + `yarn build` + `yarn cspell "**/*"` before committing.
+
+Verify after deploy: the new version's hostname returns 200 with a valid cert; the demoted version redirects to canonical docs.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -165,10 +165,6 @@ const config: Config = {
               label: 'v0.31',
             },
             {
-              to: 'https://0-30-0.docs.pomerium.com/docs',
-              label: 'v0.30',
-            },
-            {
               type: 'html',
               value: '<hr>',
             },

--- a/src/components/docVersions.json
+++ b/src/components/docVersions.json
@@ -1,11 +1,11 @@
 {
-  "0.30.0": {
-    "id": "v0.30.x",
-    "link": "https://0-30-0.docs.pomerium.com/docs"
-  },
   "0.31.0": {
     "id": "v0.31.x",
     "link": "https://0-31-0.docs.pomerium.com/docs"
+  },
+  "0.32.0": {
+    "id": "v0.32.x",
+    "link": "https://0-32-0.docs.pomerium.com/docs"
   },
   "vNext": {
     "id": "vNext",


### PR DESCRIPTION
## Summary

Align `src/components/docVersions.json` and the navbar version dropdown in `docusaurus.config.ts` to the live set (current release + previous release + `vNext`). Before: the JSON listed `0.30.0` and was missing `0.32.0` while the navbar advertised v0.32/v0.31/v0.30.

Also adds a short "Cutting a new docs version" checklist to `AGENTS.md` so the next release keeps `docVersions.json` and the navbar in step.

## Test plan

- [x] `yarn format` clean
- [x] `yarn build` succeeds (broken-anchor warnings are pre-existing)
- [x] `yarn cspell` clean
- [ ] Navbar version dropdown matches `{v0.32, v0.31, All Versions}` after deploy

## AI disclosure

Drafted with Claude Code. Human-reviewed before push.