### PR TITLE
docs: serve markdown URLs and Accept negotiation

### DIFF
--- a/netlify/edge-functions/markdown-docs.js
+++ b/netlify/edge-functions/markdown-docs.js
@@ -151,5 +151,5 @@ export default async (request, context) => {
 // Inline config keeps this repo from needing a netlify.toml just to register one edge function.
 export const config = {
   path: ['/docs', '/docs/', '/docs/*'],
-  excludedPath: ['/docs/api', '/docs/api/*', '/docs/*.md'],
+  excludedPath: ['/docs/api', '/docs/api/*', '/docs/:path(.*)\\.md'],
 };

--- a/netlify/edge-functions/markdown-docs.js
+++ b/netlify/edge-functions/markdown-docs.js
@@ -82,22 +82,6 @@ function appendVary(headers, headerName) {
   }
 }
 
-function removeVary(headers, headerName) {
-  const vary = headers.get('vary');
-  if (!vary || vary === '*') return;
-
-  const remainingHeaders = vary
-    .split(',')
-    .map((value) => value.trim())
-    .filter((value) => value.toLowerCase() !== headerName.toLowerCase());
-
-  if (remainingHeaders.length === 0) {
-    headers.delete('vary');
-  } else {
-    headers.set('vary', remainingHeaders.join(', '));
-  }
-}
-
 function isMarkdownCompatibleContentType(contentType) {
   if (!contentType) return false;
 
@@ -116,21 +100,8 @@ async function passThroughWithVary(request, context) {
   return responseWithVary;
 }
 
-async function passThroughWithoutVary(request, context) {
-  const response = await context.next();
-  const responseWithoutVary = new Response(
-    request.method === 'HEAD' ? null : response.body,
-    response,
-  );
-  removeVary(responseWithoutVary.headers, 'Accept');
-
-  return responseWithoutVary;
-}
-
 async function passThrough(request, context, shouldVary = false) {
   if (shouldVary) return passThroughWithVary(request, context);
-
-  return passThroughWithoutVary(request, context);
 }
 
 export default async (request, context) => {

--- a/netlify/edge-functions/markdown-docs.js
+++ b/netlify/edge-functions/markdown-docs.js
@@ -165,4 +165,5 @@ export default async (request, context) => {
 // Inline config keeps this repo from needing a netlify.toml just to register one edge function.
 export const config = {
   path: '/docs/:path*',
+  excludedPath: ['/docs/api', '/docs/api/*', '/docs/*.md', '/docs/:path*.md'],
 };

--- a/netlify/edge-functions/markdown-docs.js
+++ b/netlify/edge-functions/markdown-docs.js
@@ -166,7 +166,8 @@ export default async (request, context) => {
 
 // Inline config keeps this repo from needing a netlify.toml just to register one edge function.
 export const config = {
-  pattern: '/docs($|/(?!api(?:/|$))(?!.*\\.md$).*)',
+  path: '/docs/:path*',
+  excludedPath: ['/docs/api', '/docs/api/*', '/docs/*.md', '/docs/:path*.md'],
   header: {
     accept: 'text/markdown',
   },

--- a/netlify/edge-functions/markdown-docs.js
+++ b/netlify/edge-functions/markdown-docs.js
@@ -168,7 +168,4 @@ export default async (request, context) => {
 export const config = {
   path: '/docs/:path*',
   excludedPath: ['/docs/api', '/docs/api/*', '/docs/*.md', '/docs/:path*.md'],
-  header: {
-    accept: 'text/markdown',
-  },
 };

--- a/netlify/edge-functions/markdown-docs.js
+++ b/netlify/edge-functions/markdown-docs.js
@@ -82,6 +82,22 @@ function appendVary(headers, headerName) {
   }
 }
 
+function removeVary(headers, headerName) {
+  const vary = headers.get('vary');
+  if (!vary || vary === '*') return;
+
+  const remainingHeaders = vary
+    .split(',')
+    .map((value) => value.trim())
+    .filter((value) => value.toLowerCase() !== headerName.toLowerCase());
+
+  if (remainingHeaders.length === 0) {
+    headers.delete('vary');
+  } else {
+    headers.set('vary', remainingHeaders.join(', '));
+  }
+}
+
 function isMarkdownCompatibleContentType(contentType) {
   if (!contentType) return false;
 
@@ -100,10 +116,21 @@ async function passThroughWithVary(request, context) {
   return responseWithVary;
 }
 
+async function passThroughWithoutVary(request, context) {
+  const response = await context.next();
+  const responseWithoutVary = new Response(
+    request.method === 'HEAD' ? null : response.body,
+    response,
+  );
+  removeVary(responseWithoutVary.headers, 'Accept');
+
+  return responseWithoutVary;
+}
+
 async function passThrough(request, context, shouldVary = false) {
   if (shouldVary) return passThroughWithVary(request, context);
 
-  return context.next();
+  return passThroughWithoutVary(request, context);
 }
 
 export default async (request, context) => {
@@ -167,5 +194,4 @@ export default async (request, context) => {
 // Inline config keeps this repo from needing a netlify.toml just to register one edge function.
 export const config = {
   path: '/docs/:path*',
-  excludedPath: ['/docs/api', '/docs/api/*', '/docs/*.md', '/docs/:path*.md'],
 };

--- a/netlify/edge-functions/markdown-docs.js
+++ b/netlify/edge-functions/markdown-docs.js
@@ -149,4 +149,7 @@ export default async (request, context) => {
 };
 
 // Inline config keeps this repo from needing a netlify.toml just to register one edge function.
-export const config = {path: ['/docs', '/docs/', '/docs/*']};
+export const config = {
+  path: ['/docs', '/docs/', '/docs/*'],
+  excludedPath: ['/docs/api', '/docs/api/*', '/docs/*.md'],
+};

--- a/netlify/edge-functions/markdown-docs.js
+++ b/netlify/edge-functions/markdown-docs.js
@@ -150,6 +150,5 @@ export default async (request, context) => {
 
 // Inline config keeps this repo from needing a netlify.toml just to register one edge function.
 export const config = {
-  path: ['/docs', '/docs/', '/docs/*'],
-  excludedPath: ['/docs/api', '/docs/api/*', '/docs/:path(.*)\\.md'],
+  pattern: '^/docs(?:$|/(?!api(?:/|$))(?!.*\\.md$).*)',
 };

--- a/netlify/edge-functions/markdown-docs.js
+++ b/netlify/edge-functions/markdown-docs.js
@@ -69,7 +69,6 @@ function toMarkdownPath(pathname) {
 
 function appendVary(headers, headerName) {
   const vary = headers.get('vary');
-  if (vary === '*') return;
   if (!vary) {
     headers.set('vary', headerName);
     return;
@@ -78,6 +77,7 @@ function appendVary(headers, headerName) {
   const existingHeaders = vary
     .split(',')
     .map((value) => value.trim().toLowerCase());
+  if (existingHeaders.includes('*')) return;
   if (!existingHeaders.includes(headerName.toLowerCase())) {
     headers.set('vary', `${vary}, ${headerName}`);
   }
@@ -92,6 +92,7 @@ function isMarkdownCompatibleContentType(contentType) {
 
 async function passThroughWithVary(request, context) {
   const response = await context.next();
+  if (request.method === 'HEAD') response.body?.cancel?.();
   const responseWithVary = new Response(
     request.method === 'HEAD' ? null : response.body,
     response,
@@ -123,6 +124,7 @@ export default async (request, context) => {
     );
   }
 
+  // Non-negotiable paths are invariant in Accept, even when the request prefers markdown.
   if (!markdownPath) return continueStaticRequest(request, context);
 
   const markdownUrl = new URL(request.url);
@@ -154,6 +156,7 @@ export default async (request, context) => {
   const headers = new Headers(markdownResponse.headers);
   headers.set('content-type', MARKDOWN_CONTENT_TYPE);
   appendVary(headers, 'Accept');
+  if (request.method === 'HEAD') markdownResponse.body?.cancel?.();
 
   return new Response(
     request.method === 'HEAD' ? null : markdownResponse.body,

--- a/netlify/edge-functions/markdown-docs.js
+++ b/netlify/edge-functions/markdown-docs.js
@@ -150,26 +150,7 @@ export default async (request, context) => {
 
 // Inline config keeps this repo from needing a netlify.toml just to register one edge function.
 export const config = {
-  path: [
-    '/docs',
-    '/docs/',
-    '/docs/capabilities',
-    '/docs/capabilities/*',
-    '/docs/courses',
-    '/docs/deploy',
-    '/docs/deploy/*',
-    '/docs/get-started',
-    '/docs/get-started/*',
-    '/docs/guides',
-    '/docs/guides/*',
-    '/docs/integrations',
-    '/docs/integrations/*',
-    '/docs/internals',
-    '/docs/internals/*',
-    '/docs/reference',
-    '/docs/reference/*',
-    '/docs/versions',
-  ],
+  pattern: '/docs($|/(?!api(?:/|$))(?!.*\\.md$).*)',
   header: {
     accept: 'text/markdown',
   },

--- a/netlify/edge-functions/markdown-docs.js
+++ b/netlify/edge-functions/markdown-docs.js
@@ -39,6 +39,7 @@ function toMarkdownPath(pathname) {
   const normalizedPathname = pathname.replace(/\/+$/, '') || '/';
 
   if (
+    // Direct markdown sidecars pass through; this also prevents rewrite recursion.
     normalizedPathname.endsWith('.md') ||
     normalizedPathname === '/docs/api' ||
     normalizedPathname.startsWith('/docs/api/') ||
@@ -88,16 +89,24 @@ async function passThroughWithVary(request, context) {
   return responseWithVary;
 }
 
+async function passThrough(request, context, shouldVary = false) {
+  if (shouldVary) return passThroughWithVary(request, context);
+
+  return context.next();
+}
+
 export default async (request, context) => {
   if (request.method !== 'GET' && request.method !== 'HEAD') return;
 
-  if (!prefersMarkdown(request.headers.get('accept'))) {
-    return passThroughWithVary(request, context);
-  }
-
   const url = new URL(request.url);
   const markdownPath = toMarkdownPath(url.pathname);
-  if (!markdownPath) return passThroughWithVary(request, context);
+  const isNegotiableDocsPath = Boolean(markdownPath);
+
+  if (!prefersMarkdown(request.headers.get('accept'))) {
+    return passThrough(request, context, isNegotiableDocsPath);
+  }
+
+  if (!markdownPath) return passThrough(request, context);
 
   const markdownUrl = new URL(request.url);
   markdownUrl.pathname = markdownPath;
@@ -112,12 +121,16 @@ export default async (request, context) => {
     return passThroughWithVary(request, context);
   }
 
-  if (
-    !markdownResponse.ok ||
-    !isMarkdownCompatibleContentType(
-      markdownResponse.headers.get('content-type'),
-    )
-  ) {
+  const markdownContentType = markdownResponse.headers.get('content-type');
+  const isMarkdownContentType =
+    isMarkdownCompatibleContentType(markdownContentType);
+  if (markdownResponse.ok && !isMarkdownContentType) {
+    console.warn(
+      `Markdown variant for ${url.pathname} returned incompatible content-type: ${markdownContentType || 'none'}`,
+    );
+  }
+
+  if (!markdownResponse.ok || !isMarkdownContentType) {
     return passThroughWithVary(request, context);
   }
 

--- a/netlify/edge-functions/markdown-docs.js
+++ b/netlify/edge-functions/markdown-docs.js
@@ -1,0 +1,139 @@
+const MARKDOWN_CONTENT_TYPE = 'text/markdown; charset=UTF-8';
+
+function getAcceptEntryQ(parameters) {
+  const qParameter = parameters.find((parameter) => parameter.startsWith('q='));
+  if (!qParameter) return 1;
+
+  const qValue = Number.parseFloat(qParameter.slice(2));
+  return Number.isFinite(qValue) ? qValue : 0;
+}
+
+function prefersMarkdown(acceptHeader) {
+  if (!acceptHeader) return false;
+
+  let markdownQ = 0;
+  let htmlQ = 0;
+
+  for (const entry of acceptHeader.split(',')) {
+    const [mediaType, ...parameters] = entry
+      .split(';')
+      .map((part) => part.trim().toLowerCase());
+    const qValue = getAcceptEntryQ(parameters);
+
+    if (mediaType === 'text/markdown') {
+      markdownQ = Math.max(markdownQ, qValue);
+    } else if (
+      mediaType === 'text/html' ||
+      mediaType === 'application/xhtml+xml'
+    ) {
+      htmlQ = Math.max(htmlQ, qValue);
+    }
+  }
+
+  // Wildcards such as */* or text/* are intentionally not enough to select markdown.
+  // Explicit text/markdown ties intentionally favor markdown for agent clients.
+  return markdownQ > 0 && markdownQ >= htmlQ;
+}
+
+function toMarkdownPath(pathname) {
+  const normalizedPathname = pathname.replace(/\/+$/, '') || '/';
+
+  if (
+    normalizedPathname.endsWith('.md') ||
+    normalizedPathname === '/docs/api' ||
+    normalizedPathname.startsWith('/docs/api/') ||
+    normalizedPathname.includes('/_')
+  ) {
+    return '';
+  }
+
+  if (normalizedPathname === '/docs') return '/docs.md';
+  if (normalizedPathname.startsWith('/docs/'))
+    return `${normalizedPathname}.md`;
+
+  return '';
+}
+
+function appendVary(headers, headerName) {
+  const vary = headers.get('vary');
+  if (vary === '*') return;
+  if (!vary) {
+    headers.set('vary', headerName);
+    return;
+  }
+
+  const existingHeaders = vary
+    .split(',')
+    .map((value) => value.trim().toLowerCase());
+  if (!existingHeaders.includes(headerName.toLowerCase())) {
+    headers.set('vary', `${vary}, ${headerName}`);
+  }
+}
+
+function isMarkdownCompatibleContentType(contentType) {
+  if (!contentType) return false;
+
+  const mediaType = contentType.split(';', 1)[0].trim().toLowerCase();
+  return mediaType === 'text/markdown' || mediaType === 'text/plain';
+}
+
+async function passThroughWithVary(request, context) {
+  const response = await context.next();
+  const responseWithVary = new Response(
+    request.method === 'HEAD' ? null : response.body,
+    response,
+  );
+  appendVary(responseWithVary.headers, 'Accept');
+
+  return responseWithVary;
+}
+
+export default async (request, context) => {
+  if (request.method !== 'GET' && request.method !== 'HEAD') return;
+
+  if (!prefersMarkdown(request.headers.get('accept'))) {
+    return passThroughWithVary(request, context);
+  }
+
+  const url = new URL(request.url);
+  const markdownPath = toMarkdownPath(url.pathname);
+  if (!markdownPath) return passThroughWithVary(request, context);
+
+  const markdownUrl = new URL(request.url);
+  markdownUrl.pathname = markdownPath;
+
+  let markdownResponse;
+  try {
+    markdownResponse = await context.rewrite(markdownUrl);
+  } catch (error) {
+    console.warn(
+      `Could not rewrite markdown variant for ${url.pathname}: ${error.message}`,
+    );
+    return passThroughWithVary(request, context);
+  }
+
+  if (
+    !markdownResponse.ok ||
+    !isMarkdownCompatibleContentType(
+      markdownResponse.headers.get('content-type'),
+    )
+  ) {
+    return passThroughWithVary(request, context);
+  }
+
+  const headers = new Headers(markdownResponse.headers);
+  headers.set('content-type', MARKDOWN_CONTENT_TYPE);
+  appendVary(headers, 'Accept');
+
+  return new Response(
+    request.method === 'HEAD' ? null : markdownResponse.body,
+    {
+      headers,
+      status: markdownResponse.status,
+      statusText: markdownResponse.statusText,
+    },
+  );
+};
+
+// Inline config keeps this repo from needing a netlify.toml just to register one edge function.
+export const config = {path: ['/docs', '/docs/', '/docs/*']};

--- a/netlify/edge-functions/markdown-docs.js
+++ b/netlify/edge-functions/markdown-docs.js
@@ -38,6 +38,7 @@ function prefersMarkdown(acceptHeader) {
 function mentionsMarkdown(acceptHeader) {
   if (!acceptHeader) return false;
 
+  // A q=0 markdown entry still means the representation decision varied on Accept.
   return acceptHeader
     .split(',')
     .some(
@@ -100,8 +101,10 @@ async function passThroughWithVary(request, context) {
   return responseWithVary;
 }
 
-async function passThrough(request, context, shouldVary = false) {
+async function continueStaticRequest(request, context, shouldVary = false) {
   if (shouldVary) return passThroughWithVary(request, context);
+
+  // Returning undefined lets Netlify continue the normal static request chain.
 }
 
 export default async (request, context) => {
@@ -113,14 +116,14 @@ export default async (request, context) => {
 
   const acceptHeader = request.headers.get('accept');
   if (!prefersMarkdown(acceptHeader)) {
-    return passThrough(
+    return continueStaticRequest(
       request,
       context,
       isNegotiableDocsPath && mentionsMarkdown(acceptHeader),
     );
   }
 
-  if (!markdownPath) return passThrough(request, context);
+  if (!markdownPath) return continueStaticRequest(request, context);
 
   const markdownUrl = new URL(request.url);
   markdownUrl.pathname = markdownPath;

--- a/netlify/edge-functions/markdown-docs.js
+++ b/netlify/edge-functions/markdown-docs.js
@@ -150,5 +150,27 @@ export default async (request, context) => {
 
 // Inline config keeps this repo from needing a netlify.toml just to register one edge function.
 export const config = {
-  pattern: '^/docs(?:$|/(?!api(?:/|$))(?!.*\\.md$).*)',
+  path: [
+    '/docs',
+    '/docs/',
+    '/docs/capabilities',
+    '/docs/capabilities/*',
+    '/docs/courses',
+    '/docs/deploy',
+    '/docs/deploy/*',
+    '/docs/get-started',
+    '/docs/get-started/*',
+    '/docs/guides',
+    '/docs/guides/*',
+    '/docs/integrations',
+    '/docs/integrations/*',
+    '/docs/internals',
+    '/docs/internals/*',
+    '/docs/reference',
+    '/docs/reference/*',
+    '/docs/versions',
+  ],
+  header: {
+    accept: 'text/markdown',
+  },
 };

--- a/netlify/edge-functions/markdown-docs.js
+++ b/netlify/edge-functions/markdown-docs.js
@@ -35,6 +35,17 @@ function prefersMarkdown(acceptHeader) {
   return markdownQ > 0 && markdownQ >= htmlQ;
 }
 
+function mentionsMarkdown(acceptHeader) {
+  if (!acceptHeader) return false;
+
+  return acceptHeader
+    .split(',')
+    .some(
+      (entry) =>
+        entry.split(';', 1)[0].trim().toLowerCase() === 'text/markdown',
+    );
+}
+
 function toMarkdownPath(pathname) {
   const normalizedPathname = pathname.replace(/\/+$/, '') || '/';
 
@@ -102,8 +113,13 @@ export default async (request, context) => {
   const markdownPath = toMarkdownPath(url.pathname);
   const isNegotiableDocsPath = Boolean(markdownPath);
 
-  if (!prefersMarkdown(request.headers.get('accept'))) {
-    return passThrough(request, context, isNegotiableDocsPath);
+  const acceptHeader = request.headers.get('accept');
+  if (!prefersMarkdown(acceptHeader)) {
+    return passThrough(
+      request,
+      context,
+      isNegotiableDocsPath && mentionsMarkdown(acceptHeader),
+    );
   }
 
   if (!markdownPath) return passThrough(request, context);

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "format": "prettier --write .",
     "format-check": "prettier --check .",
     "check": "npm run format-check && npm run cspell",
+    "test:markdown-negotiation": "bash scripts/test-markdown-negotiation.sh",
     "cspell": "cspell --gitignore ."
   },
   "dependencies": {

--- a/plugins/llms-txt-plugin.js
+++ b/plugins/llms-txt-plugin.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const yaml = require('js-yaml');
 const {remark} = require('remark');
 const remarkParse = require('remark-parse').default;
 const remarkStringify = require('remark-stringify').default;
@@ -109,8 +110,7 @@ async function cleanMarkdownForLLM(rawContent) {
 function filterDocumentationRoutes(routes) {
   return routes.filter((route) => {
     return (
-      route.path.startsWith('/docs/') &&
-      route.path !== '/docs/' &&
+      (route.path === '/docs' || route.path.startsWith('/docs/')) &&
       !route.path.includes('/api/') &&
       !route.path.includes('/_') &&
       route.component !== '@theme/NotFound/Content'
@@ -147,17 +147,16 @@ async function scanDocumentationFiles(contentDir) {
           (entry.name.endsWith('.mdx') || entry.name.endsWith('.md')) &&
           !entry.name.startsWith('_')
         ) {
-          // Create a route-like object from the file
-          const urlPath =
+          // Read file to get frontmatter metadata
+          const metadata = await extractMetadata(fullPath);
+          const sourceRoutePath =
             '/docs/' +
             relativePath.replace(/\.(mdx?|md)$/, '').replace(/\\/g, '/');
 
-          // Read file to get frontmatter metadata
-          const metadata = await extractMetadata(fullPath);
-
           files.push({
-            path: urlPath,
+            path: buildFallbackRoutePath(relativePath, metadata),
             filePath: fullPath,
+            sourceRoutePath,
             metadata: metadata,
           });
         }
@@ -182,30 +181,23 @@ async function extractMetadata(filePath) {
     // Extract frontmatter
     const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
     if (frontmatterMatch) {
-      const frontmatter = frontmatterMatch[1];
+      const frontmatter = yaml.load(frontmatterMatch[1]) || {};
 
-      // Simple YAML parsing for title and description
-      const titleMatch = frontmatter.match(/^title:\s*['"]?(.*?)['"]?$/m);
-      if (titleMatch) {
-        metadata.title = titleMatch[1];
+      if (typeof frontmatter.title === 'string') {
+        metadata.title = frontmatter.title;
       }
-
-      const descBlockMatch = frontmatter.match(
-        /^description:\s*[|>][-+0-9]*\s*\n((?:[ \t]+.*(?:\n|$))*)/m,
-      );
-      if (descBlockMatch) {
-        metadata.description = descBlockMatch[1]
+      if (typeof frontmatter.id === 'string') {
+        metadata.id = frontmatter.id;
+      }
+      if (typeof frontmatter.slug === 'string') {
+        metadata.slug = frontmatter.slug;
+      }
+      if (typeof frontmatter.description === 'string') {
+        metadata.description = frontmatter.description
           .split('\n')
           .map((line) => line.trim())
           .filter(Boolean)
           .join(' ');
-      } else {
-        const descMatch = frontmatter.match(
-          /^description:\s*['"]?(.*?)['"]?$/m,
-        );
-        if (descMatch) {
-          metadata.description = descMatch[1];
-        }
       }
     }
 
@@ -225,6 +217,34 @@ async function extractMetadata(filePath) {
     );
     return {};
   }
+}
+
+function buildFallbackRoutePath(relativePath, metadata = {}) {
+  if (metadata.slug) {
+    return buildDocsPath(metadata.slug);
+  }
+
+  const relativeRoutePath = relativePath
+    .replace(/\.(mdx?|md)$/, '')
+    .replace(/\\/g, '/');
+  const pathParts = relativeRoutePath.split('/').filter(Boolean);
+  const fileName = pathParts.pop() || '';
+
+  if (fileName !== 'index' && fileName !== 'readme') {
+    pathParts.push(metadata.id || fileName);
+  }
+
+  return buildDocsPath(pathParts.join('/'));
+}
+
+function buildDocsPath(routePath) {
+  const normalizedRoutePath = routePath
+    .trim()
+    .replace(/^\/+/, '')
+    .replace(/^docs\/?/, '')
+    .replace(/\/+$/, '');
+
+  return normalizedRoutePath ? `/docs/${normalizedRoutePath}` : '/docs';
 }
 
 /**
@@ -482,12 +502,21 @@ function isCuratedRoute(routePath) {
   return CURATED_ROUTES.has(routePath);
 }
 
-function isTier1Route(routePath) {
-  return TIER1_ROUTES.has(routePath);
+function routeMatchesPathSet(route, pathSet) {
+  if (typeof route === 'string') return pathSet.has(route);
+
+  return (
+    pathSet.has(route.path) ||
+    (route.sourceRoutePath && pathSet.has(route.sourceRoutePath))
+  );
+}
+
+function isTier1Route(route) {
+  return routeMatchesPathSet(route, TIER1_ROUTES);
 }
 
 function filterCuratedRoutes(routes) {
-  return routes.filter((route) => isCuratedRoute(route.path));
+  return routes.filter((route) => routeMatchesPathSet(route, CURATED_ROUTES));
 }
 
 function normalizeRouteMarkdownPath(routePath) {
@@ -507,14 +536,25 @@ function normalizeRouteMarkdownPath(routePath) {
 }
 
 function buildMarkdownUrl(route, context) {
-  const routePath = normalizeRouteMarkdownPath(route.path);
-  if (!routePath) return '';
+  const outputPath = buildCanonicalMarkdownOutputPath(route.path);
+  return outputPath ? getAbsoluteSiteUrl(context, outputPath) : '';
+}
 
-  // Avoid double-index for routes that already end in /index (e.g., /docs/index)
-  if (routePath.endsWith('/index')) {
-    return getAbsoluteSiteUrl(context, `${routePath}.md`);
+function normalizeCanonicalMarkdownPath(routePath) {
+  const normalizedRoutePath = normalizeRouteMarkdownPath(routePath);
+  if (!normalizedRoutePath) return '';
+
+  const pathParts = normalizedRoutePath.split('/').filter(Boolean);
+  if (pathParts[pathParts.length - 1] === 'index') {
+    pathParts.pop();
   }
-  return getAbsoluteSiteUrl(context, `${routePath}/index.md`);
+
+  return pathParts.join('/');
+}
+
+function buildCanonicalMarkdownOutputPath(routePath) {
+  const normalizedRoutePath = normalizeCanonicalMarkdownPath(routePath);
+  return normalizedRoutePath ? `${normalizedRoutePath}.md` : '';
 }
 
 function buildRouteMarkdownOutputPath(routePath) {
@@ -522,8 +562,41 @@ function buildRouteMarkdownOutputPath(routePath) {
   return normalizedRoutePath ? `${normalizedRoutePath}/index.md` : '';
 }
 
-function resolveRouteMarkdownOutputFile(outDir, routePath) {
-  const outputPath = buildRouteMarkdownOutputPath(routePath);
+function buildSourceRoutePath(route, docsRoot) {
+  if (route.sourceRoutePath) return route.sourceRoutePath;
+  if (!route.filePath) return '';
+
+  const relativeFilePath = path
+    .relative(docsRoot, route.filePath)
+    .replace(/\\/g, '/');
+
+  if (!relativeFilePath || relativeFilePath.startsWith('..')) return '';
+
+  return `/docs/${relativeFilePath.replace(/\.(mdx?|md)$/, '')}`;
+}
+
+function buildRouteMarkdownOutputPaths(route, docsRoot) {
+  const outputPaths = new Set();
+
+  const canonicalOutputPath = buildCanonicalMarkdownOutputPath(route.path);
+  if (canonicalOutputPath) outputPaths.add(canonicalOutputPath);
+
+  const routeSidecarOutputPath = buildRouteMarkdownOutputPath(route.path);
+  if (routeSidecarOutputPath) outputPaths.add(routeSidecarOutputPath);
+
+  const sourceRoutePath = buildSourceRoutePath(route, docsRoot);
+  if (sourceRoutePath && sourceRoutePath !== route.path) {
+    const sourceSidecarRoutePath = sourceRoutePath.replace(/\/index$/, '');
+    const sourceSidecarOutputPath = buildRouteMarkdownOutputPath(
+      sourceSidecarRoutePath,
+    );
+    if (sourceSidecarOutputPath) outputPaths.add(sourceSidecarOutputPath);
+  }
+
+  return [...outputPaths];
+}
+
+function resolveMarkdownOutputFile(outDir, outputPath) {
   if (!outputPath) return '';
 
   const resolvedOutputPath = path.resolve(outDir, outputPath);
@@ -540,6 +613,12 @@ function resolveRouteMarkdownOutputFile(outDir, routePath) {
   return resolvedOutputPath;
 }
 
+function resolveRouteMarkdownOutputFiles(outDir, route, docsRoot) {
+  return buildRouteMarkdownOutputPaths(route, docsRoot)
+    .map((outputPath) => resolveMarkdownOutputFile(outDir, outputPath))
+    .filter(Boolean);
+}
+
 function shouldSkipMarkdownCopy(srcFile) {
   const skipPatterns = [
     '_template.mdx',
@@ -553,23 +632,35 @@ function shouldSkipMarkdownCopy(srcFile) {
   );
 }
 
-function validateRouteMarkdownCollisions(routes) {
+function validateRouteMarkdownCollisions(routes, docsRoot) {
   const routeOutputs = new Map();
 
   for (const route of routes) {
     if (!route.filePath || shouldSkipMarkdownCopy(route.filePath)) continue;
 
-    const outputPath = buildRouteMarkdownOutputPath(route.path);
-    if (!outputPath) continue;
+    const outputPaths = buildRouteMarkdownOutputPaths(route, docsRoot);
+    for (const outputPath of outputPaths) {
+      if (!outputPath) continue;
 
-    if (routeOutputs.has(outputPath)) {
-      throw new Error(
-        `Duplicate route markdown output path "${outputPath}" for "${route.path}" and "${routeOutputs.get(outputPath)}"`,
-      );
+      const existingRoute = routeOutputs.get(outputPath);
+      if (existingRoute && existingRoute.filePath !== route.filePath) {
+        throw new Error(
+          `Duplicate route markdown output path "${outputPath}" for "${route.path}" and "${existingRoute.path}"`,
+        );
+      }
+
+      routeOutputs.set(outputPath, route);
     }
-
-    routeOutputs.set(outputPath, route.path);
   }
+}
+
+function getMatchedManifestPaths(route, pathSet) {
+  const matches = [];
+  if (pathSet.has(route.path)) matches.push(route.path);
+  if (route.sourceRoutePath && pathSet.has(route.sourceRoutePath)) {
+    matches.push(route.sourceRoutePath);
+  }
+  return matches;
 }
 
 /**
@@ -641,8 +732,8 @@ For common Pomerium questions, start with the curated context bundle:
 For exhaustive page discovery:
 - [llms-index.txt](${indexUrl}): Complete documentation index
 
-For a specific page, fetch its markdown sidecar by appending /index.md:
-- Example: https://www.pomerium.com/docs/capabilities/mcp/index.md
+For a generated documentation page under /docs/ (excluding API pages), fetch its markdown version by appending .md:
+- Example: https://www.pomerium.com/docs/capabilities/mcp.md
 
 ${LLM_AGENT_INSTRUCTIONS.map((i) => `- ${i}`).join('\n')}
 
@@ -698,7 +789,7 @@ ${LLM_AGENT_INSTRUCTIONS.map((i) => `- ${i}`).join('\n')}
     sortedRoutes.forEach((route) => {
       const body = cleanedContentMap.get(route.path);
       if (
-        activeTier1.has(route.path) &&
+        routeMatchesPathSet(route, activeTier1) &&
         body &&
         !inlinedPaths.has(route.path)
       ) {
@@ -759,9 +850,6 @@ function generateAgenticFooter(
   const indexUrl = getAbsoluteSiteUrl(context, 'llms-index.txt');
   const buildDate = new Date().toISOString().slice(0, 10);
 
-  const fullSizeHint = fullTxtSize ? ` (${fullTxtSize})` : '';
-  const indexSizeHint = indexSize ? ` (${indexSize})` : '';
-
   return `---
 
 ## How to Use These Docs
@@ -775,7 +863,7 @@ This documentation is publicly available and approved for LLM training and refer
 | Navigator | ${llmsTxtUrl} | ${navSize || '~14KB'} | Quick orientation and curated links |
 | Context bundle | ${fullUrl} | ${fullTxtSize || '~80K tokens'} | Key docs inline — start here for most questions |
 | Full index | ${indexUrl} | ${indexSize || '~36KB'} | Exhaustive page discovery |
-| Individual page | Append \`/index.md\` to any doc URL | varies | Deep-dive on a specific topic |
+| Individual page | Append \`.md\` to generated \`/docs/\` page URLs (excluding API pages) | varies | Deep-dive on a specific topic |
 
 Cite only \`www.pomerium.com\` docs. Do not cite \`docs.pomerium.com\` or archive hosts.
 `;
@@ -1061,11 +1149,12 @@ async function pluginLlmsTxt(context, options) {
           finalRoutes = await scanDocumentationFiles(contentDir);
         }
 
-        validateRouteMarkdownCollisions(finalRoutes);
-
         // ── 2. Clean + copy markdown sidecars, collect Tier 1 content ─
         const docsRoot = path.join(context.siteDir, 'content', 'docs');
+        validateRouteMarkdownCollisions(finalRoutes, docsRoot);
+
         const cleanedContentMap = new Map();
+        const tier1RoutesWithMarkdown = new Set();
         let copied = 0,
           errors = 0;
 
@@ -1081,9 +1170,10 @@ async function pluginLlmsTxt(context, options) {
             destRel = path.basename(srcFile).replace(/\.(mdx|md)$/, '.md');
           }
           const contentDestFile = path.join(outDir, 'content', 'docs', destRel);
-          const routeDestFile = resolveRouteMarkdownOutputFile(
+          const routeDestFiles = resolveRouteMarkdownOutputFiles(
             outDir,
-            route.path,
+            route,
+            docsRoot,
           );
 
           await fs.promises.mkdir(path.dirname(contentDestFile), {
@@ -1097,15 +1187,9 @@ async function pluginLlmsTxt(context, options) {
             try {
               cleanedContent = await cleanMarkdownForLLM(preCleanedContent);
             } catch (err) {
-              console.warn(
-                `Warning: Could not fully process ${srcFile}, writing pre-cleaned version instead:`,
-                err.message,
+              throw new Error(
+                `Could not fully process cleaned markdown for ${srcFile}: ${err.message}`,
               );
-              // Apply post-processing that cleanMarkdownForLLM would have done
-              cleanedContent = preCleanedContent
-                .replace(/\n{3,}/g, '\n\n')
-                .replace(/ \\{#[^}]+}/g, '');
-              errors++;
             }
 
             // Write sidecar copies
@@ -1114,15 +1198,17 @@ async function pluginLlmsTxt(context, options) {
               cleanedContent,
               'utf8',
             );
-            if (routeDestFile) {
-              await fs.promises.mkdir(path.dirname(routeDestFile), {
-                recursive: true,
-              });
-              await fs.promises.writeFile(
-                routeDestFile,
-                cleanedContent,
-                'utf8',
-              );
+            if (routeDestFiles.length > 0) {
+              for (const routeDestFile of routeDestFiles) {
+                await fs.promises.mkdir(path.dirname(routeDestFile), {
+                  recursive: true,
+                });
+                await fs.promises.writeFile(
+                  routeDestFile,
+                  cleanedContent,
+                  'utf8',
+                );
+              }
             } else {
               console.warn(
                 `Warning: Could not resolve route markdown path for ${route.path}, skipping route-mirrored copy.`,
@@ -1130,17 +1216,37 @@ async function pluginLlmsTxt(context, options) {
             }
 
             // Collect cleaned content for Tier 1 routes
-            if (isTier1Route(route.path) && cleanedContent.trim().length > 0) {
+            if (isTier1Route(route) && cleanedContent.trim().length > 0) {
               cleanedContentMap.set(route.path, cleanedContent);
+              for (const matchedPath of getMatchedManifestPaths(
+                route,
+                TIER1_ROUTES,
+              )) {
+                tier1RoutesWithMarkdown.add(matchedPath);
+              }
             }
 
             copied++;
           } catch (err) {
             console.warn(
-              `Warning: Could not read or write ${srcFile}:`,
+              `Warning: Could not generate cleaned markdown for ${srcFile}:`,
               err.message,
             );
             errors++;
+          }
+        }
+
+        if (errors > 0) {
+          throw new Error(
+            `Failed to generate cleaned markdown for ${errors} documentation source${errors === 1 ? '' : 's'}.`,
+          );
+        }
+
+        for (const tier1Route of TIER1_ROUTES) {
+          if (!tier1RoutesWithMarkdown.has(tier1Route)) {
+            throw new Error(
+              `TIER1_ROUTES entry "${tier1Route}" did not generate a markdown artifact.`,
+            );
           }
         }
 
@@ -1157,7 +1263,11 @@ async function pluginLlmsTxt(context, options) {
         }
 
         // Warn about stale manifest entries that no longer match any route
-        const knownPaths = new Set(finalRoutes.map((r) => r.path));
+        const knownPaths = new Set(
+          finalRoutes.flatMap((r) =>
+            r.sourceRoutePath ? [r.path, r.sourceRoutePath] : [r.path],
+          ),
+        );
         for (const manifest of [
           {name: 'CURATED_ROUTES', set: CURATED_ROUTES},
           {name: 'TIER1_ROUTES', set: TIER1_ROUTES},
@@ -1189,8 +1299,18 @@ async function pluginLlmsTxt(context, options) {
         let demotions = 0;
         for (const demotePath of TIER1_DEMOTION_ORDER) {
           if (llmsFullTxtContent.length <= LLMS_FULL_SIZE_LIMIT) break;
-          if (!cleanedContentMap.has(demotePath)) continue;
+          const matchingRoute = finalRoutes.find(
+            (route) =>
+              (route.path === demotePath ||
+                route.sourceRoutePath === demotePath) &&
+              cleanedContentMap.has(route.path),
+          );
+          if (!matchingRoute) continue;
           activeTier1.delete(demotePath);
+          activeTier1.delete(matchingRoute.path);
+          if (matchingRoute.sourceRoutePath) {
+            activeTier1.delete(matchingRoute.sourceRoutePath);
+          }
           llmsFullTxtContent = generateLlmsFullTxtContent(
             routesByCategory,
             context,
@@ -1257,8 +1377,10 @@ async function pluginLlmsTxt(context, options) {
         // ── 8. Report ───────────────────────────────────────────────
         const fullSizeKB = (finalLlmsFullTxt.length / 1024).toFixed(0);
         const fullTokens = Math.round(finalLlmsFullTxt.length / 4);
-        const inlineCount = [...activeTier1].filter((p) =>
-          cleanedContentMap.has(p),
+        const inlineCount = finalRoutes.filter(
+          (route) =>
+            routeMatchesPathSet(route, activeTier1) &&
+            cleanedContentMap.has(route.path),
         ).length;
         const linkedCount = finalRoutes.length - inlineCount;
 

--- a/plugins/llms-txt-plugin.js
+++ b/plugins/llms-txt-plugin.js
@@ -238,13 +238,18 @@ function buildFallbackRoutePath(relativePath, metadata = {}) {
 }
 
 function buildDocsPath(routePath) {
-  const normalizedRoutePath = routePath
+  const pathParts = routePath
     .trim()
     .replace(/^\/+/, '')
-    .replace(/^docs\/?/, '')
-    .replace(/\/+$/, '');
+    .replace(/\/+$/, '')
+    .split('/')
+    .filter(Boolean);
 
-  return normalizedRoutePath ? `/docs/${normalizedRoutePath}` : '/docs';
+  if (pathParts[0] === 'docs') {
+    pathParts.shift();
+  }
+
+  return pathParts.length ? `/docs/${pathParts.join('/')}` : '/docs';
 }
 
 /**
@@ -1262,21 +1267,29 @@ async function pluginLlmsTxt(context, options) {
           );
         }
 
-        // Warn about stale manifest entries that no longer match any route
+        // Fail on stale manifest entries so curated LLM docs cannot silently drift.
         const knownPaths = new Set(
           finalRoutes.flatMap((r) =>
             r.sourceRoutePath ? [r.path, r.sourceRoutePath] : [r.path],
           ),
         );
+        const staleManifestEntries = [];
         for (const manifest of [
           {name: 'CURATED_ROUTES', set: CURATED_ROUTES},
           {name: 'TIER1_ROUTES', set: TIER1_ROUTES},
         ]) {
           for (const p of manifest.set) {
             if (!knownPaths.has(p)) {
-              console.warn(`⚠️  ${manifest.name} contains stale entry: ${p}`);
+              staleManifestEntries.push(`${manifest.name}: ${p}`);
             }
           }
+        }
+        if (staleManifestEntries.length > 0) {
+          throw new Error(
+            `Stale llms route manifest entries:\n${staleManifestEntries
+              .map((entry) => `- ${entry}`)
+              .join('\n')}`,
+          );
         }
 
         const curatedRoutesByCategory = await groupRoutesByCategoryAuto(

--- a/scripts/test-markdown-negotiation.sh
+++ b/scripts/test-markdown-negotiation.sh
@@ -7,6 +7,7 @@ DOC_PATH="/docs/capabilities/mcp/protect-mcp-server"
 API_PATH="/docs/api"
 FIXTURE_DIR="build/docs/capabilities/markdown-negotiation-test"
 MISSING_DOC_PATH="/docs/capabilities/markdown-negotiation-test/missing"
+UNDERSCORE_DOC_PATH="/docs/capabilities/markdown-negotiation-test/_partial"
 LEGACY_INDEX_PATH="${DOC_PATH}/index.md"
 LOG_FILE="$(mktemp -t pomerium-docs-netlify-dev.XXXXXX.log)"
 NETLIFY_PID=""
@@ -258,7 +259,10 @@ do
 done
 
 assert_response "HEAD markdown negotiation" "${DOC_PATH}" 200 "text/markdown" "vary" -I -H "Accept: text/markdown"
+headers="$(response_headers "${DOC_PATH}" -H "Accept: text/markdown")"
+assert_header_contains "${headers}" "content-type" "charset=UTF-8"
 assert_markdown_body_shape "${DOC_PATH}" -H "Accept: text/markdown"
+assert_markdown_body_starts_with "${DOC_PATH}" "# Protect an MCP Server" -H "Accept: text/markdown"
 
 for header in \
   "" \
@@ -278,7 +282,11 @@ do
 done
 
 assert_response "API exclusion" "${API_PATH}" 200 "text/html" "any-vary" -H "Accept: text/markdown"
+assert_response "HEAD API exclusion" "${API_PATH}" 200 "text/html" "any-vary" -I -H "Accept: text/markdown"
 headers="$(response_headers "${API_PATH}" -H "Accept: text/markdown")"
+assert_header_not_contains "${headers}" "content-type" "text/markdown"
+assert_response "underscore path exclusion" "${UNDERSCORE_DOC_PATH}" 404 "text/html" "any-vary" -H "Accept: text/markdown"
+headers="$(response_headers "${UNDERSCORE_DOC_PATH}" -H "Accept: text/markdown")"
 assert_header_not_contains "${headers}" "content-type" "text/markdown"
 
 for fixture_path in "${DOTTED_DOC_PATH}" "${FILE_LIKE_DOC_PATH}"; do
@@ -288,6 +296,7 @@ assert_markdown_body_starts_with "${DOTTED_DOC_PATH}" "# Dotted Slug" -H "Accept
 assert_markdown_body_starts_with "${FILE_LIKE_DOC_PATH}" "# File-Like Slug" -H "Accept: text/markdown"
 
 assert_response "missing markdown fallback" "${MISSING_DOC_PATH}" 404 "text/html" "vary" -H "Accept: text/markdown"
+assert_response "HEAD missing markdown fallback" "${MISSING_DOC_PATH}" 404 "text/html" "vary" -I -H "Accept: text/markdown"
 headers="$(response_headers "${MISSING_DOC_PATH}" -H "Accept: text/markdown")"
 assert_header_not_contains "${headers}" "content-type" "text/markdown"
 assert_response "direct missing .md" "${MISSING_DOC_PATH}.md" 404 "text/html" "any-vary"

--- a/scripts/test-markdown-negotiation.sh
+++ b/scripts/test-markdown-negotiation.sh
@@ -239,9 +239,13 @@ netlify dev \
 NETLIFY_PID="$!"
 wait_for_netlify
 
-assert_response "direct .md" "${DOC_PATH}.md" 200 "text/markdown" "no-vary"
+# Netlify's deployed edge router adds Vary: Accept to paths covered by the
+# /docs edge route even when local netlify dev does not. Keep these assertions
+# focused on representation correctness and only require no-vary for /docs.md,
+# which is outside the edge route.
+assert_response "direct .md" "${DOC_PATH}.md" 200 "text/markdown" "any-vary"
 assert_response "direct /docs.md" "/docs.md" 200 "text/markdown" "no-vary"
-assert_response "legacy /index.md" "${LEGACY_INDEX_PATH}" 200 "text/markdown" "no-vary"
+assert_response "legacy /index.md" "${LEGACY_INDEX_PATH}" 200 "text/markdown" "any-vary"
 assert_response "root /docs markdown negotiation" "/docs" 200 "text/markdown" "vary" -H "Accept: text/markdown"
 assert_response "root /docs/ markdown negotiation" "/docs/" 200 "text/markdown" "vary" -H "Accept: text/markdown"
 
@@ -264,16 +268,16 @@ for header in \
 do
   if [[ -n "${header}" ]]; then
     if [[ "${header}" == "Accept: */*" ]]; then
-      assert_response "HTML fallback (${header})" "${DOC_PATH}" 200 "text/html" "no-vary" -H "${header}"
+      assert_response "HTML fallback (${header})" "${DOC_PATH}" 200 "text/html" "any-vary" -H "${header}"
     else
       assert_response "HTML fallback (${header})" "${DOC_PATH}" 200 "text/html" "vary" -H "${header}"
     fi
   else
-    assert_response "HTML fallback (no Accept)" "${DOC_PATH}" 200 "text/html" "no-vary"
+    assert_response "HTML fallback (no Accept)" "${DOC_PATH}" 200 "text/html" "any-vary"
   fi
 done
 
-assert_response "API exclusion" "${API_PATH}" 200 "text/html" "no-vary" -H "Accept: text/markdown"
+assert_response "API exclusion" "${API_PATH}" 200 "text/html" "any-vary" -H "Accept: text/markdown"
 headers="$(response_headers "${API_PATH}" -H "Accept: text/markdown")"
 assert_header_not_contains "${headers}" "content-type" "text/markdown"
 

--- a/scripts/test-markdown-negotiation.sh
+++ b/scripts/test-markdown-negotiation.sh
@@ -240,13 +240,14 @@ netlify dev \
 NETLIFY_PID="$!"
 wait_for_netlify
 
-# Netlify's deployed edge router adds Vary: Accept to paths covered by the
-# /docs edge route even when local netlify dev does not. Keep these assertions
-# focused on representation correctness and only require no-vary for /docs.md,
-# which is outside the edge route.
-assert_response "direct .md" "${DOC_PATH}.md" 200 "text/markdown" "any-vary"
+# Static markdown sidecars and non-negotiated fallbacks should not fragment
+# caches by Accept. Only responses that actually consider Accept should vary.
+assert_response "direct .md" "${DOC_PATH}.md" 200 "text/markdown" "no-vary"
 assert_response "direct /docs.md" "/docs.md" 200 "text/markdown" "no-vary"
-assert_response "legacy /index.md" "${LEGACY_INDEX_PATH}" 200 "text/markdown" "any-vary"
+assert_response "legacy /index.md" "${LEGACY_INDEX_PATH}" 200 "text/markdown" "no-vary"
+assert_response "HEAD direct .md" "${DOC_PATH}.md" 200 "text/markdown" "no-vary" -I -H "Accept: text/markdown"
+assert_response "HEAD direct /docs.md" "/docs.md" 200 "text/markdown" "no-vary" -I -H "Accept: text/markdown"
+assert_response "HEAD legacy /index.md" "${LEGACY_INDEX_PATH}" 200 "text/markdown" "no-vary" -I -H "Accept: text/markdown"
 assert_response "root /docs markdown negotiation" "/docs" 200 "text/markdown" "vary" -H "Accept: text/markdown"
 assert_response "root /docs/ markdown negotiation" "/docs/" 200 "text/markdown" "vary" -H "Accept: text/markdown"
 
@@ -267,25 +268,26 @@ assert_markdown_body_starts_with "${DOC_PATH}" "# Protect an MCP Server" -H "Acc
 for header in \
   "" \
   "Accept: */*" \
+  "Accept: text/*" \
   "Accept: text/markdown;q=0, text/html" \
   "Accept: text/html, text/markdown;q=0.5"
 do
   if [[ -n "${header}" ]]; then
-    if [[ "${header}" == "Accept: */*" ]]; then
-      assert_response "HTML fallback (${header})" "${DOC_PATH}" 200 "text/html" "any-vary" -H "${header}"
+    if [[ "${header}" == "Accept: */*" || "${header}" == "Accept: text/*" ]]; then
+      assert_response "HTML fallback (${header})" "${DOC_PATH}" 200 "text/html" "no-vary" -H "${header}"
     else
       assert_response "HTML fallback (${header})" "${DOC_PATH}" 200 "text/html" "vary" -H "${header}"
     fi
   else
-    assert_response "HTML fallback (no Accept)" "${DOC_PATH}" 200 "text/html" "any-vary"
+    assert_response "HTML fallback (no Accept)" "${DOC_PATH}" 200 "text/html" "no-vary"
   fi
 done
 
-assert_response "API exclusion" "${API_PATH}" 200 "text/html" "any-vary" -H "Accept: text/markdown"
-assert_response "HEAD API exclusion" "${API_PATH}" 200 "text/html" "any-vary" -I -H "Accept: text/markdown"
+assert_response "API exclusion" "${API_PATH}" 200 "text/html" "no-vary" -H "Accept: text/markdown"
+assert_response "HEAD API exclusion" "${API_PATH}" 200 "text/html" "no-vary" -I -H "Accept: text/markdown"
 headers="$(response_headers "${API_PATH}" -H "Accept: text/markdown")"
 assert_header_not_contains "${headers}" "content-type" "text/markdown"
-assert_response "underscore path exclusion" "${UNDERSCORE_DOC_PATH}" 404 "text/html" "any-vary" -H "Accept: text/markdown"
+assert_response "underscore path exclusion" "${UNDERSCORE_DOC_PATH}" 404 "text/html" "no-vary" -H "Accept: text/markdown"
 headers="$(response_headers "${UNDERSCORE_DOC_PATH}" -H "Accept: text/markdown")"
 assert_header_not_contains "${headers}" "content-type" "text/markdown"
 
@@ -299,6 +301,7 @@ assert_response "missing markdown fallback" "${MISSING_DOC_PATH}" 404 "text/html
 assert_response "HEAD missing markdown fallback" "${MISSING_DOC_PATH}" 404 "text/html" "vary" -I -H "Accept: text/markdown"
 headers="$(response_headers "${MISSING_DOC_PATH}" -H "Accept: text/markdown")"
 assert_header_not_contains "${headers}" "content-type" "text/markdown"
-assert_response "direct missing .md" "${MISSING_DOC_PATH}.md" 404 "text/html" "any-vary"
+assert_response "direct missing .md" "${MISSING_DOC_PATH}.md" 404 "text/html" "no-vary"
+assert_response "HEAD direct missing .md" "${MISSING_DOC_PATH}.md" 404 "text/html" "no-vary" -I -H "Accept: text/markdown"
 
 echo "markdown negotiation test passed on ${BASE_URL}"

--- a/scripts/test-markdown-negotiation.sh
+++ b/scripts/test-markdown-negotiation.sh
@@ -5,8 +5,8 @@ PORT="${PORT:-8899}"
 BASE_URL="http://localhost:${PORT}"
 DOC_PATH="/docs/capabilities/mcp/protect-mcp-server"
 API_PATH="/docs/api"
-FIXTURE_DIR="build/docs/markdown-negotiation-test"
-MISSING_DOC_PATH="/docs/markdown-negotiation-test/missing"
+FIXTURE_DIR="build/docs/capabilities/markdown-negotiation-test"
+MISSING_DOC_PATH="/docs/capabilities/markdown-negotiation-test/missing"
 LEGACY_INDEX_PATH="${DOC_PATH}/index.md"
 LOG_FILE="$(mktemp -t pomerium-docs-netlify-dev.XXXXXX.log)"
 NETLIFY_PID=""
@@ -224,8 +224,8 @@ if grep -Eq "https://www\\.pomerium\\.com/docs/.*/index\\.md\\)" build/llms.txt 
   fail "llms link files should not prefer legacy /index.md sidecars"
 fi
 
-DOTTED_DOC_PATH="/docs/markdown-negotiation-test/v1.2.3"
-FILE_LIKE_DOC_PATH="/docs/markdown-negotiation-test/config.json"
+DOTTED_DOC_PATH="/docs/capabilities/markdown-negotiation-test/v1.2.3"
+FILE_LIKE_DOC_PATH="/docs/capabilities/markdown-negotiation-test/config.json"
 create_markdown_fixture "${DOTTED_DOC_PATH}" "Dotted Slug"
 create_markdown_fixture "${FILE_LIKE_DOC_PATH}" "File-Like Slug"
 
@@ -263,9 +263,13 @@ for header in \
   "Accept: text/html, text/markdown;q=0.5"
 do
   if [[ -n "${header}" ]]; then
-    assert_response "HTML fallback (${header})" "${DOC_PATH}" 200 "text/html" "vary" -H "${header}"
+    if [[ "${header}" == "Accept: */*" ]]; then
+      assert_response "HTML fallback (${header})" "${DOC_PATH}" 200 "text/html" "no-vary" -H "${header}"
+    else
+      assert_response "HTML fallback (${header})" "${DOC_PATH}" 200 "text/html" "vary" -H "${header}"
+    fi
   else
-    assert_response "HTML fallback (no Accept)" "${DOC_PATH}" 200 "text/html" "vary"
+    assert_response "HTML fallback (no Accept)" "${DOC_PATH}" 200 "text/html" "no-vary"
   fi
 done
 

--- a/scripts/test-markdown-negotiation.sh
+++ b/scripts/test-markdown-negotiation.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT="${PORT:-8899}"
+BASE_URL="http://localhost:${PORT}"
+DOC_PATH="/docs/capabilities/mcp/protect-mcp-server"
+API_PATH="/docs/api"
+FIXTURE_DIR="build/docs/markdown-negotiation-test"
+MISSING_DOC_PATH="/docs/markdown-negotiation-test/missing"
+LOG_FILE="$(mktemp -t pomerium-docs-netlify-dev.XXXXXX.log)"
+NETLIFY_PID=""
+NETLIFY_DIR_EXISTED=0
+CREATED_FIXTURES=()
+
+[[ -e .netlify ]] && NETLIFY_DIR_EXISTED=1
+
+cleanup() {
+  if [[ -n "${NETLIFY_PID}" ]] && kill -0 "${NETLIFY_PID}" 2>/dev/null; then
+    kill "${NETLIFY_PID}" 2>/dev/null || true
+    wait "${NETLIFY_PID}" 2>/dev/null || true
+  fi
+
+  for fixture in "${CREATED_FIXTURES[@]}"; do
+    rm -f "${fixture}"
+  done
+  if [[ "${#CREATED_FIXTURES[@]}" -gt 0 ]]; then
+    rmdir "${FIXTURE_DIR}" 2>/dev/null || true
+  fi
+
+  if [[ "${NETLIFY_DIR_EXISTED}" == "0" ]]; then
+    rm -rf .netlify
+  fi
+  rm -f "${LOG_FILE}"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "markdown negotiation test failed: $*" >&2
+  if [[ -f "${LOG_FILE}" ]]; then
+    echo "netlify dev log:" >&2
+    sed -n '1,220p' "${LOG_FILE}" >&2
+  fi
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+response_headers() {
+  local request_path="$1"
+  shift
+  curl -sS -o /dev/null -D - "$@" "${BASE_URL}${request_path}" | tr -d '\r'
+}
+
+response_body() {
+  local request_path="$1"
+  shift
+  curl -fsS "$@" "${BASE_URL}${request_path}"
+}
+
+assert_status() {
+  local expected="$1"
+  local headers="$2"
+  local actual
+  actual="$(echo "${headers}" | sed -n '1p' | awk '{print $2}')"
+  [[ "${actual}" == "${expected}" ]] ||
+    fail "expected status ${expected}, got:
+${headers}"
+}
+
+assert_header_contains() {
+  local headers="$1"
+  local header_name="$2"
+  local expected="$3"
+
+  echo "${headers}" |
+    awk -v header="${header_name}" 'BEGIN {IGNORECASE=1} index($0, header ":") == 1 {print}' |
+    grep -iq "${expected}" ||
+    fail "expected ${header_name} header to contain ${expected}; got:
+${headers}"
+}
+
+assert_header_not_contains() {
+  local headers="$1"
+  local header_name="$2"
+  local unexpected="$3"
+
+  if echo "${headers}" |
+    awk -v header="${header_name}" 'BEGIN {IGNORECASE=1} index($0, header ":") == 1 {print}' |
+    grep -iq "${unexpected}"; then
+    fail "expected ${header_name} header not to contain ${unexpected}; got:
+${headers}"
+  fi
+}
+
+assert_response() {
+  local label="$1"
+  local request_path="$2"
+  local expected_status="$3"
+  local expected_content_type="$4"
+  local expect_vary="$5"
+  shift 5
+
+  local headers
+  headers="$(response_headers "${request_path}" "$@")"
+  assert_status "${expected_status}" "${headers}"
+  assert_header_contains "${headers}" "content-type" "${expected_content_type}"
+
+  if [[ "${expect_vary}" == "vary" ]]; then
+    assert_header_contains "${headers}" "vary" "Accept"
+  fi
+
+  echo "ok - ${label}"
+}
+
+assert_markdown_body_starts_with() {
+  local request_path="$1"
+  local expected="$2"
+  shift 2
+
+  local first_line
+  first_line="$(response_body "${request_path}" "$@" | sed -n '1p')"
+  [[ "${first_line}" == "${expected}" ]] ||
+    fail "expected ${request_path} body to start with ${expected}; got: ${first_line}"
+
+  echo "ok - ${request_path} body starts with ${expected}"
+}
+
+create_markdown_fixture() {
+  local request_path="$1"
+  local title="$2"
+  local fixture_file="build${request_path}.md"
+
+  if [[ -f "${fixture_file}" ]]; then
+    return
+  fi
+
+  mkdir -p "$(dirname "${fixture_file}")"
+  printf '# %s\n' "${title}" >"${fixture_file}"
+  CREATED_FIXTURES+=("${fixture_file}")
+}
+
+wait_for_netlify() {
+  for _ in {1..60}; do
+    if curl -fsS -o /dev/null "${BASE_URL}${DOC_PATH}" 2>/dev/null; then
+      return
+    fi
+    if ! kill -0 "${NETLIFY_PID}" 2>/dev/null; then
+      fail "netlify dev exited before becoming ready"
+    fi
+    sleep 1
+  done
+
+  fail "netlify dev did not become ready on ${BASE_URL}"
+}
+
+require_command curl
+require_command netlify
+
+[[ -d build ]] || fail "build/ does not exist; run yarn build first"
+[[ -f build/docs.md ]] || fail "build/docs.md does not exist; run yarn build first"
+[[ -f build${DOC_PATH}.md ]] ||
+  fail "build${DOC_PATH}.md does not exist; run yarn build first"
+
+DOTTED_DOC_PATH="/docs/markdown-negotiation-test/v1.2.3"
+FILE_LIKE_DOC_PATH="/docs/markdown-negotiation-test/config.json"
+create_markdown_fixture "${DOTTED_DOC_PATH}" "Dotted Slug"
+create_markdown_fixture "${FILE_LIKE_DOC_PATH}" "File-Like Slug"
+
+netlify dev \
+  --offline \
+  --dir build \
+  --port "${PORT}" \
+  --no-open \
+  --skip-gitignore \
+  >"${LOG_FILE}" 2>&1 &
+NETLIFY_PID="$!"
+wait_for_netlify
+
+assert_response "direct .md" "${DOC_PATH}.md" 200 "text/markdown" "no-vary"
+
+for header in \
+  "Accept: text/markdown" \
+  "Accept: text/html;q=0.5, text/markdown" \
+  "Accept: text/html, text/markdown"
+do
+  assert_response "markdown negotiation (${header})" "${DOC_PATH}" 200 "text/markdown" "vary" -H "${header}"
+done
+
+assert_response "HEAD markdown negotiation" "${DOC_PATH}" 200 "text/markdown" "vary" -I -H "Accept: text/markdown"
+assert_markdown_body_starts_with "${DOC_PATH}" "# Protect an MCP Server" -H "Accept: text/markdown"
+
+for header in \
+  "" \
+  "Accept: */*" \
+  "Accept: text/markdown;q=0, text/html" \
+  "Accept: text/html, text/markdown;q=0.5"
+do
+  if [[ -n "${header}" ]]; then
+    assert_response "HTML fallback (${header})" "${DOC_PATH}" 200 "text/html" "vary" -H "${header}"
+  else
+    assert_response "HTML fallback (no Accept)" "${DOC_PATH}" 200 "text/html" "vary"
+  fi
+done
+
+assert_response "API exclusion" "${API_PATH}" 200 "text/html" "vary" -H "Accept: text/markdown"
+headers="$(response_headers "${API_PATH}" -H "Accept: text/markdown")"
+assert_header_not_contains "${headers}" "content-type" "text/markdown"
+
+for fixture_path in "${DOTTED_DOC_PATH}" "${FILE_LIKE_DOC_PATH}"; do
+  assert_response "dotted/file-like slug ${fixture_path}" "${fixture_path}" 200 "text/markdown" "vary" -H "Accept: text/markdown"
+done
+assert_markdown_body_starts_with "${DOTTED_DOC_PATH}" "# Dotted Slug" -H "Accept: text/markdown"
+assert_markdown_body_starts_with "${FILE_LIKE_DOC_PATH}" "# File-Like Slug" -H "Accept: text/markdown"
+
+assert_response "missing markdown fallback" "${MISSING_DOC_PATH}" 404 "text/html" "vary" -H "Accept: text/markdown"
+headers="$(response_headers "${MISSING_DOC_PATH}" -H "Accept: text/markdown")"
+assert_header_not_contains "${headers}" "content-type" "text/markdown"
+
+echo "markdown negotiation test passed on ${BASE_URL}"

--- a/scripts/test-markdown-negotiation.sh
+++ b/scripts/test-markdown-negotiation.sh
@@ -7,6 +7,7 @@ DOC_PATH="/docs/capabilities/mcp/protect-mcp-server"
 API_PATH="/docs/api"
 FIXTURE_DIR="build/docs/markdown-negotiation-test"
 MISSING_DOC_PATH="/docs/markdown-negotiation-test/missing"
+LEGACY_INDEX_PATH="${DOC_PATH}/index.md"
 LOG_FILE="$(mktemp -t pomerium-docs-netlify-dev.XXXXXX.log)"
 NETLIFY_PID=""
 NETLIFY_DIR_EXISTED=0
@@ -94,6 +95,27 @@ ${headers}"
   fi
 }
 
+assert_vary_contains_accept() {
+  local headers="$1"
+
+  echo "${headers}" |
+    awk 'BEGIN {IGNORECASE=1} index($0, "vary:") == 1 {sub(/^[^:]*:[[:space:]]*/, ""); print}' |
+    grep -Eiq '(^|,)[[:space:]]*accept[[:space:]]*(,|$)' ||
+    fail "expected Vary header to contain Accept; got:
+${headers}"
+}
+
+assert_vary_not_contains_accept() {
+  local headers="$1"
+
+  if echo "${headers}" |
+    awk 'BEGIN {IGNORECASE=1} index($0, "vary:") == 1 {sub(/^[^:]*:[[:space:]]*/, ""); print}' |
+    grep -Eiq '(^|,)[[:space:]]*accept[[:space:]]*(,|$)'; then
+    fail "expected Vary header not to contain Accept; got:
+${headers}"
+  fi
+}
+
 assert_response() {
   local label="$1"
   local request_path="$2"
@@ -108,10 +130,33 @@ assert_response() {
   assert_header_contains "${headers}" "content-type" "${expected_content_type}"
 
   if [[ "${expect_vary}" == "vary" ]]; then
-    assert_header_contains "${headers}" "vary" "Accept"
+    assert_vary_contains_accept "${headers}"
+  elif [[ "${expect_vary}" == "no-vary" ]]; then
+    assert_vary_not_contains_accept "${headers}"
+  elif [[ "${expect_vary}" == "any-vary" ]]; then
+    true
+  else
+    fail "unknown Vary expectation: ${expect_vary}"
   fi
 
   echo "ok - ${label}"
+}
+
+assert_markdown_body_shape() {
+  local request_path="$1"
+  shift
+
+  local body
+  local first_line
+  body="$(response_body "${request_path}" "$@")"
+  first_line="$(echo "${body}" | sed -n '1p')"
+  [[ "${first_line}" == "# "* ]] ||
+    fail "expected ${request_path} body to start with a markdown H1; got: ${first_line}"
+  if echo "${body}" | grep -Eq '(^|[[:space:]]):::[[:alpha:]]|<TabItem'; then
+    fail "expected ${request_path} body to be cleaned markdown without Docusaurus MDX syntax"
+  fi
+
+  echo "ok - ${request_path} body is cleaned markdown"
 }
 
 assert_markdown_body_starts_with() {
@@ -156,12 +201,28 @@ wait_for_netlify() {
 }
 
 require_command curl
+require_command grep
 require_command netlify
 
 [[ -d build ]] || fail "build/ does not exist; run yarn build first"
 [[ -f build/docs.md ]] || fail "build/docs.md does not exist; run yarn build first"
 [[ -f build${DOC_PATH}.md ]] ||
   fail "build${DOC_PATH}.md does not exist; run yarn build first"
+[[ -f build${LEGACY_INDEX_PATH} ]] ||
+  fail "build${LEGACY_INDEX_PATH} does not exist; run yarn build first"
+[[ -f build/docs/reference/routes.md ]] ||
+  fail "build/docs/reference/routes.md does not exist; run yarn build first"
+[[ -f build/docs/reference/routes/index.md ]] ||
+  fail "build/docs/reference/routes/index.md does not exist; run yarn build first"
+[[ ! -e build/docs/capabilities/mcp/protect-mcp-server/index/index.md ]] ||
+  fail "unexpected build/docs/capabilities/mcp/protect-mcp-server/index/index.md was generated"
+grep -q "https://www.pomerium.com/docs/capabilities/mcp/protect-mcp-server.md" build/llms.txt ||
+  fail "llms.txt does not link to canonical protect-mcp-server.md"
+grep -q "https://www.pomerium.com/docs/capabilities/mcp/protect-mcp-server.md" build/llms-index.txt ||
+  fail "llms-index.txt does not link to canonical protect-mcp-server.md"
+if grep -Eq "https://www\\.pomerium\\.com/docs/.*/index\\.md\\)" build/llms.txt build/llms-index.txt; then
+  fail "llms link files should not prefer legacy /index.md sidecars"
+fi
 
 DOTTED_DOC_PATH="/docs/markdown-negotiation-test/v1.2.3"
 FILE_LIKE_DOC_PATH="/docs/markdown-negotiation-test/config.json"
@@ -179,6 +240,10 @@ NETLIFY_PID="$!"
 wait_for_netlify
 
 assert_response "direct .md" "${DOC_PATH}.md" 200 "text/markdown" "no-vary"
+assert_response "direct /docs.md" "/docs.md" 200 "text/markdown" "no-vary"
+assert_response "legacy /index.md" "${LEGACY_INDEX_PATH}" 200 "text/markdown" "no-vary"
+assert_response "root /docs markdown negotiation" "/docs" 200 "text/markdown" "vary" -H "Accept: text/markdown"
+assert_response "root /docs/ markdown negotiation" "/docs/" 200 "text/markdown" "vary" -H "Accept: text/markdown"
 
 for header in \
   "Accept: text/markdown" \
@@ -189,7 +254,7 @@ do
 done
 
 assert_response "HEAD markdown negotiation" "${DOC_PATH}" 200 "text/markdown" "vary" -I -H "Accept: text/markdown"
-assert_markdown_body_starts_with "${DOC_PATH}" "# Protect an MCP Server" -H "Accept: text/markdown"
+assert_markdown_body_shape "${DOC_PATH}" -H "Accept: text/markdown"
 
 for header in \
   "" \
@@ -204,7 +269,7 @@ do
   fi
 done
 
-assert_response "API exclusion" "${API_PATH}" 200 "text/html" "vary" -H "Accept: text/markdown"
+assert_response "API exclusion" "${API_PATH}" 200 "text/html" "no-vary" -H "Accept: text/markdown"
 headers="$(response_headers "${API_PATH}" -H "Accept: text/markdown")"
 assert_header_not_contains "${headers}" "content-type" "text/markdown"
 
@@ -217,5 +282,6 @@ assert_markdown_body_starts_with "${FILE_LIKE_DOC_PATH}" "# File-Like Slug" -H "
 assert_response "missing markdown fallback" "${MISSING_DOC_PATH}" 404 "text/html" "vary" -H "Accept: text/markdown"
 headers="$(response_headers "${MISSING_DOC_PATH}" -H "Accept: text/markdown")"
 assert_header_not_contains "${headers}" "content-type" "text/markdown"
+assert_response "direct missing .md" "${MISSING_DOC_PATH}.md" 404 "text/html" "any-vary"
 
 echo "markdown negotiation test passed on ${BASE_URL}"


### PR DESCRIPTION
## Why this exists

Agent and LLM clients need stable markdown versions of the current docs without changing normal browser behavior. This PR generates markdown sidecars for docs pages, keeps legacy sidecar URLs working, and negotiates markdown from canonical docs URLs only when a request explicitly prefers `text/markdown`.

The customer-facing rule is conservative: browsers and wildcard clients keep receiving HTML, `/docs/api` stays HTML, direct markdown URLs remain available for agents, and `Vary: Accept` is only used when `Accept` can change the representation.

## What changed

- Generates canonical markdown sidecars such as `/docs/capabilities/mcp/protect-mcp-server.md`.
- Preserves legacy `/index.md` sidecars such as `/docs/capabilities/mcp/protect-mcp-server/index.md`.
- Updates `llms.txt`, `llms-full.txt`, and `llms-index.txt` to prefer canonical `.md` links instead of legacy `/index.md` links.
- Adds a Netlify edge function that serves markdown for canonical `/docs/...` URLs when `Accept: text/markdown` is explicitly preferred.
- Parses q-values correctly: markdown wins when preferred, HTML wins when preferred, and equal explicit q-values intentionally favor markdown for agent clients.
- Keeps no-accept, wildcard-only (`*/*`, `text/*`), API, underscore, direct `.md`, and direct missing `.md` paths on normal static/HTML behavior without `Vary: Accept`.
- Fails the build if curated llms route manifests drift away from the current docs route set.
- Adds a Netlify smoke test for generated artifacts, negotiation headers, direct sidecars, legacy sidecars, root `/docs`, q-values, HEAD requests, dotted/file-like slugs, API fallback, underscore exclusion, missing-route fallback, and cache Vary behavior.

## Deployed behavior verified

Validated against final immutable Netlify deploy:

`https://69fc2f51620d2b00086eeaf7--pomerium-docs.netlify.app`

| Case | Result |
| --- | --- |
| Direct canonical `.md` | 200 `text/markdown`, no `Vary: Accept` |
| Direct `/docs.md` | 200 `text/markdown`, no `Vary: Accept` |
| Legacy `/index.md` | 200 `text/markdown`, no `Vary: Accept` |
| HEAD direct sidecars | 200 `text/markdown`, no `Vary: Accept` |
| `/docs` and `/docs/` with `Accept: text/markdown` | 200 `text/markdown`, `Vary: Accept` |
| Canonical docs URL with markdown-preferred Accept | 200 `text/markdown`, `Vary: Accept`, cleaned markdown body |
| Equal q-value tie (`text/html, text/markdown`) | 200 `text/markdown`, `Vary: Accept` |
| Canonical docs URL with HTML-preferred Accept | 200 `text/html`, `Vary: Accept` |
| No Accept / wildcard-only Accept | 200 `text/html`, no `Vary: Accept` |
| `text/markdown;q=0, text/html` | 200 `text/html`, `Vary: Accept` |
| `/docs/api` GET and HEAD with `Accept: text/markdown` | 200 `text/html`, no `Vary: Accept` |
| Underscore path with `Accept: text/markdown` | 404 `text/html`, no `Vary: Accept` |
| Missing canonical route with `Accept: text/markdown` | 404 `text/html`, `Vary: Accept` |
| Direct missing `.md` GET and HEAD | 404 `text/html`, no `Vary: Accept` |

The canonical markdown body for `/docs/capabilities/mcp/protect-mcp-server` starts with `# Protect an MCP Server` and does not leak Docusaurus MDX wrappers.

## Validation

- [x] `bash -n scripts/test-markdown-negotiation.sh`
- [x] `git diff --check origin/main...HEAD`
- [x] `yarn format-check`
- [x] `yarn cspell "**/*"`
- [x] `yarn build`
- [x] `yarn test:markdown-negotiation`
- [x] GitHub checks green: Analyze actions, Analyze javascript-typescript, CodeQL, dependency-review, pre-commit, CLA
- [x] Netlify checks green: deploy preview, header rules, redirect rules
- [x] Immutable deploy matrix green on `69fc2f51620d2b00086eeaf7`

`yarn build` still prints existing unrelated warnings: Docusaurus broken anchors in Enterprise/MCP docs, a webpack warning from `vscode-languageserver-types`, and the existing MUI X license warning. The build exits successfully.

## Review feedback incorporated

- Fixed docs path generation so `docs*` path segments are not stripped accidentally.
- Promoted stale llms manifest drift from warning to build failure.
- Replaced brittle exact-H1 assertions with cleaned-markdown shape assertions.
- Added direct `/docs.md`, legacy `/index.md`, root `/docs`, q-value, HEAD, dotted slug, file-like slug, API, underscore, and missing-route coverage.
- Added recursion guards for direct `.md` sidecars and API paths.
- Corrected the cache contract so static sidecars and non-negotiated fallbacks do not carry `Vary: Accept`.
- Strengthened `appendVary` for wildcard Vary tokens and explicitly cancels upstream bodies on HEAD pass-through.
- Merged current `origin/main` so this PR does not remove the generated `certificateAutoProvision` Kubernetes reference update from PR #2182.

## Honest gaps

- Production CDN behavior is not observed until merge, although the final immutable Netlify deploy preview was tested directly.
- This PR does not fix the unrelated build warnings listed above.

## AI assistance

Codex drafted and revised the implementation. Claude reviewed the branch multiple times; the final review found no code blockers, flagged the stale main merge and stale PR body, and those findings were incorporated. I verified the final local and deploy-preview behavior with the commands and matrix above before pushing.
