### PR TITLE
docs: update 0.32 version metadata

### DIFF
--- a/content/docs/capabilities/mcp/delegate-mcp-to-llm.mdx
+++ b/content/docs/capabilities/mcp/delegate-mcp-to-llm.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Delegate MCP Access to an LLM"
-sidebar_label: "Delegate MCP Access to an LLM"
+title: 'Delegate MCP Access to an LLM'
+sidebar_label: 'Delegate MCP Access to an LLM'
 sidebar_position: 6
 lang: en-US
-description: "Let AI agents call MCP servers on a user behalf — via a client application with token delegation or via service accounts for headless agents in CI."
+description: 'Let AI agents call MCP servers on a user behalf — via a client application with token delegation or via service accounts for headless agents in CI.'
 keywords:
   [
     MCP,
@@ -40,8 +40,7 @@ Build a web application where the authenticated user's Pomerium token is capture
   frameBorder="0"
   webkitallowfullscreen="true"
   mozallowfullscreen="true"
-  allowFullScreen={true}
-></iframe>
+  allowFullScreen={true}></iframe>
 
 **What you get:**
 
@@ -111,10 +110,10 @@ routes:
         upstream_oauth2:
           client_id: xxxxxxxxxxxx
           client_secret: yyyyyyyyy
-          scopes: ["read:user", "repo"]
+          scopes: ['read:user', 'repo']
           endpoint:
-            auth_url: "https://github.com/login/oauth/authorize"
-            token_url: "https://github.com/login/oauth/access_token"
+            auth_url: 'https://github.com/login/oauth/authorize'
+            token_url: 'https://github.com/login/oauth/access_token'
     policy:
       allow:
         and:
@@ -209,8 +208,7 @@ authorize_log_fields:
   frameBorder="0"
   webkitallowfullscreen="true"
   mozallowfullscreen="true"
-  allowFullScreen={true}
-></iframe>
+  allowFullScreen={true}></iframe>
 
 See [Observability](/docs/capabilities/mcp/reference#observability) for the full logging reference.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -157,10 +157,6 @@ const config = {
               label: 'v0.31',
             },
             {
-              to: 'https://0-30-0.docs.pomerium.com/docs',
-              label: 'v0.30',
-            },
-            {
               type: 'html',
               value: '<hr>',
             },

--- a/src/components/docVersions.json
+++ b/src/components/docVersions.json
@@ -7,8 +7,8 @@
     "id": "v0.32.x",
     "link": "https://0-32-0.docs.pomerium.com/docs"
   },
-   "vNext": {
+  "vNext": {
     "id": "vNext",
     "link": "https://main.docs.pomerium.com/docs"
- }
+  }
 }


### PR DESCRIPTION
## Summary

- Remove the retired v0.30 docs link from the 0.32 release branch version dropdown.
- Keep the 0.32 branch dropdown pointed at the live peer version (`v0.31`) plus the All Versions page.
- Keep `src/components/docVersions.json` formatted and aligned with the live version set.
- Includes a separate formatting commit for an existing Prettier failure in `content/docs/capabilities/mcp/delegate-mcp-to-llm.mdx` so the branch can pass `yarn format-check`.

## Context

This is part of the OPE-275 docs TLS/routing cleanup. The Netlify custom-domain/certificate/routing repair remains a control-plane/UI task; this PR only updates release-branch docs metadata so the live branch menus are correct after Netlify is repaired.

## Validation

- `yarn prettier --write content/docs/capabilities/mcp/delegate-mcp-to-llm.mdx src/components/docVersions.json`
- `yarn format-check`
- `yarn build`
- `rm -rf build && yarn cspell "**/*"`

`yarn build` passed with existing warnings about deprecated Docusaurus config, SVG image-size parsing, MUI X license configuration, llms plugin parsing, and existing broken anchors.

## AI Assistance

Codex drafted the branch cleanup, split unrelated formatting into its own commit after review feedback, and ran validation. Manual verification covered the final diff, PR scope, and command results.