### PR TITLE
docs: update 0.31 version metadata

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -140,12 +140,8 @@ const config = {
           dropdownActiveClassDisabled: true,
           dropdownItemsAfter: [
             {
-              to: 'https://0-30-0.docs.pomerium.com/docs',
-              label: 'v0.30',
-            },
-            {
-              to: 'https://0-29-0.docs.pomerium.com/docs',
-              label: 'v0.29',
+              to: 'https://0-32-0.docs.pomerium.com/docs',
+              label: 'v0.32',
             },
             {
               type: 'html',

--- a/src/components/docVersions.json
+++ b/src/components/docVersions.json
@@ -1,7 +1,7 @@
 {
-  "0.30.0": {
-    "id": "v0.30.x",
-    "link": "https://0-30-0.docs.pomerium.com/docs"
+  "0.32.0": {
+    "id": "v0.32.x",
+    "link": "https://0-32-0.docs.pomerium.com/docs"
   },
   "0.31.0": {
     "id": "v0.31.x",


### PR DESCRIPTION
## Summary

- Updates the `0-31-0` release branch version dropdown to link to the newer live `v0.32` docs instead of retired `v0.30`/`v0.29` hosts.
- Updates `src/components/docVersions.json` so the All Versions table reflects the current live set for the incident: `v0.32`, `v0.31`, and `vNext`.

## Context

Part of OPE-275 docs TLS/routing cleanup. The Netlify cert/routing fix is still control-plane work; this PR only keeps the release branch docs metadata aligned once the versioned hosts are repaired.

## Validation

- `yarn format-check`
- `yarn build` (passed with existing Docusaurus warnings about deprecated config, image-size SVG warning, MUI license warning, and existing broken-anchor warnings)
- `rm -rf build && yarn cspell "**/*"`

## AI Assistance

Codex drafted the branch metadata edits, split/reviewed the final diff, ran validation locally, and incorporated Claude review feedback by removing duplicate self-links from the version dropdown. Manual verification covered the final diffs and command results.