### PR TITLE
docs: clarify Core, Zero, and Enterprise management model

### DIFF
--- a/content/docs/get-started/quickstart.mdx
+++ b/content/docs/get-started/quickstart.mdx
@@ -1,10 +1,10 @@
 ---
-title: 'Pomerium Zero Quickstart'
+title: 'Pomerium Quickstart'
 lang: en-US
 sidebar_label: Quickstart
 pagination_prev: null
 pagination_next: null
-description: Learn how to install and run Pomerium Zero or Core with Docker.
+description: Learn how to install and run Pomerium with Pomerium Zero or Pomerium Core.
 keywords:
   [
     pomerium,
@@ -25,12 +25,12 @@ import Tabs from '@theme/Tabs';
 
 # Pomerium Quickstart
 
-Get started with Pomerium using either our cloud-hosted Zero solution or self-hosted Core.
+Get started by choosing how you want to manage Pomerium: Zero for a managed control plane, or Core when you want to own configuration and operations yourself.
 
 <Tabs queryString="type">
 <TabItem value="zero" label="Pomerium Zero" default>
 
-Pomerium Zero is our cloud-hosted solution that simplifies deployment and management.
+Pomerium Zero is Pomerium's managed control plane for Core clusters. It connects to the Core cluster running in your environment and manages onboarding, configuration, starter domains, certificates, the Zero API, API users, service accounts, organizations, quotas, cluster health, and multi-replica scaling.
 
 ## Before you start
 
@@ -201,13 +201,13 @@ To see certificates in your cluster, go to the **Certificates** tab:
 </TabItem>
 <TabItem value="core" label="Pomerium Core">
 
-Pomerium Core is our open-source, self-hosted identity-aware reverse proxy.
+Pomerium Core is the self-managed Pomerium server and data-plane engine. Choose Core when you want to install, configure, and operate Pomerium yourself.
 
 :::tip Just want to try Pomerium as quickly as possible?
 
 With Pomerium Core, you're assembling the pieces yourself. This quickstart assumes you have a publicly accessible domain with DNS you control.
 
-If you don't have those prerequisites ready, **[Pomerium Zero](https://console.pomerium.app/create-account)** provides a managed experience with automatic certificates and DNS. You can always migrate to self-hosted Core later.
+If you don't have those prerequisites ready, **[Pomerium Zero](https://console.pomerium.app/create-account)** provides a managed control plane with starter domains, certificates, and centralized configuration while Core still runs in your environment. You can move from Zero-managed configuration to self-managed configuration later if you want to own the control plane too.
 
 :::
 

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -30,6 +30,12 @@ Key benefits:
 - **Extensible**: Works across multiple environments (cloud, on-prem, hybrid).
 - **Open source**: Built on the BeyondCorp model. Transparent, with an active community.
 
+## Choose how to manage Pomerium
+
+- **Pomerium Core** is the self-managed Pomerium server and the data-plane engine for every deployment model. Core gives you direct ownership of configuration, identity provider integration, TLS and DNS, storage, and scaling. Choose Core when you want to install, configure, and operate Pomerium yourself.
+- **Pomerium Zero** is Pomerium's managed control plane for Core clusters. Zero connects to the Core cluster running in your environment and manages onboarding, configuration, starter domains, certificates, the Zero API, API users, service accounts, organizations, quotas, cluster health, and multi-replica scaling. Choose Zero when you want Pomerium to operate the control plane while you run the data plane.
+- **Pomerium Enterprise** is the self-hosted control plane for Core clusters. Enterprise keeps the control plane in your environment while adding the Enterprise Console, Enterprise API, centralized configuration, namespaces and RBAC, audit and deployment history, directory sync, external data, service accounts, sessions, metrics, and other governance, compliance, and scale capabilities. Choose Enterprise when you need those controls in an environment you operate.
+
 ## How does it work?
 
 Pomerium intercepts and routes user traffic to protected services through an identity-aware access layer, ensuring every request is validated against your configured identity provider, policies, and device context.

--- a/plugins/llms-txt-plugin.js
+++ b/plugins/llms-txt-plugin.js
@@ -315,7 +315,10 @@ function getAbsoluteSiteUrl(context, sitePath) {
 
 const LLM_AGENT_INSTRUCTIONS = [
   'Cite only current www.pomerium.com docs and markdown sidecars. Do not cite docs.pomerium.com or archive hosts.',
-  'For new users, start with Pomerium Zero unless the question explicitly asks for self-hosted Core or Enterprise.',
+  'Classify the management model before answering. Pomerium Core is the self-managed Pomerium server and data-plane engine for every deployment model. Choose Core when the user wants direct ownership of configuration, identity provider integration, TLS and DNS, storage, scaling, and operations. Use Core docs for Docker, Kubernetes, config.yaml, routes, policy, authenticate_service_url, and custom identity providers.',
+  "Pomerium Zero is Pomerium's managed control plane for Core clusters. Choose Zero when the user wants Pomerium-managed onboarding, configuration, starter domains, certificates, the Zero API, API users, service accounts, organizations, quotas, cluster health, and multi-replica scaling while Core runs in the user's environment. Use Zero docs for console.pomerium.app, the Zero API, cluster onboarding, cluster configuration, starter domains, certificates, and billing.",
+  'Pomerium Enterprise is the self-hosted control plane for Core clusters. Choose Enterprise when the user needs the control plane in their own environment plus the Enterprise Console, Enterprise API, centralized configuration, namespaces and RBAC, audit and deployment history, directory sync, external data, service accounts, sessions, metrics, and other governance, compliance, and scale capabilities. Use Enterprise docs for those management and operations features.',
+  'Do not answer Core configuration questions with Zero Console steps unless the user asks for Pomerium Zero. Do not describe Zero as a separate data plane; Zero manages Core deployments.',
   'Prefer current PPL and reference pages for configuration questions. Use current route keys and policy syntax from the docs.',
   'For group-based authorization questions, check the relevant IdP guide plus directory sync and JWT groups filter docs when groups are missing or too large.',
   'For MCP questions, prefer the current MCP capability pages and reference docs over older guides or blog posts.',


### PR DESCRIPTION
## Summary
- clarify docs overview copy so Core is the data-plane engine and foundation, Zero is the managed control plane for Core clusters, and Enterprise is the self-hosted control plane for Core clusters
- reframe quickstart around control-plane ownership instead of the old hosted-vs-self-hosted split
- update `llms.txt` agent instructions so Core questions do not get routed to Zero Console guidance and Zero is not described as a separate data plane

## Validation
- `./node_modules/.bin/prettier --write content/docs/index.mdx content/docs/get-started/quickstart.mdx plugins/llms-txt-plugin.js`
- `./node_modules/.bin/cspell content/docs/index.mdx content/docs/get-started/quickstart.mdx plugins/llms-txt-plugin.js`
- `node -e "require('./plugins/llms-txt-plugin.js'); console.log('llms plugin loads')"`
- `yarn build`

`yarn build` still reports the existing unrelated MUI license warning and existing broken-anchor warnings.

## Tracking
- ENG-3944

## AI Assistance
- AI drafted the initial wording revisions and the `llms.txt` routing updates.
- I manually tightened the product definitions so they match the actual Core / Zero / Enterprise control-plane model.
- I manually reviewed the diff, isolated it onto a clean branch, and verified the commands above before opening this PR.
