### PR TITLE
update lodash-es from 4.17.23 to 4.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "diff": ">=5.2.2",
     "dompurify": ">=3.3.2",
     "fast-xml-parser": ">=5.5.7",
-    "lodash": ">=4.17.23",
+    "lodash-es": ">=4.18.0",
     "picomatch": ">=2.3.2",
     "qs": ">=6.14.1",
     "serialize-javascript": ">=6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7980,10 +7980,10 @@ locate-path@^7.1.0:
   dependencies:
     p-locate "^6.0.0"
 
-lodash-es@4.17.23, lodash-es@^4.17.21, lodash-es@^4.17.23:
-  version "4.17.23"
-  resolved "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz"
-  integrity sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==
+lodash-es@4.17.23, lodash-es@>=4.18.0, lodash-es@^4.17.21, lodash-es@^4.17.23:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.18.1.tgz#b962eeb80d9d983a900bf342961fb7418ca10b1d"
+  integrity sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
 
 lodash.debounce@^4.0.8:
   version "4.0.8"
@@ -8005,7 +8005,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz"
   integrity sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
 
-lodash@>=4.17.23, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.18.1:
+lodash@^4.17.20, lodash@^4.17.21, lodash@^4.18.1:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==


### PR DESCRIPTION
Add a `resolutions` override to force `lodash-es` to 4.18.0. Remove the existing override for `lodash` as it doesn't appear to be needed currently.

Related issue:
- https://github.com/pomerium/documentation/security/dependabot/124