### PR TITLE
docs: clean up enterprise deployment docs

### DIFF
--- a/content/docs/deploy/enterprise/_category_.json
+++ b/content/docs/deploy/enterprise/_category_.json
@@ -1,4 +1,3 @@
 {
-  "label": "Enterprise",
-  "position": 5
+  "label": "Enterprise"
 }

--- a/content/docs/deploy/enterprise/_category_.json
+++ b/content/docs/deploy/enterprise/_category_.json
@@ -1,3 +1,4 @@
 {
-  "label": "Enterprise"
+  "label": "Enterprise",
+  "position": 5
 }

--- a/content/docs/deploy/enterprise/configure-metrics.mdx
+++ b/content/docs/deploy/enterprise/configure-metrics.mdx
@@ -1,124 +1,122 @@
 ---
-# cSpell:ignore XPOST tsdb
+# cSpell:ignore tsdb
 
 title: Configure Metrics in Pomerium Enterprise
 sidebar_label: Metrics
-description: Learn how to configure Prometheus to power metrics in the Pomerium Enterprise Console.
+description: Configure Prometheus metrics for the Pomerium Enterprise Console.
+sidebar_position: 4
 lang: en-US
 keywords: [pomerium, enterprise pomerium, telemetry, metrics, prometheus]
 ---
 
-Learn how to configure [Prometheus](https://prometheus.io/) as a metrics collection backend in Pomerium Enterprise.
+# Configure Metrics in Pomerium Enterprise
 
-## Overview
+Pomerium Enterprise uses Prometheus data to show traffic and monitoring views in the Console. You can either connect Enterprise to an external Prometheus instance or let Enterprise run an embedded Prometheus instance.
 
-Pomerium Enterprise uses Prometheus to collect observability and monitoring metrics from your Pomerium deployment. To set up Pomerium to work with Prometheus, you must configure either an external or embedded Prometheus instance.
-
-This guide explains what the [external](#external-prometheus) and [embedded](#embedded-prometheus) Prometheus options are, and how to configure them.
-
-## Before you start
+## Before You Start
 
 To complete this guide, you need:
 
-- [Pomerium Enterprise](/docs/deploy/enterprise)
-- [Pomerium Core](/docs/deploy/core)
+- A working [Pomerium Enterprise](/docs/deploy/enterprise) deployment
+- A working [Pomerium Core](/docs/deploy/core) deployment
+- Network access from Prometheus or the Enterprise Console to the metrics endpoints you configure
 
-This guide runs both Pomerium instances on localhost (`127.0.0.1`).
+## Metrics Settings
 
-## Configure Pomerium
+Enterprise metrics use two different settings:
 
-In your Pomerium Enterprise configuration file, define the `metrics_addr` key to a network interface or port:
+| Component | Setting | Purpose |
+| :-- | :-- | :-- |
+| Pomerium Core | [`metrics_address`](/docs/reference/metrics#metrics-address) / `METRICS_ADDRESS` | Exposes Core metrics for Prometheus to scrape. |
+| Enterprise Console | [`metrics_addr`](/docs/deploy/enterprise/configure#metrics-addr) / `METRICS_ADDR` | Exposes Console metrics for Prometheus to scrape. |
 
-```yaml title="pomerium-enterprise.yaml"
-metrics_addr: 127.0.0.1:9092
-```
+For production deployments, expose metrics only on private network interfaces reachable by Prometheus or the Enterprise Console. These endpoints can include operational data you should not expose publicly.
 
-This setting exposes internal metrics within the Enterprise Console. If not defined, Pomerium will expose `127.0.0.1` on port `:9092` by default.
+## External Prometheus
 
-## Configure Prometheus
+Use external Prometheus when you already operate Prometheus or want to manage retention, alerting, and scraping yourself.
 
-### External Prometheus
+The example values below (`10.0.0.10`, `10.0.0.20`, `prometheus.example.com`) are placeholder hosts; substitute the private network addresses or DNS names that Prometheus reaches Core and the Console on. `metrics_address` and `metrics_addr` take a listen `host:port`; `prometheus_url` takes a Prometheus base URL.
 
-An external Prometheus instance runs as its own process separate from Pomerium. Use this option if you prefer to configure and maintain Prometheus yourself.
-
-The steps below show you how to connect Prometheus to Pomerium Core and Pomerium Enterprise.
-
-:::tip
-
-For production deployments, we suggest using a dedicated Prometheus instance.
-
-:::
-
-1. In your Prometheus configuration file, add [instances](https://prometheus.io/docs/concepts/jobs_instances/#jobs-and-instances) for Pomerium and Pomerium Enterprise:
-
-   ```yaml title="prometheus.yaml"
-   - job_name: 'Pomerium'
-      scrape_interval: 30s
-      scrape_timeout: 5s
-      static_configs:
-         - targets: ['127.0.0.1:9091']
-   - job_name: 'Pomerium Enterprise'
-      scrape_interval: 30s
-      scrape_timeout: 5s
-      static_configs:
-         - targets: ['127.0.0.1:9092']
-
-   ```
-
-1. [Reload](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#configuration) the Prometheus configuration:
-
-   ```bash
-   curl -i -XPOST path.to.prometheus:port/-/reload
-   ```
-
-1. In your Pomerium Enterprise configuration file, define the [`prometheus_url`](/docs/deploy/enterprise/configure#prometheus-url) key to point to your Prometheus instance. The example below uses port 9090, the default [Prometheus port](https://prometheus.io/docs/introduction/first_steps/).
-
-   ```yaml title="pomerium-enterprise.yaml"
-   prometheus_url: http://192.168.122.50:9090
-   ```
-
-1. In your Pomerium configuration file, define the [`metrics_address`](/docs/reference/metrics#metrics-address) key to a network interface or port. In the example below, Pomerium provides metrics at port `9091` on an IP address reachable by Pomerium Enterprise:
+1. In your Core configuration, set Core to listen for metrics on a private interface Prometheus can reach:
 
    ```yaml title="pomerium.yaml"
-   metrics_address: 127.0.0.1:9091
+   metrics_address: 10.0.0.10:9091
    ```
 
-   :::note
+1. In your Enterprise Console configuration, set the Console to listen for metrics on a private interface Prometheus can reach:
 
-   If you're running Pomerium Enterprise in a distributed environment where the IP address is unknown at the time of deployment, you can use the resolvable fully qualified domain name (FQDN) of the Pomerium host (for example, `pomerium0.internal.example.com`). Or, you can override this key with the [`METRICS_ADDRESS`](/docs/reference/metrics#metrics-address) environment variable.
+   ```yaml title="pomerium-enterprise.yaml"
+   metrics_addr: 10.0.0.20:9092
+   ```
 
-   We do not recommend exposing this endpoint to public traffic as it can contain potentially sensitive information.
+1. Add both targets to Prometheus:
 
-   :::
+   ```yaml title="prometheus.yaml"
+   scrape_configs:
+     - job_name: 'pomerium-core'
+       scrape_interval: 30s
+       scrape_timeout: 5s
+       static_configs:
+         - targets: ['10.0.0.10:9091']
 
-### Embedded Prometheus
+     - job_name: 'pomerium-enterprise'
+       scrape_interval: 30s
+       scrape_timeout: 5s
+       static_configs:
+         - targets: ['10.0.0.20:9092']
+   ```
 
-Pomerium Enterprise supports an embedded Prometheus instance that you configure only in Pomerium. Use this option if you don't want to maintain an external Prometheus instance, or if you're testing metrics.
+1. Reload Prometheus. The `/-/reload` endpoint requires Prometheus to be started with the `--web.enable-lifecycle` flag; without it the request returns `Lifecycle API is not enabled`. Restart Prometheus instead if you cannot enable the lifecycle API.
 
-To configure an embedded Prometheus instance, add the [`prometheus_data_dir`](/docs/deploy/enterprise/configure#prometheus-data-dir) key and file path in your Pomerium Enterprise configuration file:
+   ```bash
+   curl -i -XPOST http://prometheus.example.com:9090/-/reload
+   ```
 
-```yaml title="pomerium-enterprise.yaml"
-prometheus_data_dir: /var/lib/pomerium-console/tsdb
-```
+1. Point the Enterprise Console at Prometheus:
 
-:::note
+   ```yaml title="pomerium-enterprise.yaml"
+   prometheus_url: http://prometheus.example.com:9090
+   ```
 
-The directory path can be any location that you have permissions to write to. This example uses the default location created if you install Pomerium Enterprise with the [OS Packages](/docs/deploy/enterprise/install#install-pomerium-enterprise) option.
+## Embedded Prometheus
 
-:::
+Use embedded Prometheus when you want Enterprise to manage a local Prometheus process for a small deployment or test environment.
 
-## Test the configuration
+1. In your Core configuration, expose the Core metrics endpoint on a private address reachable by the Enterprise Console:
 
-To view metrics collected by Prometheus, you must restart the Pomerium and Pomerium Enterprise services.
+   ```yaml title="pomerium.yaml"
+   metrics_address: 10.0.0.10:9091
+   ```
+
+1. In your Enterprise Console configuration, set a Prometheus data directory:
+
+   ```yaml title="pomerium-enterprise.yaml"
+   prometheus_data_dir: /var/lib/pomerium-console/tsdb
+   ```
+
+   The directory can be any absolute path the Console process can write to. Do not set `prometheus_url` when you use `prometheus_data_dir`; the embedded and external Prometheus modes are mutually exclusive. If you installed with OS packages, `/var/lib/pomerium-console/tsdb` matches the default service layout.
+
+1. Optionally expose the embedded Prometheus server:
+
+   ```yaml title="pomerium-enterprise.yaml"
+   prometheus_listen_addr: 127.0.0.1:9090
+   ```
+
+## Verify Metrics
+
+Restart Pomerium Core, the Enterprise Console, and Prometheus if you changed their configuration.
 
 In the Enterprise Console, select **Traffic**. You should see route traffic metrics collected from your Pomerium deployment:
 
-    ![Traffic Data in Pomerium Enterprise](./img/metrics/traffic-dashboard.png)
+![Traffic Data in Pomerium Enterprise](./img/metrics/traffic-dashboard.png)
 
 To view monitoring metrics for an external data source:
 
 1. Select **External Data**.
 1. Select an external data source.
-1. Select the **Metrics** tab. You should see monitoring data collected from the external data source record:
+1. Select the **Metrics** tab.
 
-   ![External Data Source in Pomerium Enterprise](./img/metrics/external-data-sources-dashboard.png)
+You should see monitoring data collected from the external data source record:
+
+![External Data Source in Pomerium Enterprise](./img/metrics/external-data-sources-dashboard.png)

--- a/content/docs/deploy/enterprise/configure.mdx
+++ b/content/docs/deploy/enterprise/configure.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configuration
+sidebar_position: 3
 lang: en-US
 keywords:
   [
@@ -18,7 +19,21 @@ keywords:
 import TabItem from '@theme/TabItem';
 import Tabs from '@theme/Tabs';
 
-The **Configure** section of the Pomerium Enterprise Console houses settings that affect the entirety of the Console environment (across all Namespaces). Adjust these settings with care.
+The Enterprise Console accepts runtime settings from a configuration file or environment variables. These settings control the Console process itself: licensing, database access, Databroker access, bootstrap administrators, TLS, metrics, and diagnostics.
+
+Core settings, route settings, and policy settings are still managed through Pomerium Core configuration, the Enterprise Console UI, the Enterprise API, or Terraform. For example, Core uses [`metrics_address`](/docs/reference/metrics#metrics-address), while the Console uses `metrics_addr` / `METRICS_ADDR` for its own metrics endpoint.
+
+## Metrics Endpoint {#metrics-addr}
+
+The Console exposes its own Prometheus metrics endpoint with `metrics_addr` or `METRICS_ADDR`. This is separate from Pomerium Core's [`metrics_address`](/docs/reference/metrics#metrics-address) setting.
+
+## Feedback Widget {#disable-feedback-widget}
+
+Use `disable_feedback_widget` or `DISABLE_FEEDBACK_WIDGET` to remove the third-party feedback widget from the Enterprise Console.
+
+## Validation Mode {#validation-mode}
+
+Use `validation_mode` or `VALIDATION_MODE` to control how strictly the Console validates configuration changes before applying them.
 
 ## Outbound network requirements
 
@@ -35,39 +50,44 @@ The keys listed below can be applied in Pomerium Console's `config.yaml` file or
 
 All values are case sensitive unless otherwise noted.
 
+The tables below cover the customer-facing settings the binary accepts. Operator-only flags (`--debug-addr`, `--dangerously-disable-all-namespace-checks`) are intentionally omitted. Hidden flags surfaced for Pomerium Support guidance, like `DEBUG_CONFIG_DUMP`, are documented here but do not appear in `pomerium-console serve --help`.
+
 <Tabs>
 <TabItem label="Environment variables" value="Environment variables">
 
 | Name | Description | Default Value |
 | :-- | :-- | --- |
 | <a className="entRef-anchor" id="administrators">#</a><a href='#administrators'>ADMINISTRATORS</a> | A list of user ids, names or emails to make administrators. Useful for bootstrapping. | none |
-| <a className="entRef-anchor" id="audience">#</a><a href='#audience'>AUDIENCE</a> | A list of audiences for verifying the signing key. | `[]` |
+| <a className="entRef-anchor" id="audience">#</a><a href='#audience'>AUDIENCE</a> | Required: A list of audiences for verifying the signing key. The Console refuses to start if unset. | none |
 | <a className="entRef-anchor" id="authenticate-service-url">#</a><a href='#authenticate-service-url'>AUTHENTICATE_SERVICE_URL</a> | (deprecated) Authenticate service URL is not required in the Console configuration. For Device Enrollment, use the [external route URL](/docs/reference/routes/from). | none |
 | <a className="entRef-anchor" id="bind-addr">#</a><a href='#bind-addr'>BIND_ADDR</a> | The address the Pomerium Console will listen on. | `:8701` |
 | <a className="entRef-anchor" id="bootstrap-service-account">#</a><a href="#bootstrap-service-account">BOOTSTRAP_SERVICE_ACCOUNT</a> | Enable the bootstrap service account. | `false` |
 | <a className="entRef-anchor" id="cache-dir">#</a><a href="#cache-dir">CACHE_DIR</a> | Directory to use for caching. | Cache only in memory. |
+| <a className="entRef-anchor" id="changeset-required-approval-count">#</a><a href='#changeset-required-approval-count'>CHANGESET_REQUIRED_APPROVAL_COUNT</a> | How many approvals are required to deploy a changeset. Setting to `0` disables changesets entirely; any value `> 0` enables changesets and requires that many approvals. | `0` |
 | <a className="entRef-anchor" id="customer-id">#</a><a href='#customer-id'>CUSTOMER_ID</a> | The customer ID | none |
-| <a className="entRef-anchor" id="database-encryption-key">#</a><a href='#database-encryption-key'>DATABASE_ENCRYPTION_KEY</a> | The base64-encoded encryption key for encrypting sensitive data in the database. | none |
+| <a className="entRef-anchor" id="database-encryption-key">#</a><a href='#database-encryption-key'>DATABASE_ENCRYPTION_KEY</a> | Required: The base64-encoded encryption key for encrypting sensitive data in the database. The Console refuses to start if unset (or use a `*_FILE` / `*_RAW_FILE` variant). | none |
 | <a className="entRef-anchor" id="database-encryption-key-file">#</a><a href='#database-encryption-key-file'>DATABASE_ENCRYPTION_KEY_FILE</a> | Loads base64-encoded `database-encryption-key` secret from a file. | none |
 | <a className="entRef-anchor" id="database-encryption-key-raw-file">#</a><a href='#database-encryption-key-raw-file'>DATABASE_ENCRYPTION_KEY_RAW_FILE</a> | Loads `database-encryption-key` secret from a raw file. Setting this option from a raw file does not require base64 encoding. | none |
 | <a className="entRef-anchor" id="database-url">#</a><a href='#database-url'>DATABASE_URL</a> | The database Pomerium Enterprise Console will use. | `postgresql://pomerium:pomerium`<br/>`@localhost:5432/dashboard?sslmode=disable` |
 | <a className="entRef-anchor" id="databroker-service-url">#</a><a href='#databroker-service-url'>DATABROKER_SERVICE_URL</a> | Databroker service URL for Console to reach Core. Leave unset in the default single-process deployment (Console uses `http://localhost:5443`). Set only when the databroker runs on another host/port or Core is split/remote. | `http://localhost:5443` |
+| <a className="entRef-anchor" id="databroker-service-urls">#</a><a href='#databroker-service-urls'>DATABROKER_SERVICE_URLS</a> | Comma-separated list of databroker service URLs for highly-available Core deployments. Use instead of `DATABROKER_SERVICE_URL` when Core runs more than one databroker replica. | none |
 | <a className="entRef-anchor" id="debug-config-dump">#</a><a href='#debug-config-dump'>DEBUG_CONFIG_DUMP</a> | Dumps the Databroker configuration. This is a debug option to be used only when specified by Pomerium Support. | `false` |
-| <a className="entRef-anchor" id="disable-feedback-widget">#</a><a href='#disable-feedback-widget'>DISABLE_FEEDBACK_WIDGET</a> | Disables third-party feedback widget and removes it from the Enterprise Console. | `false` |
-| <a className="entRef-anchor" id="disable-remote-diagnostics">#</a><a href='#disable-remote-diagnostics'>DISABLE_REMOTE_DIAGNOSTICS</a> | Disable remote diagnostics. | `true` |
+| <a className="entRef-anchor" id="disable-feedback-widget-env">#</a><a href='#disable-feedback-widget'>DISABLE_FEEDBACK_WIDGET</a> | Disables third-party feedback widget and removes it from the Enterprise Console. | `false` |
+| <a className="entRef-anchor" id="disable-remote-diagnostics">#</a><a href='#disable-remote-diagnostics'>DISABLE_REMOTE_DIAGNOSTICS</a> | Disable remote diagnostics. Setting `true` requires a license entitlement; the Console exits with `your license does not permit disabling remote diagnostics` if the entitlement is absent. | `false` |
 | <a className="entRef-anchor" id="disable-validation">#</a><a href='#disable-validation'>DISABLE_VALIDATION</a> | (deprecated, please update your configuration to set `VALIDATION_MODE=none` instead) Disable config validation. | `false` |
 | <a className="entRef-anchor" id="grpc-addr">#</a><a href='#grpc-addr'>GRPC_ADDR</a> | The address to listen for gRPC on. | `:8702` |
-| <a className="entRef-anchor" id="help">#</a><a href='#help'>HELP</a> | help for serve | `false` |
 | <a className="entRef-anchor" id="license-key">#</a><a href='#license-key'>LICENSE_KEY</a> | Required: Provide the license key issued by your account team. | none |
+| <a className="entRef-anchor" id="license-key-validate-offline">#</a><a href='#license-key-validate-offline'>LICENSE_KEY_VALIDATE_OFFLINE</a> | Validate the license key offline, without contacting the Pomerium license server. Required for air-gapped deployments; the license must be issued with offline validation enabled. | `false` |
+| <a className="entRef-anchor" id="metrics-addr-env">#</a><a href='#metrics-addr'>METRICS_ADDR</a> | Address where the Console exposes its `/metrics` endpoint in Prometheus format. | `127.0.0.1:9092` |
 | <a className="entRef-anchor" id="override-certificate-name">#</a><a href='#override-certificate-name'>OVERRIDE_CERTIFICATE_NAME</a> | Overrides the certificate name used for the databroker connection. | none |
-| <a className="entRef-anchor" id="prometheus-data-dir">#</a><a href='#prometheus-data-dir'>PROMETHEUS_DATA_DIR</a> | The path to Prometheus data | none |
+| <a className="entRef-anchor" id="prometheus-data-dir">#</a><a href='#prometheus-data-dir'>PROMETHEUS_DATA_DIR</a> | Absolute path for embedded Prometheus data. Do not set with `PROMETHEUS_URL`; embedded and external Prometheus modes are mutually exclusive. | none |
 | <a className="entRef-anchor" id="prometheus-listen-addr">#</a><a href='#prometheus-listen-addr'>PROMETHEUS_LISTEN_ADDR</a> | When set, embedded Prometheus listens at this address. Set as `host:port` | `127.0.0.1:9090` |
 | <a className="entRef-anchor" id="prometheus-scrape-interval">#</a><a href='#prometheus-scrape-interval'>PROMETHEUS_SCRAPE_INTERVAL</a> | The Prometheus scrape frequency | `10s` |
-| <a className="entRef-anchor" id="prometheus-url">#</a><a href='#prometheus-url'>PROMETHEUS_URL</a> | The URL to access the Prometheus metrics server. | none |
-| <a className="entRef-anchor" id="shared-secret">#</a><a href='#shared-secret'>SHARED_SECRET</a> | The base64-encoded secret for signing JWTs, shared with OSS Pomerium. | none |
+| <a className="entRef-anchor" id="prometheus-url">#</a><a href='#prometheus-url'>PROMETHEUS_URL</a> | URL for an external Prometheus server. Do not set with `PROMETHEUS_DATA_DIR`; external and embedded Prometheus modes are mutually exclusive. | none |
+| <a className="entRef-anchor" id="shared-secret">#</a><a href='#shared-secret'>SHARED_SECRET</a> | Required: The base64-encoded secret for signing JWTs, shared with OSS Pomerium. The Console refuses to start if unset (or use a `*_FILE` / `*_RAW_FILE` variant). | none |
 | <a className="entRef-anchor" id="shared-secret-file">#</a><a href='#shared-secret-file'>SHARED_SECRET_FILE</a> | Loads base64-encoded `shared-secret` from a file. | none |
 | <a className="entRef-anchor" id="shared-secret-raw-file">#</a><a href='#shared-secret-raw-file'>SHARED_SECRET_RAW_FILE</a> | Loads `shared-secret` from a raw file. Setting this option from a raw file does not require base64 encoding. | none |
-| <a className="entRef-anchor" id="signing-key">#</a><a href='#signing-key'>SIGNING_KEY</a> | (deprecated) base64-encoded signing key (public or private) for verifying JWTs. This option is no longer required in the Console config. | none |
+| <a className="entRef-anchor" id="signing-key">#</a><a href='#signing-key'>SIGNING_KEY</a> | (deprecated) base64-encoded signing key (public or private) for verifying JWTs. Usually omitted when the Console can verify identity headers from Pomerium's JWKS endpoint; local self-signed examples may set it to match Core. | none |
 | <a className="entRef-anchor" id="signing-key-file">#</a><a href='#signing-key-file'>SIGNING_KEY_FILE</a> | Loads base64-encoded `signing-key` secret from a file. | none |
 | <a className="entRef-anchor" id="signing-key-raw-file">#</a><a href='#signing-key-raw-file'>SIGNING_KEY_RAW_FILE</a> | Loads `signing-key` secret from a raw file. Setting this option from a raw file does not require base64 encoding. | none |
 | <a className="entRef-anchor" id="tls-ca">#</a><a href='#tls-ca'>TLS_CA</a> | base64-encoded string of tls-ca | none |
@@ -79,53 +99,56 @@ All values are case sensitive unless otherwise noted.
 | <a className="entRef-anchor" id="tls-key">#</a><a href='#tls-key'>TLS_KEY</a> | base64-encoded string of tls-key | none |
 | <a className="entRef-anchor" id="tls-key-file">#</a><a href='#tls-key-file'>TLS_KEY_FILE</a> | file storing tls-key | none |
 | <a className="entRef-anchor" id="use-static-assets">#</a><a href='#use-static-assets'>USE_STATIC_ASSETS</a> | When false, forward static requests to `localhost:3000`. | `true` |
-| <a className="entRef-anchor" id="validation_mode">#</a><a href='#validation_mode'>VALIDATION_MODE</a> | Validates config based on the specified mode: `full` (The default config validation mode), `static` (A "light" validation mode that catches most config issues), or `none` (Disables config validation). | `full` |
+| <a className="entRef-anchor" id="validation-mode-env">#</a><a href='#validation-mode'>VALIDATION_MODE</a> | Validates config based on the specified mode: `full` (The default config validation mode), `static` (A "light" validation mode that catches most config issues), or `none` (Disables config validation). | `full` |
 
 </TabItem>
 <TabItem label="Config file keys" value="Config file keys">
 
 | Name | Description | Default Value |
 | :-- | :-- | --- |
-| <a className="entRef-anchor" id="administrators">#</a><a href='#administrators'>administrators</a> | A list of user ids, names or emails to make administrators. Useful for bootstrapping. | none |
-| <a className="entRef-anchor" id="audience">#</a><a href='#audience'>audience</a> | A list of audiences for verifying the signing key. | `[]` |
-| <a className="entRef-anchor" id="authenticate-service-url">#</a><a href='#authenticate-service-url'>authenticate_service_url</a> | (deprecated) Authenticate service URL is not required in the Console configuration. For Device Enrollment, use the [external route URL](/docs/reference/routes/from). | none |
-| <a className="entRef-anchor" id="bind-addr">#</a><a href='#bind-addr'>bind_addr</a> | The address the Pomerium Console will listen on. | `:8701` |
-| <a className="entRef-anchor" id="bootstrap-service-account">#</a><a href="#bootstrap-service-account">bootstrap_service_account</a> | Enable the bootstrap service account. | `false` |
-| <a className="entRef-anchor" id="cache-dir">#</a><a href="#cache-dir">cache_dir</a> | Directory to use for caching. | Cache only in memory. |
-| <a className="entRef-anchor" id="customer-id">#</a><a href='#customer-id'>customer_id</a> | The customer ID | none |
-| <a className="entRef-anchor" id="database-encryption-key">#</a><a href='#database-encryption-key'>database_encryption_key</a> | The base64-encoded encryption key for encrypting sensitive data in the database. | none |
-| <a className="entRef-anchor" id="database-encryption-key-file">#</a><a href='#database-encryption-key-file'>database_encryption_key_file</a> | Loads base64-encoded `database-encryption-key` secret from a file. | none |
-| <a className="entRef-anchor" id="database-encryption-key-raw-file">#</a><a href='#database-encryption-key-raw-file'>database_encryption_key_raw_file</a> | Loads `database-encryption-key` secret from a raw file. Setting this option from a raw file does not require base64 encoding. | none |
-| <a className="entRef-anchor" id="database-url">#</a><a href='#database-url'>database_url</a> | The database Pomerium Enterprise Console will use. | `postgresql://pomerium:pomerium`<br/>`@localhost:5432/dashboard?sslmode=disable` |
-| <a className="entRef-anchor" id="databroker-service-url">#</a><a href='#databroker-service-url'>databroker_service_url</a> | Databroker service URL for Console to reach Core. Leave unset in the default single-process deployment (Console uses `http://localhost:5443`). Set only when the databroker runs on another host/port or Core is split/remote. | `http://localhost:5443` |
-| <a className="entRef-anchor" id="debug-config-dump">#</a><a href='#debug-config-dump'>debug_config_dump</a> | Dumps the Databroker configuration. This is a debug option to be used only when specified by Pomerium Support. | `false` |
-| <a className="entRef-anchor" id="disable-feedback-widget">#</a><a href='#disable-feedback-widget'>disable_feedback_widget</a> | Disables third-party feedback widget and removes it from the Enterprise Console. | `false` |
-| <a className="entRef-anchor" id="disable-remote-diagnostics">#</a><a href='#disable-remote-diagnostics'>disable_remote_diagnostics</a> | Disable remote diagnostics. | `true` |
-| <a className="entRef-anchor" id="disable-validation">#</a><a href='#disable-validation'>disable_validation</a> | (deprecated, please update your configuration to set `validation_mode=none` instead) Disable config validation. | `false` |
-| <a className="entRef-anchor" id="grpc-addr">#</a><a href='#grpc-addr'>grpc_addr</a> | The address to listen for gRPC on. | `:8702` |
-| <a className="entRef-anchor" id="help">#</a><a href='#help'>help</a> | help for serve | `false` |
-| <a className="entRef-anchor" id="license-key">#</a><a href='#license-key'>license_key</a> | Required: Provide the license key issued by your account team. | none |
-| <a className="entRef-anchor" id="override-certificate-name">#</a><a href='#override-certificate-name'>override_certificate_name</a> | Overrides the certificate name used for the databroker connection. | none |
-| <a className="entRef-anchor" id="prometheus-data-dir">#</a><a href='#prometheus-data-dir'>prometheus_data_dir</a> | The path to Prometheus data | none |
-| <a className="entRef-anchor" id="prometheus-listen-addr">#</a><a href='#prometheus-listen-addr'>prometheus_listen_addr</a> | When set, embedded Prometheus listens at this address. Set as `host:port` | `127.0.0.1:9090` |
-| <a className="entRef-anchor" id="prometheus-scrape-interval">#</a><a href='#prometheus-scrape-interval'>prometheus_scrape_interval</a> | The Prometheus scrape frequency | `10s` |
-| <a className="entRef-anchor" id="prometheus-url">#</a><a href='#prometheus-url'>prometheus_url</a> | The URL to access the Prometheus metrics server. | none |
-| <a className="entRef-anchor" id="shared-secret">#</a><a href='#shared-secret'>shared_secret</a> | The base64-encoded secret for signing JWTs, shared with OSS Pomerium. | none |
-| <a className="entRef-anchor" id="shared-secret-file">#</a><a href='#shared-secret-file'>shared_secret_file</a> | Loads base64-encoded `shared-secret` from a file. | none |
-| <a className="entRef-anchor" id="shared-secret-raw-file">#</a><a href='#shared-secret-raw-file'>shared_secret_raw_file</a> | Loads `shared-secret` from a raw file. Setting this option from a raw file does not require base64 encoding. | none |
-| <a className="entRef-anchor" id="signing-key">#</a><a href='#signing-key'>signing_key</a> | (deprecated) base64-encoded signing key (public or private) for verifying JWTs. This option is no longer required in the Console config. | none |
-| <a className="entRef-anchor" id="signing-key-file">#</a><a href='#signing-key-file'>signing_key_file</a> | Loads base64-encoded `signing-key` secret from a file. | none |
-| <a className="entRef-anchor" id="signing-key-raw-file">#</a><a href='#signing-key-raw-file'>signing_key_raw_file</a> | Loads `signing-key` secret from a raw file. Setting this option from a raw file does not require base64 encoding. | none |
-| <a className="entRef-anchor" id="tls-ca">#</a><a href='#tls-ca'>tls_ca</a> | base64-encoded string of tls-ca | none |
-| <a className="entRef-anchor" id="tls-ca-file">#</a><a href='#tls-ca-file'>tls_ca_file</a> | file storing tls-ca | none |
-| <a className="entRef-anchor" id="tls-cert">#</a><a href='#tls-cert'>tls_cert</a> | base64-encoded string of tls-cert | none |
-| <a className="entRef-anchor" id="tls-cert-file">#</a><a href='#tls-cert-file'>tls_cert_file</a> | file storing tls-cert | none |
-| <a className="entRef-anchor" id="tls-derive">#</a><a href='#tls-derive'>tls_derive</a> | Derives TLS server certificate for the console HTTPS and gRPC endpoints for the host specified by this option, using the CA derived from the shared key. Uses this CA to verify the server certificate presented by the Databroker gRPC TLS when the [`tls_derive`](/docs/reference/tls-derive) option is set in the Pomerium Core. | none |
-| <a className="entRef-anchor" id="tls-insecure-skip-verify">#</a><a href='#tls-insecure-skip-verify'>tls_insecure_skip_verify</a> | Disable remote hosts TLS certificate chain and hostname checks. | `false` |
-| <a className="entRef-anchor" id="tls-key">#</a><a href='#tls-key'>tls_key</a> | base64-encoded string of tls-key | none |
-| <a className="entRef-anchor" id="tls-key-file">#</a><a href='#tls-key-file'>tls_key_file</a> | file storing tls-key | none |
-| <a className="entRef-anchor" id="use-static-assets">#</a><a href='#use-static-assets'>use_static_assets</a> | When false, forward static requests to `localhost:3000`. | `true` |
-| <a className="entRef-anchor" id="validation_mode">#</a><a href='#validation_mode'>validation_mode</a> | Validates config based on the specified mode: `full` (The default config validation mode), `static` (A "light" validation mode that catches most config issues), or `none` (Disables config validation). | `full` |
+| <a className="entRef-anchor" id="administrators-config">#</a><a href='#administrators-config'>administrators</a> | A list of user ids, names or emails to make administrators. Useful for bootstrapping. | none |
+| <a className="entRef-anchor" id="audience-config">#</a><a href='#audience-config'>audience</a> | Required: A list of audiences for verifying the signing key. The Console refuses to start if unset. | none |
+| <a className="entRef-anchor" id="authenticate-service-url-config">#</a><a href='#authenticate-service-url-config'>authenticate_service_url</a> | (deprecated) Authenticate service URL is not required in the Console configuration. For Device Enrollment, use the [external route URL](/docs/reference/routes/from). | none |
+| <a className="entRef-anchor" id="bind-addr-config">#</a><a href='#bind-addr-config'>bind_addr</a> | The address the Pomerium Console will listen on. | `:8701` |
+| <a className="entRef-anchor" id="bootstrap-service-account-config">#</a><a href="#bootstrap-service-account-config">bootstrap_service_account</a> | Enable the bootstrap service account. | `false` |
+| <a className="entRef-anchor" id="cache-dir-config">#</a><a href="#cache-dir-config">cache_dir</a> | Directory to use for caching. | Cache only in memory. |
+| <a className="entRef-anchor" id="changeset-required-approval-count-config">#</a><a href='#changeset-required-approval-count-config'>changeset_required_approval_count</a> | How many approvals are required to deploy a changeset. Setting to `0` disables changesets entirely; any value `> 0` enables changesets and requires that many approvals. | `0` |
+| <a className="entRef-anchor" id="customer-id-config">#</a><a href='#customer-id-config'>customer_id</a> | The customer ID | none |
+| <a className="entRef-anchor" id="database-encryption-key-config">#</a><a href='#database-encryption-key-config'>database_encryption_key</a> | Required: The base64-encoded encryption key for encrypting sensitive data in the database. The Console refuses to start if unset (or use a `*_file` / `*_raw_file` variant). | none |
+| <a className="entRef-anchor" id="database-encryption-key-file-config">#</a><a href='#database-encryption-key-file-config'>database_encryption_key_file</a> | Loads base64-encoded `database-encryption-key` secret from a file. | none |
+| <a className="entRef-anchor" id="database-encryption-key-raw-file-config">#</a><a href='#database-encryption-key-raw-file-config'>database_encryption_key_raw_file</a> | Loads `database-encryption-key` secret from a raw file. Setting this option from a raw file does not require base64 encoding. | none |
+| <a className="entRef-anchor" id="database-url-config">#</a><a href='#database-url-config'>database_url</a> | The database Pomerium Enterprise Console will use. | `postgresql://pomerium:pomerium`<br/>`@localhost:5432/dashboard?sslmode=disable` |
+| <a className="entRef-anchor" id="databroker-service-url-config">#</a><a href='#databroker-service-url-config'>databroker_service_url</a> | Databroker service URL for Console to reach Core. Leave unset in the default single-process deployment (Console uses `http://localhost:5443`). Set only when the databroker runs on another host/port or Core is split/remote. | `http://localhost:5443` |
+| <a className="entRef-anchor" id="databroker-service-urls-config">#</a><a href='#databroker-service-urls-config'>databroker_service_urls</a> | List of databroker service URLs for highly-available Core deployments. Use instead of `databroker_service_url` when Core runs more than one databroker replica. | none |
+| <a className="entRef-anchor" id="debug-config-dump-config">#</a><a href='#debug-config-dump-config'>debug_config_dump</a> | Dumps the Databroker configuration. This is a debug option to be used only when specified by Pomerium Support. | `false` |
+| <a className="entRef-anchor" id="disable-feedback-widget-config">#</a><a href='#disable-feedback-widget-config'>disable_feedback_widget</a> | Disables third-party feedback widget and removes it from the Enterprise Console. | `false` |
+| <a className="entRef-anchor" id="disable-remote-diagnostics-config">#</a><a href='#disable-remote-diagnostics-config'>disable_remote_diagnostics</a> | Disable remote diagnostics. Setting `true` requires a license entitlement; the Console exits with `your license does not permit disabling remote diagnostics` if the entitlement is absent. | `false` |
+| <a className="entRef-anchor" id="disable-validation-config">#</a><a href='#disable-validation-config'>disable_validation</a> | (deprecated, please update your configuration to set `validation_mode=none` instead) Disable config validation. | `false` |
+| <a className="entRef-anchor" id="grpc-addr-config">#</a><a href='#grpc-addr-config'>grpc_addr</a> | The address to listen for gRPC on. | `:8702` |
+| <a className="entRef-anchor" id="license-key-config">#</a><a href='#license-key-config'>license_key</a> | Required: Provide the license key issued by your account team. | none |
+| <a className="entRef-anchor" id="license-key-validate-offline-config">#</a><a href='#license-key-validate-offline-config'>license_key_validate_offline</a> | Validate the license key offline, without contacting the Pomerium license server. Required for air-gapped deployments; the license must be issued with offline validation enabled. | `false` |
+| <a className="entRef-anchor" id="metrics-addr-config">#</a><a href='#metrics-addr-config'>metrics_addr</a> | Address where the Console exposes its `/metrics` endpoint in Prometheus format. | `127.0.0.1:9092` |
+| <a className="entRef-anchor" id="override-certificate-name-config">#</a><a href='#override-certificate-name-config'>override_certificate_name</a> | Overrides the certificate name used for the databroker connection. | none |
+| <a className="entRef-anchor" id="prometheus-data-dir-config">#</a><a href='#prometheus-data-dir-config'>prometheus_data_dir</a> | Absolute path for embedded Prometheus data. Do not set with `prometheus_url`; embedded and external Prometheus modes are mutually exclusive. | none |
+| <a className="entRef-anchor" id="prometheus-listen-addr-config">#</a><a href='#prometheus-listen-addr-config'>prometheus_listen_addr</a> | When set, embedded Prometheus listens at this address. Set as `host:port` | `127.0.0.1:9090` |
+| <a className="entRef-anchor" id="prometheus-scrape-interval-config">#</a><a href='#prometheus-scrape-interval-config'>prometheus_scrape_interval</a> | The Prometheus scrape frequency | `10s` |
+| <a className="entRef-anchor" id="prometheus-url-config">#</a><a href='#prometheus-url-config'>prometheus_url</a> | URL for an external Prometheus server. Do not set with `prometheus_data_dir`; external and embedded Prometheus modes are mutually exclusive. | none |
+| <a className="entRef-anchor" id="shared-secret-config">#</a><a href='#shared-secret-config'>shared_secret</a> | Required: The base64-encoded secret for signing JWTs, shared with OSS Pomerium. The Console refuses to start if unset (or use a `*_file` / `*_raw_file` variant). | none |
+| <a className="entRef-anchor" id="shared-secret-file-config">#</a><a href='#shared-secret-file-config'>shared_secret_file</a> | Loads base64-encoded `shared-secret` from a file. | none |
+| <a className="entRef-anchor" id="shared-secret-raw-file-config">#</a><a href='#shared-secret-raw-file-config'>shared_secret_raw_file</a> | Loads `shared-secret` from a raw file. Setting this option from a raw file does not require base64 encoding. | none |
+| <a className="entRef-anchor" id="signing-key-config">#</a><a href='#signing-key-config'>signing_key</a> | (deprecated) base64-encoded signing key (public or private) for verifying JWTs. Usually omitted when the Console can verify identity headers from Pomerium's JWKS endpoint; local self-signed examples may set it to match Core. | none |
+| <a className="entRef-anchor" id="signing-key-file-config">#</a><a href='#signing-key-file-config'>signing_key_file</a> | Loads base64-encoded `signing-key` secret from a file. | none |
+| <a className="entRef-anchor" id="signing-key-raw-file-config">#</a><a href='#signing-key-raw-file-config'>signing_key_raw_file</a> | Loads `signing-key` secret from a raw file. Setting this option from a raw file does not require base64 encoding. | none |
+| <a className="entRef-anchor" id="tls-ca-config">#</a><a href='#tls-ca-config'>tls_ca</a> | base64-encoded string of tls-ca | none |
+| <a className="entRef-anchor" id="tls-ca-file-config">#</a><a href='#tls-ca-file-config'>tls_ca_file</a> | file storing tls-ca | none |
+| <a className="entRef-anchor" id="tls-cert-config">#</a><a href='#tls-cert-config'>tls_cert</a> | base64-encoded string of tls-cert | none |
+| <a className="entRef-anchor" id="tls-cert-file-config">#</a><a href='#tls-cert-file-config'>tls_cert_file</a> | file storing tls-cert | none |
+| <a className="entRef-anchor" id="tls-derive-config">#</a><a href='#tls-derive-config'>tls_derive</a> | Derives TLS server certificate for the console HTTPS and gRPC endpoints for the host specified by this option, using the CA derived from the shared key. Uses this CA to verify the server certificate presented by the Databroker gRPC TLS when the [`tls_derive`](/docs/reference/tls-derive) option is set in the Pomerium Core. | none |
+| <a className="entRef-anchor" id="tls-insecure-skip-verify-config">#</a><a href='#tls-insecure-skip-verify-config'>tls_insecure_skip_verify</a> | Disable remote hosts TLS certificate chain and hostname checks. | `false` |
+| <a className="entRef-anchor" id="tls-key-config">#</a><a href='#tls-key-config'>tls_key</a> | base64-encoded string of tls-key | none |
+| <a className="entRef-anchor" id="tls-key-file-config">#</a><a href='#tls-key-file-config'>tls_key_file</a> | file storing tls-key | none |
+| <a className="entRef-anchor" id="use-static-assets-config">#</a><a href='#use-static-assets-config'>use_static_assets</a> | When false, forward static requests to `localhost:3000`. | `true` |
+| <a className="entRef-anchor" id="validation-mode-config">#</a><a href='#validation-mode-config'>validation_mode</a> | Validates config based on the specified mode: `full` (The default config validation mode), `static` (A "light" validation mode that catches most config issues), or `none` (Disables config validation). | `full` |
 
 </TabItem>
 </Tabs>

--- a/content/docs/deploy/enterprise/enterprise.md
+++ b/content/docs/deploy/enterprise/enterprise.md
@@ -1,113 +1,71 @@
 ---
 title: Pomerium Enterprise
-description: Learn what features come with Pomerium Enterprise, including a Console GUI where you can manage your policies, namespaces, groups, routes, and more.
+description: Install, configure, and operate the self-hosted Pomerium Enterprise control plane for Pomerium Core clusters.
+sidebar_position: 0
 keywords:
   [
     Pomerium Enterprise,
-    PPL Builder,
-    Console GUI,
+    Enterprise Console,
+    Enterprise API,
+    self-hosted control plane,
     namespaces,
     directory sync,
-    device management,
-    groups,
-    programmatic api,
-    branding,
+    service accounts,
+    metrics,
+    terraform,
   ]
 ---
 
-import ClearIcon from '@mui/icons-material/Clear';
-
 # Pomerium Enterprise
 
-Pomerium Enterprise is built on our open-source Pomerium Core offering. Pomerium Enterprise makes Pomerium easier to manage at scale, and adds additional functionality aimed at organizations with auditing, compliance, governance, and risk management needs.
+Pomerium Enterprise is the self-hosted control plane for Pomerium Core clusters. Core still runs in your environment and proxies traffic to your applications. Enterprise adds the Console, API, centralized configuration, governance, audit history, and operational visibility for teams that need to manage Pomerium at scale.
 
-## Pomerium Enterprise Features
+## Enterprise Console
 
-Pomerium Enterprise comes with all the capabilities in Pomerium Core, plus the following features:
+The Enterprise Console is the browser-based management UI and API surface for Enterprise deployments. Use it to manage global settings, namespaces, routes, policies, certificates, external data, directory sync, sessions, service accounts, deployment history, and operational dashboards.
 
-### Enterprise Console
+## Start Here
 
-The **Enterprise Console** provides a dashboard where you can view traffic and logs, manage routes and policies, import external data, configure global and namespaced settings, and more.
-
-![An overview animation of the Pomerium Enterprise Console](./img/enterprise-console-overview.gif)
-
-### Enterprise API
-
-The **Enterprise API** helps you manage your configuration with your preferred programming language or infrastructure management tool.
-
-Everything that is manageable in the Enterprise Console can also be driven programmatically through the [Enterprise API](/docs/internals/management-api-enterprise).
-
-### Session Management
-
-The **Sessions** dashboard allows you to view and manage sessions within your organization. Admin members can export session data and revoke sessions in real time.
-
-![View and manage sessions in the Enterprise Console's Sessions dashboard](./img/manage-sessions.png)
-
-:::enterprise
-
-Ready to upgrade to Pomerium Enterprise? [**Contact us**](https://www.pomerium.com/enterprise-sales/) today to get started.
-
-:::
-
-### Namespaces and Self-Service
-
-The **Namespaces** dashboard is where you configure user roles and permissions for routes, policies, and the Enterprise Console itself. Once you've configured a [Namespace](/docs/internals/namespacing), members of that namespace can self-manage access to the infrastructure they build from or depend on.
-
-Pomerium Enterprise allows you to import groups defined by your identity provider. This allows you to build stable policies that don't require adjustments as your company changes.
-
-![Manage Namespaces in the Enterprise Console's Namespaces dashboard](./img/manage-namespaces.gif)
-
-### Clusters
-
-In the **Namespaces** dashboard you can also add [**Clusters**](/docs/internals/clusters-for-enterprise) &mdash; independent installations of [Pomerium Core](/docs/deploy/core), each with their own set of routes, certificates, and policies.
-
-![Add Cluster](../../internals/img/clusters/enterprise-add-cluster.png)
-
-### Deployment History and Audit Logs
-
-The **Deployments** dashboard allows you to view and export change logs from the Enterprise Console. Select a change to review which user applied it and when.
-
-![View deployments in the Enterprise Console's Deployments dashboard](./img/deployments-dashboard.gif)
-
-### Directory Sync
-
-Pomerium Enterprise's [**Directory Sync**](/docs/integrations/user-standing/directory-sync) feature allows you to import your identity provider's directory data. After a successful sync, you can use your internal groups and teams data when building policies. ![Viewing the Identity Providers settings for a directory sync in the Enterprise Console](./img/directory-sync-2.png)
-
-### External Data Sources
-
-In the **External Data** dashboard, you can import, view, and manage [external data sources](/docs/capabilities/integrations). After a successful sync, you can use data unique to your organization to serve as context in your authorization policies. ![Using the External Data Source Record type in a policy](./img/external-data-as-context.gif)
-
-## Pomerium Enterprise features comparison
-
-| Features | Pomerium Core | Pomerium Enterprise |
+| Goal | Page | Use it for |
 | :-- | :-- | :-- |
-| Identity-based Access | ![Pomerium checkmark](./img/pomerium-checkmark.svg) | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
-| SSO Support | ![Pomerium checkmark](./img/pomerium-checkmark.svg) | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
-| Declarative Authorization Policy | ![Pomerium checkmark](./img/pomerium-checkmark.svg) | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
-| TCP Support | ![Pomerium checkmark](./img/pomerium-checkmark.svg) | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
-| Enterprise Console | <ClearIcon /> | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
-| [Enterprise API](/docs/internals/management-api-enterprise) | <ClearIcon /> | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
-| [Session Management](/docs/internals/metrics) | <ClearIcon /> | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
-| [Namespaces](/docs/internals/namespacing) | <ClearIcon /> | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
-| [Directory Sync](/docs/integrations/user-standing/directory-sync) | <ClearIcon /> | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
-| [User Impersonation](/docs/capabilities/impersonation) | <ClearIcon /> | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
-| [Deployment History](/docs/internals/metrics) | <ClearIcon /> | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
-| [Device Identity](/docs/integrations/device-context/device-identity) | <ClearIcon /> | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
-| [Custom Branding](/docs/capabilities/branding) | <ClearIcon /> | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
-| [Service Accounts](/docs/capabilities/service-accounts) | <ClearIcon /> | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
-| [Metrics](/docs/internals/metrics) | <ClearIcon /> | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
-| [External Data Sources](/docs/capabilities/integrations) | <ClearIcon /> | ![Pomerium checkmark](./img/pomerium-checkmark.svg) |
+| Try Enterprise locally | [Quickstart](/docs/deploy/enterprise/quickstart) | Run Core, the Enterprise Console, PostgreSQL, and a test app with Docker Compose. |
+| Install Enterprise | [Install](/docs/deploy/enterprise/install) | Choose Docker, OS packages, Kubernetes with Kustomize, or Kubernetes with Terraform. |
+| Set Console options | [Configuration](/docs/deploy/enterprise/configure) | Configure bootstrap admins, licensing, database access, Databroker access, TLS, and runtime flags. |
+| Enable traffic metrics | [Metrics](/docs/deploy/enterprise/configure-metrics) | Connect Enterprise to external Prometheus or use the embedded Prometheus mode. |
+| Manage resources as code | [Terraform](/docs/deploy/terraform) | Configure Core, Enterprise, or Zero resources with the Pomerium Terraform provider. |
+| Upgrade safely | [Upgrading](/docs/deploy/upgrading) | Review version-specific Core and Enterprise upgrade notes. |
 
-## Next Steps
+## How Enterprise Fits With Core
 
-:::enterprise
+An Enterprise deployment has three required pieces:
 
-Already upgraded to Pomerium Enterprise, but need some help setting up the Enterprise Console?
+1. **Pomerium Core** is the data plane. It authenticates users, authorizes requests, proxies traffic, stores Databroker state, and protects the Console route.
+1. **Pomerium Enterprise Console** is the self-hosted management plane. It stores its own data in PostgreSQL, connects to the Core Databroker, and exposes the Console UI and Enterprise API.
+1. **A protected Console route** in Core sends authenticated users to the Console and passes identity headers so Enterprise can authorize administrators and namespace members.
 
-The following docs can help:
+Keep Core and Enterprise Console on the same minor version. For example, Core `v0.32.x` with Enterprise Console `v0.32.x` is supported; Core `v0.32.x` with Enterprise Console `v0.31.x` is not. The Docker examples in these docs use Pomerium Core `v0.32.6` and Enterprise Console `v0.32.1`.
 
-- [**Install Pomerium Enterprise**](/docs/deploy/enterprise/install)
-- [**Pomerium Enterprise Configuration**](/docs/deploy/enterprise/configure)
-- [**Pomerium Enterprise Quickstart**](/docs/deploy/enterprise/quickstart)
+:::caution
+
+For the v0.32 upgrade path, upgrade the Enterprise Console before upgrading Core. See [Upgrading Pomerium Enterprise](/docs/deploy/upgrading#upgrading-pomerium-enterprise).
 
 :::
+
+## Enterprise Capabilities
+
+| Area | Enterprise adds |
+| :-- | :-- |
+| Central management | The [Enterprise Console](/docs/deploy/enterprise/install) and [Enterprise API](/docs/internals/management-api-enterprise) for managing routes, policies, certificates, settings, and namespaces. |
+| Delegated administration | [Namespaces](/docs/internals/namespacing) for RBAC and self-service management across teams. |
+| Identity context | [Directory Sync](/docs/integrations/user-standing/directory-sync), [Device Identity](/docs/integrations/device-context/device-identity), and [External Data Sources](/docs/capabilities/integrations) for richer policy context. |
+| Automation | [Service accounts](/docs/capabilities/service-accounts), the Enterprise API, and [Terraform](/docs/deploy/terraform) for infrastructure-as-code workflows. |
+| Operations | [Session management](/docs/internals/sessions), [audit logs](/docs/capabilities/audit-logs), deployment history, and [metrics](/docs/deploy/enterprise/configure-metrics). |
+| User experience | [Custom branding](/docs/capabilities/branding), [user impersonation](/docs/capabilities/impersonation), and self-service access workflows. |
+
+## Setup Sequence
+
+1. Install or confirm a working [Pomerium Core](/docs/deploy/core) deployment.
+1. Install the Enterprise Console with [Docker, OS packages, Kubernetes, or Terraform](/docs/deploy/enterprise/install).
+1. Configure the Console database, license key, shared secret, Databroker connection, and initial administrators.
+1. Protect the Console route with Core and enable identity headers.
+1. Add optional operations features such as [metrics](/docs/deploy/enterprise/configure-metrics), [Terraform configuration](/docs/deploy/terraform), directory sync, external data, and service accounts.

--- a/content/docs/deploy/enterprise/enterprise.md
+++ b/content/docs/deploy/enterprise/enterprise.md
@@ -1,7 +1,7 @@
 ---
 title: Pomerium Enterprise
 description: Install, configure, and operate the self-hosted Pomerium Enterprise control plane for Pomerium Core clusters.
-sidebar_position: 0
+sidebar_position: 3
 keywords:
   [
     Pomerium Enterprise,

--- a/content/docs/deploy/enterprise/install.mdx
+++ b/content/docs/deploy/enterprise/install.mdx
@@ -1,6 +1,10 @@
 ---
-title: Install
-description: Install Pomerium Enterprise Console alongside Pomerium Core using Docker, Kubernetes, or system packages.
+# cSpell:ignore makecache disablerepo enablerepo lsb tfvars
+
+title: Install Pomerium Enterprise
+sidebar_label: Install
+description: Install the Pomerium Enterprise Console with Docker, OS packages, Kubernetes Kustomize, or Kubernetes Terraform.
+sidebar_position: 2
 lang: en-US
 keywords:
   [
@@ -18,132 +22,128 @@ keywords:
   ]
 ---
 
+import CodeBlock from '@theme/CodeBlock';
 import TabItem from '@theme/TabItem';
 import Tabs from '@theme/Tabs';
 
-Pomerium offers several ways to install the Enterprise Console to suit your organization's needs. Watch the video below for a quick primer on deploying Pomerium Core and Enterprise, or view the sections below for specific installation instructions.
+import Config from '!!raw-loader!@site/k8s/config-template/config.yaml';
+import Ingress from '!!raw-loader!@site/k8s/config-template/ingress-console.yaml';
+import Kustomization from '!!raw-loader!@site/k8s/config-template/kustomization.yaml';
+import Secret from '!!raw-loader!@site/k8s/config-template/secret.yaml';
 
-<iframe
-  width="100%"
-  height="450"
-  src="https://www.youtube.com/embed/NrRwisO9sDg?rel=0"
-  title="YouTube video player"
-  frameborder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowFullScreen
-/>
+# Install Pomerium Enterprise
 
-## Install Pomerium Enterprise
+Install the Enterprise Console alongside a working Pomerium Core deployment. Use the [quickstart](/docs/deploy/enterprise/quickstart) for a local Docker Compose trial; use this page when you are choosing a production install method.
+
+Before installing Enterprise, make sure you have:
+
+- A working [Pomerium Core](/docs/deploy/core) deployment
+- A PostgreSQL database for the Enterprise Console
+- A Pomerium Enterprise license key
+- Cloudsmith registry credentials for private Enterprise artifacts
+
+Keep Core and the Enterprise Console on the same minor version. The Docker examples on this page use Pomerium Core `v0.32.6` and Enterprise Console `v0.32.1`.
+
+## Install Method
 
 <Tabs>
 <TabItem label="Docker" value="Docker">
 
-The Pomerium Enterprise Docker image is available at a private Cloudsmith Docker registry.
+The Enterprise Console Docker image is published in Pomerium's private Cloudsmith registry.
 
-To access the Pomerium Enterprise Docker image:
-
-1. In your terminal, run the following command:
+Sign in to Cloudsmith:
 
 ```shell
 docker login docker.cloudsmith.io
 ```
 
-2. Enter your **username** and **password**:
+For Cloudsmith entitlement-token credentials, use `pomerium/enterprise` as the username and the entitlement token as the password.
+
+Pull the current Enterprise Console image:
 
 ```shell
- % docker login docker.cloudsmith.io
-Username: <username>
-Password: <password>
+docker pull docker.cloudsmith.io/pomerium/enterprise/pomerium-console:v0.32.1
 ```
 
-3. Pull a specific tagged release of the Pomerium Enterprise image:
+The image only installs the Console process. You still need to provide:
 
-```shell
-docker pull docker.cloudsmith.io/pomerium/enterprise/pomerium-console:${vX.X.X}
-```
+- A Console configuration file or environment variables
+- A PostgreSQL database
+- A route in Pomerium Core that protects the Console and passes identity headers
 
-See the [Enterprise Quickstart](/docs/deploy/enterprise/quickstart) for instructions to run and deploy the Enterprise Console with Docker Compose.
+For a complete local Docker Compose example, see the [Enterprise Docker Quickstart](/docs/deploy/enterprise/quickstart).
 
 </TabItem>
 <TabItem label="OS Packages" value="OS Packages">
 
-You can find the latest `rpm` and `deb` packages on [Cloudsmith](https://cloudsmith.io/~pomerium/repos/pomerium/groups/) or download them from the [GitHub releases](https://github.com/pomerium/pomerium/releases) page.
+Enterprise OS packages are available through the private Cloudsmith repository. Replace `[access-key]` with the access key provided by Pomerium.
 
-| **Supported Operating Systems** | **Supported Architectures** |
-| :------------------------------ | :-------------------------- |
-| `linux`                         | `amd64`                     |
-| `darwin`                        | `arm64`                     |
+### DEB Installation
 
-### DEB installation
-
-To automatically configure the repository for Debian and Ubuntu distributions:
-
-1. Replace `[access-key]` in the command below and run it:
+Configure the repository for Debian or Ubuntu:
 
 ```bash
 curl -1sLf \
-'https://dl.cloudsmith.io/[access-key]/pomerium/enterprise/setup.deb.sh' \
-| sudo -E bash
+  'https://dl.cloudsmith.io/[access-key]/pomerium/enterprise/setup.deb.sh' \
+  | sudo -E bash
 ```
 
-To manually configure the repository, do the following:
+If you need to configure the repository manually:
 
 ```bash
-apt-get install -y debian-keyring  # debian only
-apt-get install -y debian-archive-keyring  # debian only
-apt-get install -y apt-transport-https
-# For Debian Stretch, Ubuntu 16.04 and later
+sudo apt-get install -y debian-keyring debian-archive-keyring apt-transport-https
 keyring_location=/usr/share/keyrings/pomerium-enterprise-archive-keyring.gpg
-# For Debian Jessie, Ubuntu 15.10 and earlier
-keyring_location=/etc/apt/trusted.gpg.d/pomerium-enterprise.gpg
-curl -1sLf 'https://dl.cloudsmith.io/[access-key]/pomerium/enterprise/gpg.B1D0324399CB9BC3.key' |  gpg --dearmor >> ${keyring_location}
-curl -1sLf 'https://dl.cloudsmith.io/[access-key]/pomerium/enterprise/config.deb.txt?distro=debian&codename=wheezy&component=main' > /etc/apt/sources.list.d/pomerium-enterprise.list
+curl -1sLf 'https://dl.cloudsmith.io/[access-key]/pomerium/enterprise/gpg.B1D0324399CB9BC3.key' | sudo gpg --dearmor -o ${keyring_location}
+. /etc/os-release
+curl -1sLf "https://dl.cloudsmith.io/[access-key]/pomerium/enterprise/config.deb.txt?distro=${ID}&codename=${VERSION_CODENAME}&component=main" | sudo tee /etc/apt/sources.list.d/pomerium-enterprise.list
 sudo chmod 644 ${keyring_location}
 sudo chmod 644 /etc/apt/sources.list.d/pomerium-enterprise.list
-apt-get update
 ```
 
-2. Update `apt` and install Pomerium Enterprise:
+Install the Console package:
 
 ```bash
-sudo apt update; sudo apt install pomerium-console
+sudo apt update
+sudo apt install pomerium-console
 ```
 
-After you've installed the package, enable and start the system service:
+Edit `/etc/pomerium-console/config.yaml` with your license key, database URL, database encryption key, shared secret, Databroker URL, audience, and administrators (see [Enterprise configuration](/docs/deploy/enterprise/configure) for the full list of required settings). The package's default config contains placeholder values; the service will not start until they are replaced.
+
+Then enable and start the service:
 
 ```bash
 sudo systemctl enable --now pomerium-console
 ```
 
-### RPM installation
+### RPM Installation
 
-To automatically configure the repository for RHEL based distributions:
-
-1. Replace [access-key] in the command below and run it:
+Configure the repository for RHEL-based distributions:
 
 ```bash
 curl -1sLf \
-'https://dl.cloudsmith.io/[access-key]/pomerium/enterprise/setup.rpm.sh' \
-| sudo -E bash
+  'https://dl.cloudsmith.io/[access-key]/pomerium/enterprise/setup.rpm.sh' \
+  | sudo -E bash
 ```
 
-To manually configure the repository, run:
+If you need to configure the repository manually:
 
 ```bash
-yum install yum-utils pygpgme
-rpm --import 'https://dl.cloudsmith.io/[access-key]/pomerium/enterprise/gpg.B1D0324399CB9BC3.key'
-curl -1sLf 'https://dl.cloudsmith.io/[access-key]/pomerium/enterprise/config.rpm.txt?distro=el&codename=9' > /tmp/pomerium-enterprise.repo
-yum-config-manager --add-repo '/tmp/pomerium-enterprise.repo'
-yum -q makecache -y --disablerepo='*' --enablerepo='pomerium-enterprise'
+sudo yum install -y yum-utils
+sudo rpm --import 'https://dl.cloudsmith.io/[access-key]/pomerium/enterprise/gpg.B1D0324399CB9BC3.key'
+curl -1sLf "https://dl.cloudsmith.io/[access-key]/pomerium/enterprise/config.rpm.txt?distro=el&codename=$(rpm -E %{rhel})" > /tmp/pomerium-enterprise.repo
+sudo yum-config-manager --add-repo /tmp/pomerium-enterprise.repo
+sudo yum -q makecache -y --disablerepo='*' --enablerepo='pomerium-enterprise'
 ```
 
-2. Update `yum` and install Pomerium Enterprise:
+Install the Console package:
 
 ```bash
-yum -y install pomerium-console
+sudo yum -y install pomerium-console
 ```
 
-After you've installed the package, enable and start the system service:
+Edit `/etc/pomerium-console/config.yaml` with your license key, database URL, database encryption key, shared secret, Databroker URL, audience, and administrators (see [Enterprise configuration](/docs/deploy/enterprise/configure) for the full list of required settings). The package's default config contains placeholder values; the service will not start until they are replaced.
+
+Then enable and start the service:
 
 ```bash
 sudo systemctl enable --now pomerium-console
@@ -152,95 +152,155 @@ sudo systemctl enable --now pomerium-console
 </TabItem>
 <TabItem label="Kubernetes with Kustomize" value="Kubernetes with Kustomize">
 
-These steps cover installing Pomerium Enterprise into your existing Kubernetes cluster. It's designed to work with an existing cluster running Pomerium, as described in [Pomerium Kustomize]. Follow that document before continuing here.
+Use this path when you already run Pomerium Core in Kubernetes with the [Pomerium ingress controller](/docs/deploy/k8s/install).
 
-The assumption is that Pomerium is installed into the `pomerium` namespace, and Enterprise would be installed into the `pomerium-enterprise` namespace.
+The examples assume:
 
-## Prepare Core
+- Core runs in the `pomerium` namespace.
+- Enterprise runs in the `pomerium-enterprise` namespace.
+- You have a PostgreSQL database reachable from the cluster.
+- You have a DNS name and TLS setup for the Console route.
 
-The below command will expose the Pomerium Core Databroker gRPC interface.
+These commands pin the Kubernetes manifests to commit `e2392b54`, the current commit behind the `0-32-0` docs release ref when this guide was validated. The local overlays pin the rendered images to Pomerium ingress-controller `v0.32.6` and Enterprise Console `v0.32.1`.
 
-```console
-kubectl apply -k github.com/pomerium/documentation/k8s/core\?ref=0-31-0
+:::caution
+
+When you upgrade to a newer docs release ref, resolve it to a commit SHA before applying it:
+
+```bash
+git ls-remote https://github.com/pomerium/documentation refs/heads/<release-ref>
 ```
 
-## Deploy Enterprise Console
+Then replace the pinned `?ref=<SHA>` values in the kustomization files below with the audited SHA. Do not use `?ref=main` for production.
 
-```console
-kubectl apply -k github.com/pomerium/documentation/k8s/console\?ref=0-31-0
+:::
+
+This guide assumes you already have a working Pomerium Core deployment with a `Pomerium` custom resource configured (see [Kubernetes install](/docs/deploy/k8s/install)). The Enterprise overlay deploys the Console only - without an existing Core ingress-controller bound to a `Pomerium` CR, the Console cannot reach the databroker and will fail readiness.
+
+Expose the Core Databroker service used by the Console.
+
+The overlay below is intended for Core deployments based on Pomerium's documented Kustomize base. It imports that base and therefore renders the ingress controller, namespace, CRDs, RBAC, services, and the Databroker service. If your Core deployment already uses a customized overlay, merge only the Databroker service and the `--databroker-auto-tls` patch into your existing Core overlay instead of applying this overlay as-is.
+
+Create `core-databroker/kustomization.yaml`:
+
+```yaml title="core-databroker/kustomization.yaml"
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - github.com/pomerium/documentation/k8s/core?ref=e2392b544a5a4f6a4bb1cccdc66c2c480bc5d0a3&timeout=180s
+images:
+  - name: pomerium/ingress-controller
+    newTag: v0.32.6
 ```
 
-The Enterprise Console need be configured before it becomes fully operational.
+The `&timeout=180s` query parameter overrides Kustomize's default 27-second git fetch timeout, which can fail on slower networks.
 
-## Create Cloudsmith Directory Secret
+```console
+kubectl apply -k ./core-databroker
+```
+
+Create the Enterprise namespace:
+
+```console
+kubectl create namespace pomerium-enterprise --dry-run=client -o yaml | kubectl apply -f -
+```
+
+Create the Cloudsmith image pull secret:
 
 ```console
 kubectl create secret docker-registry pomerium-enterprise-docker \
-    --namespace pomerium-enterprise \
-    --docker-server=docker.cloudsmith.io \
-    --docker-username=pomerium/enterprise \
-    --docker-password="your password provided by Pomerium Sales"
+  --namespace pomerium-enterprise \
+  --docker-server=docker.cloudsmith.io \
+  --docker-username=pomerium/enterprise \
+  --docker-password='your Cloudsmith entitlement token' \
+  --dry-run=client \
+  -o yaml | kubectl apply -f -
 ```
 
-## Configure Enterprise Console
+Create a `config` directory and add the following files. Replace placeholder domains, database settings, secrets, license values, and administrator emails before applying them.
 
-Create a `config` directory, and fill in the configuration parameters for the following template files:
-
-import CodeBlock from '@theme/CodeBlock';
-
-import Config from '!!raw-loader!@site/k8s/config-template/config.yaml';
-import Ingress from '!!raw-loader!@site/k8s/config-template/ingress-console.yaml';
-import Kustomization from '!!raw-loader!@site/k8s/config-template/kustomization.yaml';
-import Secret from '!!raw-loader!@site/k8s/config-template/secret.yaml';
-
-<CodeBlock language="jsx" title="kustomization.yaml">
+<CodeBlock language="yaml" title="kustomization.yaml">
   {Kustomization}
 </CodeBlock>
 
-See [Environment Variables] for Config and Secret keys description.
-
-<CodeBlock language="jsx" title="config.yaml">
+<CodeBlock language="yaml" title="config.yaml">
   {Config}
 </CodeBlock>
 
-<CodeBlock language="jsx" title="secret.yaml">
+<CodeBlock language="yaml" title="secret.yaml">
   {Secret}
 </CodeBlock>
 
-Create [Ingress] for Console.
+The Console will not start until `database_url`, `database_encryption_key`, `license_key`, and `shared_secret` are populated with real values. Use the base64 `shared_secret` from your Core bootstrap secret so Console and Core trust the same Databroker tokens.
 
-<CodeBlock language="jsx" title="ingress-console.yaml">
+<CodeBlock language="yaml" title="ingress-console.yaml">
   {Ingress}
 </CodeBlock>
 
+Apply your local configuration:
+
 ```console
-
 kubectl apply -k ./config
-
 ```
 
-[pomerium kustomize]: /docs/deploy/k8s/install
-[environment variables]: /docs/deploy/enterprise/configure
-[ingress]: /docs/deploy/k8s/ingress
+Deploy the Enterprise Console:
+
+Create `enterprise-console/kustomization.yaml`:
+
+```yaml title="enterprise-console/kustomization.yaml"
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - github.com/pomerium/documentation/k8s/console?ref=e2392b544a5a4f6a4bb1cccdc66c2c480bc5d0a3&timeout=180s
+images:
+  - name: docker.cloudsmith.io/pomerium/enterprise/pomerium-console
+    newTag: v0.32.1
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: pomerium-console
+      spec:
+        template:
+          spec:
+            containers:
+              - name: pomerium-console
+                env:
+                  - name: AUTHENTICATE_SERVICE_URL
+                    $patch: delete
+                  - name: METRICS_ADDR
+                    value: ":9092"
+```
+
+The `METRICS_ADDR=:9092` patch is required: the pinned upstream Console manifests do not set `METRICS_ADDR`, so the binary binds metrics on `127.0.0.1:9092` by default. The Console `Service` exposes port `9090` targeting the container's `metrics` port (`9092`); without binding the Console to `0.0.0.0:9092` the Service has nothing to forward to and external Prometheus scrapes return empty.
+
+```console
+kubectl apply -k ./enterprise-console
+```
+
+See [Enterprise configuration](/docs/deploy/enterprise/configure) for each Console setting used by these manifests.
 
 </TabItem>
 <TabItem label="Kubernetes with Terraform" value="Kubernetes with Terraform">
 
-You can deploy Pomerium Enterprise to Kubernetes using Terraform modules from the [`pomerium/install`](https://github.com/pomerium/install) repository. This approach uses two modules:
+Use this path when you want Terraform to install Pomerium Core and the Enterprise Console into Kubernetes. To manage Pomerium routes, policies, settings, service accounts, and other resources after the Console is running, use the shared [Terraform configuration guide](/docs/deploy/terraform).
 
-1. **Ingress Controller** — deploys Pomerium Core as a Kubernetes ingress controller
-2. **Enterprise Console** — deploys the Pomerium Enterprise Console, connecting it to the ingress controller
+The Kubernetes installation modules live in the [`pomerium/install`](https://github.com/pomerium/install) repository:
+
+1. **Ingress Controller** deploys Pomerium Core as a Kubernetes ingress controller.
+2. **Enterprise Console** deploys the Console and connects it to the ingress controller.
 
 :::caution
 
-Keep installation and [configuration](/docs/deploy/terraform) in separate Terraform runs. The Pomerium Terraform provider must connect to a running Enterprise Console, so if Pomerium is misconfigured or an essential component (such as the console database) is down, all dependent configuration resources will fail and the entire `terraform plan` / `terraform apply` will be blocked.
+Keep installation and configuration in separate Terraform runs. The Pomerium Terraform provider must connect to a running Enterprise Console, so dependent configuration resources fail if the Console, database, or protected API route is not ready.
 
 :::
 
 ### Prerequisites
 
-- A Kubernetes cluster with a configured Terraform [Kubernetes provider](https://registry.terraform.io/providers/hashicorp/kubernetes/latest)
-- [Terraform](https://www.terraform.io/downloads) >= 1.0
+- A Kubernetes cluster with configured Terraform [Kubernetes](https://registry.terraform.io/providers/hashicorp/kubernetes/latest) and [`kubectl`](https://registry.terraform.io/providers/gavinbunney/kubectl/latest) providers. In CI or Terraform Cloud, configure both providers explicitly or ensure both can load the same kubeconfig.
+- Terraform >= 1.0
 - A PostgreSQL database for the Enterprise Console
 - A Pomerium Enterprise license key and Cloudsmith registry credentials
 
@@ -253,7 +313,6 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.0"
     }
-    # Required by the ingress-controller module
     tls = {
       source  = "hashicorp/tls"
       version = "~> 4.0"
@@ -270,76 +329,137 @@ terraform {
 }
 ```
 
-### Deploy the Ingress Controller
+:::caution
 
-The ingress controller module is an all-in-one deployment of Pomerium Core and the ingress controller. It creates the following Kubernetes resources: Namespace, CRDs, RBAC (ClusterRole, ClusterRoleBinding, ServiceAccounts), IngressClass, Deployment, Services, and Secrets.
+The `pomerium/install` repository does not publish version-aligned release tags. The examples below pin both modules to commit `166bfa15`, the SHA used to validate this guide against Pomerium Core v0.32.x. Re-pin to a newer SHA you have audited yourself when you upgrade. Do not use `?ref=main` for production.
+
+Each module has its own `image_tag` variable with a separate default:
+
+- Ingress controller defaults to `v0.31.0`. Override to `v0.32.6`.
+- Enterprise Console defaults to `v0.31.1`. Override to `v0.32.1`.
+
+:::
+
+### Deploy the Ingress Controller
 
 ```hcl
 module "pomerium_ingress_controller" {
-  source = "git::https://github.com/pomerium/install.git//ingress-controller/terraform?ref=main"
+  source = "git::https://github.com/pomerium/install.git//ingress-controller/terraform?ref=166bfa15d9ece7a3b88e0d3472c39b1669846735"
 
   namespace_name    = "pomerium"
   enable_databroker = true
+  image_tag         = "v0.32.6"
 
   config = {
-    # Reference TLS certificates available in the namespace
     certificates = ["pomerium/wildcard-tls"]
-    # See https://www.pomerium.com/docs/k8s/reference for all options
   }
 }
 ```
 
-See the [ingress-controller module variables](https://github.com/pomerium/install/tree/main/ingress-controller/terraform) for a full list of configuration options, including identity provider settings, resource limits, and proxy service type.
+See the [ingress-controller module variables](https://github.com/pomerium/install/tree/166bfa15d9ece7a3b88e0d3472c39b1669846735/ingress-controller/terraform) for identity provider settings, resource limits, certificates, and proxy service options.
 
 ### Deploy the Enterprise Console
 
-The enterprise console module deploys the Pomerium Enterprise Console and connects it to the ingress controller using shared secrets.
-
 ```hcl
 module "pomerium_enterprise_console" {
-  source = "git::https://github.com/pomerium/install.git//enterprise/terraform/kubernetes?ref=main"
+  source = "git::https://github.com/pomerium/install.git//enterprise/terraform/kubernetes?ref=166bfa15d9ece7a3b88e0d3472c39b1669846735"
 
-  # Secrets from the ingress controller module
   shared_secret_b64 = module.pomerium_ingress_controller.shared_secret_b64
   signing_key_b64   = module.pomerium_ingress_controller.signing_key_b64
 
-  # Namespace where Pomerium Core is deployed
   core_namespace_name = "pomerium"
 
-  # Enterprise image registry credentials
   image_registry_password = var.cloudsmith_password
+  image_tag               = "v0.32.1"
+  license_key             = var.pomerium_license_key
 
-  # Enterprise license
-  license_key = var.pomerium_license_key
-
-  # PostgreSQL database connection string
   database_url = "postgres://console:${var.db_password}@db-host:5432/pomerium-enterprise?sslmode=require"
 
-  # Console web UI and API ingress configuration
+  # Required: Console refuses to start if AUDIENCE is unset. The pinned module
+  # default for `audience` can render to "" depending on inputs; set it explicitly.
+  audience = ["console.example.com", "console-api.example.com"]
+
   console_ingress = {
-    dns         = "console.example.com"
-    annotations = {}
+    dns = "console.example.com"
+    annotations = {
+      "ingress.pomerium.io/pass_identity_headers"        = "true"
+      "ingress.pomerium.io/allow_any_authenticated_user" = "true"
+      "ingress.pomerium.io/secure_upstream"              = "true"
+    }
   }
   console_api_ingress = {
-    dns         = "console-api.example.com"
-    annotations = {}
+    dns = "console-api.example.com"
+    annotations = {
+      "ingress.pomerium.io/pass_identity_headers"        = "true"
+      "ingress.pomerium.io/allow_any_authenticated_user" = "true"
+      "ingress.pomerium.io/secure_upstream"              = "true"
+    }
   }
 
-  # Initial administrator emails for console bootstrap
   administrators = ["admin@example.com"]
-
-  # Sidecar containers (e.g. cloud-sql-proxy for GCP Cloud SQL)
-  sidecars = []
+  sidecars       = []
 
   depends_on = [module.pomerium_ingress_controller]
 }
 ```
 
-See the [enterprise console module variables](https://github.com/pomerium/install/tree/main/enterprise/terraform/kubernetes) for a full list of configuration options, including resource limits, clustered databroker settings, and observability options.
+Declare the variables the example references. A minimal `variables.tf`:
+
+```hcl title="variables.tf"
+variable "cloudsmith_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "pomerium_license_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "db_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "wildcard_tls_cert_pem" {
+  type      = string
+  sensitive = true
+}
+
+variable "wildcard_tls_key_pem" {
+  type      = string
+  sensitive = true
+}
+```
+
+The `ingress-controller` and `enterprise-console` modules each create their own namespace (`pomerium` and `pomerium-enterprise` by default). Do not pre-create those namespaces in your Terraform: apply will fail with `namespaces "pomerium" already exists`.
+
+The `certificates = ["pomerium/wildcard-tls"]` reference expects a `kubernetes.io/tls` secret named `wildcard-tls` in the `pomerium` namespace. Because the module creates the namespace, create the secret as a Terraform-managed resource that depends on the module. During the first apply, the Pomerium resource may reference the secret before Terraform creates it; the controller reconciles after the secret exists. The `wildcard_tls_cert_pem` / `wildcard_tls_key_pem` variables are declared in the `variables.tf` block above:
+
+```hcl
+resource "kubernetes_secret" "wildcard_tls" {
+  metadata {
+    name      = "wildcard-tls"
+    namespace = "pomerium"
+  }
+  type = "kubernetes.io/tls"
+  data = {
+    "tls.crt" = var.wildcard_tls_cert_pem
+    "tls.key" = var.wildcard_tls_key_pem
+  }
+  depends_on = [module.pomerium_ingress_controller]
+}
+```
+
+Source the PEM values from cert-manager, an external secrets manager, or a `terraform.tfvars` file backed by your cert provisioning workflow.
+
+The Terraform sample above provisions the install scaffolding (Pomerium ingress-controller, Console deployment, secrets, ingresses, namespaces) but does NOT configure the Core's identity provider. Without an IdP configured on the `Pomerium` CR the module creates, sign-in requests will fail at the authenticate step. Configure the Pomerium ingress-controller's IdP via the [Pomerium ingress-controller settings](https://pomerium.com/docs/k8s/ingress) (or use the hosted authenticate for trial/dev) before users can sign in to the Console.
+
+See the [enterprise console module variables](https://github.com/pomerium/install/tree/166bfa15d9ece7a3b88e0d3472c39b1669846735/enterprise/terraform/kubernetes) for resource limits, clustered Databroker settings, observability options, and ingress settings.
 
 ### DNS Records
 
-After deployment, point your console DNS records to the ingress controller's proxy service load balancer IP:
+After deployment, point the Console DNS records at the ingress controller proxy service load balancer IP:
 
 ```hcl
 data "kubernetes_service" "pomerium_proxy" {
@@ -351,10 +471,9 @@ data "kubernetes_service" "pomerium_proxy" {
   depends_on = [module.pomerium_ingress_controller]
 }
 
-# Create DNS records for the console and API endpoints pointing to the
-# load balancer IP:
-# - console.example.com     -> data.kubernetes_service.pomerium_proxy.status[0].load_balancer[0].ingress[0].ip
-# - console-api.example.com -> data.kubernetes_service.pomerium_proxy.status[0].load_balancer[0].ingress[0].ip
+# Create DNS records for:
+# - console.example.com
+# - console-api.example.com
 ```
 
 </TabItem>

--- a/content/docs/deploy/enterprise/quickstart.mdx
+++ b/content/docs/deploy/enterprise/quickstart.mdx
@@ -1,105 +1,128 @@
 ---
-# cSpell:ignore pygpgme makecache disablerepo enablerepo
-
-title: Run Pomerium Enterprise With Docker
+title: Enterprise Docker Quickstart
 sidebar_label: Quickstart
-description: Demo Pomerium Enterprise
+description: Run Pomerium Enterprise locally with Docker Compose and connect to the Enterprise Console.
 sidebar_position: 1
 ---
-
-import TabItem from '@theme/TabItem';
-import Tabs from '@theme/Tabs';
 
 import HostedConfig from '/content/examples/enterprise/hosted-auth-config.yaml.md';
 import HostedCompose from '/content/examples/enterprise/hosted-auth-docker.yaml.md';
 
-# Run Pomerium Enterprise With Docker
+# Enterprise Docker Quickstart
 
-Run Pomerium Enterprise with Docker containers and connect to the Console.
+Run Pomerium Core, the Enterprise Console, PostgreSQL, and a test application with Docker Compose.
 
-This guide uses our [**Hosted Authenticate Service**](/docs/capabilities/authentication). If you use our hosted service and have a license key, you can complete this guide in **under 5 minutes**.
+This quickstart uses the [Hosted Authenticate Service](/docs/capabilities/authentication) so you can try Enterprise without configuring your own identity provider. For a self-hosted identity provider, follow the Core authentication docs before adapting this example.
 
-See the [Self-Hosted Authenticate Service](/docs/capabilities/authentication) page if you want to self-host Pomerium.
+This guide uses Pomerium Core `v0.32.6` and Enterprise Console `v0.32.1`.
 
 ## Prerequisites
 
 To complete this guide, you need:
 
-- [Pomerium Core](/docs/get-started/quickstart)
 - [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/)
+- A Pomerium Enterprise license key
+- Cloudsmith registry credentials for the private Enterprise Console image
+- The email address you will use to sign in to Pomerium
 
-:::note
+If you need trial credentials, [contact us](https://www.pomerium.com/enterprise-sales/).
 
-This guide assumes you've already registered for Pomerium Enterprise and have credentials to access the private **Cloudsmith.io** Docker registry, and a **license key**. If you haven't registered for Pomerium Enterprise, [sign up here](https://www.pomerium.com/enterprise-sales/) for a free trial. Then, follow the steps below to install the Enterprise Console with Docker.
+## Sign In to Cloudsmith
 
-<details>
-  <summary>Install Pomerium Enterprise with Docker</summary>
-    <div>
-1. In your terminal, run the following command:
+Sign in to the private Cloudsmith registry:
 
 ```shell
 docker login docker.cloudsmith.io
 ```
 
-2. Enter your <b>username</b> and <b>password</b>:
+Enter the Cloudsmith username and password provided by Pomerium.
+
+For Cloudsmith entitlement-token credentials, use `pomerium/enterprise` as the username and the entitlement token as the password.
+
+Then pull the Enterprise Console image used by this guide:
 
 ```shell
-% docker login docker.cloudsmith.io
-Username: <username>
-Password: <password>
+docker pull docker.cloudsmith.io/pomerium/enterprise/pomerium-console:v0.32.1
 ```
-
-3. Pull a specific tagged release of the Pomerium Enterprise image:
-
-```shell
-docker pull docker.cloudsmith.io/pomerium/enterprise/pomerium-console:${vX.X.X}
-```
-
-   </div>
-</details>
-
-:::
 
 ## Configure Pomerium Core
 
-If you haven't, create a file called `config.yaml` and add the following code:
+Create `config.yaml`:
 
 <HostedConfig />
 
-Replace `user@example.com` with your email address.
+Replace `user@example.com` with the email address you will use to sign in.
 
-## Configure Pomerium Enterprise Console
+## Configure the Enterprise Console
 
-Create a file called `console-config.yaml` and update the following values:
+Create `console-config.yaml`:
 
-```title="console-config.yaml"
-administrators: admin@example.com
+```yaml title="console-config.yaml"
+administrators: user@example.com
 license_key: REPLACE_ME
 ```
 
-You must configure at least one administrator for console access. This user (or users) can then configure additional administrators in the console UI.
+Replace `user@example.com` with the same email address you used in `config.yaml`, and replace `REPLACE_ME` with your Enterprise license key.
 
-Multiple administrators are defined as a comma-separated string.
+The administrator email must also be allowed through the Console route in `config.yaml`; otherwise Core will block the user before the Console can grant admin access.
 
-## Configure Docker Compose services
+Do not commit `console-config.yaml`; it contains your Enterprise license key. The rest of the required Console settings, including the database URL, database encryption key, audience, shared secret, and Databroker URL, are passed as environment variables in the Docker Compose file below.
 
-Create a file called `docker-compose.yaml` in your project's root folder and add the configuration below:
+## Configure Docker Compose
+
+Create `docker-compose.yaml` in the same directory:
 
 <HostedCompose />
 
-Below are a few points to note about services running in `docker-compose.yaml`:
+The compose file starts:
 
-- `pomerium_console` exposes ports `8701` and `9090`. In your `config.yaml` file, you define port `8701` in a route that connects to the Pomerium Enterprise Console. Port `9090` is the [default port](https://prometheus.io/docs/introduction/first_steps/#configuring-prometheus) used by Prometheus to scrape metrics.
-- The healthcheck parameter ensures the database is ready to receive requests. Without a healthcheck, other containers that depend on the database service (like Pomerium Console) will attempt to connect to the database before it is in a ready state, **which will crash the container**. (See the [Docker healthcheck](https://docs.docker.com/engine/reference/builder/#healthcheck) docs for more information.)
+- `pomerium`, the Core data plane and protected reverse proxy
+- `pomerium_console`, the Enterprise Console
+- `database`, the PostgreSQL database used by the Console
+- `verify`, a test application for confirming routing
 
-## Connect to Pomerium Enterprise Console
+The example binds Pomerium to `127.0.0.1:443`, not all host interfaces. It also sets `SIGNING_KEY` on both Core and Console for this local self-signed trial so the Console can verify identity headers without fetching JWKS over the trial certificate. Leave `SIGNING_KEY` unset in production Console deployments unless Pomerium Support tells you otherwise.
 
-Run `docker compose up`.
+## Start Enterprise
 
-Go to `https://console.localhost.pomerium.io` to access your Console.
+Run:
+
+```shell
+docker compose up
+```
+
+Open `https://console.localhost.pomerium.io` and sign in with the email address you configured.
+
+:::caution
+
+Pomerium derives a self-signed TLS certificate from the shared secret for the trial. Browsers will reject it as untrusted on first visit. In Chrome, click **Advanced** then **Proceed to console.localhost.pomerium.io (unsafe)**; Firefox and Safari have similar overrides. The same warning applies to `verify.localhost.pomerium.io`. For non-trial use, configure Pomerium with a real certificate via [autocert](/docs/reference/autocert) or a TLS secret.
+
+:::
+
+To confirm Core routing, open `https://verify.localhost.pomerium.io`.
+
+The `*.localhost.pomerium.io` hostnames resolve to localhost. If your DNS resolver overrides them, map `console.localhost.pomerium.io` and `verify.localhost.pomerium.io` to `127.0.0.1` locally before opening the URLs.
+
+To confirm the Console metrics endpoint and embedded Prometheus are running, wait for `docker compose ps` to show `pomerium_console` in the `Up` state (the container exits during license validation if `license_key` still holds the placeholder), then:
+
+```shell
+docker compose exec pomerium_console wget -qO- http://127.0.0.1:9092/metrics | head
+docker compose exec pomerium_console wget -qO- http://127.0.0.1:9090/-/healthy
+```
+
+## Clean Up
+
+To remove the local containers, network, and named volumes:
+
+```shell
+docker compose down -v
+```
+
+This deletes the local PostgreSQL and metrics data created by the quickstart. To remove the saved registry login as well, run `docker logout docker.cloudsmith.io`.
 
 ## Next Steps
 
-If you want to try connecting Pomerium with other services, see some of our [Guides](/docs/guides).
-
-**Did you finish this quickstart guide?** We'd love to hear what you think. Get in touch with us on our [Discuss forum](https://discuss.pomerium.com/), message us on [Twitter](https://twitter.com/pomerium_io), [LinkedIn](https://www.linkedin.com/company/pomerium-inc), or check out our [Community](https://discuss.pomerium.com/) page.
+- Review [installation options](/docs/deploy/enterprise/install) before moving beyond a local test.
+- Review [Enterprise configuration](/docs/deploy/enterprise/configure) for production database, TLS, license, Databroker, and bootstrap settings.
+- Configure [Enterprise metrics](/docs/deploy/enterprise/configure-metrics) when you want traffic and external data source visibility.
+- Use [Terraform](/docs/deploy/terraform) when you want routes, policies, and Enterprise resources managed as code.

--- a/content/docs/deploy/upgrading.mdx
+++ b/content/docs/deploy/upgrading.mdx
@@ -404,13 +404,13 @@ No breaking changes in v0.28.
 
 ##### Changed
 
-- `--disable-validation` is now deprecated. Use [`--validation-mode=none`](/docs/deploy/enterprise/configure#validation_mode) to preserve existing behavior, or [`--validation-mode=static`](/docs/deploy/enterprise/configure#validation_mode). We'll remove `--disable-validation` in a future release.
+- `--disable-validation` is now deprecated. Use [`--validation-mode=none`](/docs/deploy/enterprise/configure#validation-mode) to preserve existing behavior, or [`--validation-mode=static`](/docs/deploy/enterprise/configure#validation-mode). We'll remove `--disable-validation` in a future release.
 
 - The Enterprise Console now includes a “Report issue” feedback widget, allowing you to easily report any problems you may encounter.
 - IdP directory sync performance has been improved, especially when using Okta.
 - The policy builder has a new “Exists” condition for use with external data source records.
 - When configuring an external data source, the “Foreign Key” input will now display all valid choices.
-- The `--disable-validation` option has been expanded to include additional validation modes, represented by [`--validation-mode`](/docs/deploy/enterprise/configure#validation_mode).
+- The `--disable-validation` option has been expanded to include additional validation modes, represented by [`--validation-mode`](/docs/deploy/enterprise/configure#validation-mode).
 
 - A few policy builder UI bugs are fixed:
   - The “Claim” criterion now correctly displays claim names containing a “/” character.

--- a/content/examples/enterprise/hosted-auth-config.yaml.md
+++ b/content/examples/enterprise/hosted-auth-config.yaml.md
@@ -9,7 +9,10 @@ routes:
                 is: user@example.com
   - from: https://console.localhost.pomerium.io
     to: http://pomerium_console:8701
-    allowed_users:
-      - user@example.com
+    policy:
+      - allow:
+          or:
+            - email:
+                is: user@example.com
     pass_identity_headers: true
 ```

--- a/content/examples/enterprise/hosted-auth-docker.yaml.md
+++ b/content/examples/enterprise/hosted-auth-docker.yaml.md
@@ -1,11 +1,28 @@
 ```yaml title="docker-compose.yaml"
+# WARNING: the COOKIE_SECRET, SHARED_SECRET, SIGNING_KEY, and DATABASE_ENCRYPTION_KEY
+# values below are example-only. Generate fresh values before any non-trial use:
+#   COOKIE_SECRET / SHARED_SECRET / DATABASE_ENCRYPTION_KEY: openssl rand -base64 32
+#   SIGNING_KEY: a base64-encoded EC private key PEM. Generate with:
+#     openssl ecparam -name prime256v1 -genkey -noout | base64 | tr -d '\n'
+#   See https://www.pomerium.com/docs/reference/signing-key for details.
+#   In this local quickstart, Core and Console must use the same SIGNING_KEY so
+#   Console can verify Pomerium identity headers without fetching JWKS over the
+#   self-signed trial certificate.
 services:
   pomerium:
-    image: pomerium/pomerium:latest
+    image: pomerium/pomerium:v0.32.6
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     ports:
-      - 443:443
+      - 127.0.0.1:443:443
+    # Keep local route hostnames resolvable inside the Compose network. Console
+    # also receives SIGNING_KEY below so the signed-in UI does not depend on
+    # JWKS over the self-signed trial certificate.
+    networks:
+      default:
+        aliases:
+          - console.localhost.pomerium.io
+          - verify.localhost.pomerium.io
     environment:
       - AUTHENTICATE_SERVICE_URL=https://authenticate.pomerium.app
       - COOKIE_SECRET=j9jZgysWVxCs3uqbmw9a2LxWwz1ZPLKQZ8v20eoDT8Y=
@@ -19,7 +36,7 @@ services:
         condition: service_healthy
       pomerium:
         condition: service_started
-    image: docker.cloudsmith.io/pomerium/enterprise/pomerium-console:v0.32.0
+    image: docker.cloudsmith.io/pomerium/enterprise/pomerium-console:v0.32.1
     command:
       - 'serve'
       - '--config'
@@ -33,14 +50,15 @@ services:
       - DATABROKER_SERVICE_URL=http://pomerium:5443
       - SHARED_SECRET=mxGl062SqkrbQKvqG9R2jqHqxq1Oi1BNj2AAeZHNq7c=
       - DATABASE_URL=postgresql://postgres:postgres@database/postgres?sslmode=disable
+      - SIGNING_KEY=LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUc0R0N4bjlxaDBHRVZnV3VCM0VoRm51RlptZ2VkZXJsMEtLd0ZoRWo4Tk9vQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFMXFOWXNUMFpSZEVTS0djSXRqZFUxcGJZREVDTktRd2lNcmNHVFl6RUhLM1V5MnVoT1N3bgpXVGdWUHppTk4vcWozYXFJeSs3Sk55ZEFLVlo3bURPNGtnPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
+      - METRICS_ADDR=:9092
       - PROMETHEUS_LISTEN_ADDR=:9090
       - PROMETHEUS_DATA_DIR=/data
-      - SIGNING_KEY=LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUc0R0N4bjlxaDBHRVZnV3VCM0VoRm51RlptZ2VkZXJsMEtLd0ZoRWo4Tk9vQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFMXFOWXNUMFpSZEVTS0djSXRqZFUxcGJZREVDTktRd2lNcmNHVFl6RUhLM1V5MnVoT1N3bgpXVGdWUHppTk4vcWozYXFJeSs3Sk55ZEFLVlo3bURPNGtnPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
     volumes:
       - metrics:/data:rw
       - ./console-config.yaml:/pomerium/console-config.yaml:ro
   database:
-    image: postgres:latest
+    image: postgres:17
     restart: always
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -d postgres -U postgres']
@@ -57,7 +75,7 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
   verify:
-    image: pomerium/verify:latest
+    image: pomerium/verify:sha-b4ecbab
     expose:
       - 8000
     restart: always

--- a/k8s/config-template/config.yaml
+++ b/k8s/config-template/config.yaml
@@ -3,8 +3,6 @@ kind: ConfigMap
 metadata:
   name: enterprise
 data:
-  # should match authenticate service URL from Pomerium Settings CRD
-  authenticate_service_url: https://authenticate.domain.com/
   # audience should correspond to the name in the ingress you created for the console
   # without the protocol part
   audience: console.domain.com
@@ -14,5 +12,5 @@ data:
   # databroker service URL allows Console to communicate to Pomerium Core
   databroker_service_url: https://pomerium-databroker.pomerium.svc.cluster.local
   # external Prometheus service URL, to enable metrics.
-  # see https://www.pomerium.com#metrics
+  # see https://www.pomerium.com/docs/deploy/enterprise/configure-metrics
   # prometheus_url: ""

--- a/k8s/console/deployment/env.yaml
+++ b/k8s/console/deployment/env.yaml
@@ -25,12 +25,6 @@ spec:
                   name: enterprise
                   key: databroker_service_url
                   optional: false
-            - name: AUTHENTICATE_SERVICE_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: enterprise
-                  key: authenticate_service_url
-                  optional: false
             - name: PROMETHEUS_URL
               valueFrom:
                 configMapKeyRef:
@@ -66,3 +60,5 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+            - name: METRICS_ADDR
+              value: ':9092'

--- a/k8s/console/deployment/image.yaml
+++ b/k8s/console/deployment/image.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: pomerium-console
-          image: docker.cloudsmith.io/pomerium/enterprise/pomerium-console:v0.32.0
+          image: docker.cloudsmith.io/pomerium/enterprise/pomerium-console:v0.32.1
           imagePullPolicy: IfNotPresent
       imagePullSecrets:
         - name: pomerium-enterprise-docker

--- a/k8s/core/kustomization.yaml
+++ b/k8s/core/kustomization.yaml
@@ -2,8 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: pomerium
 resources:
-  - github.com/pomerium/ingress-controller/config/default?ref=v0.32.0
+  - github.com/pomerium/ingress-controller/config/default?ref=v0.32.6
   - service.yaml
+images:
+  - name: pomerium/ingress-controller
+    newTag: v0.32.6
 patches:
   - patch: |-
       - op: add


### PR DESCRIPTION
## Why this exists

The Enterprise deployment docs had drifted from the real install paths. A first-time operator could hit broken package setup commands, mutable image/ref assumptions, a Postgres image that no longer starts, a Console auth/JWT validation failure, K8s metrics that do not scrape, and Terraform examples that do not validate cleanly.

This PR restructures the docs and fixes those failures by walking the install paths with a real Enterprise license and Cloudsmith entitlement.

## What changed

- Split Enterprise docs into overview, Docker quickstart, install, configuration, and metrics.
- Pinned tested artifacts: Core `v0.32.6`, Console `v0.32.1`, Postgres `17`, Verify `sha-b4ecbab`.
- Hardened Docker quickstart: loopback-only bind, explicit Cloudsmith entitlement auth, self-signed cert warning, shared local-trial `SIGNING_KEY`, network aliases so Console reaches Pomerium's JWKS over the in-network DNS, metrics smoke checks, cleanup section.
- Fixed OS package setup for modern Debian/Ubuntu/RHEL-family systems (`/etc/os-release` over `lsb_release`, dropped `pygpgme`, install-then-configure-then-start ordering).
- Pinned Kustomize examples to an immutable docs commit, added `&timeout=180s` for slower networks, documented the working-Core prerequisite, patched `METRICS_ADDR=:9092` inline (so users fetching the remote ref get the metrics fix without waiting for upstream branch updates).
- Pinned Terraform modules to an audited commit, added required variables, audience, ingress authorization annotations, sensitive PEM variables for the wildcard TLS secret, namespace-creation note, IdP wiring caveat.
- Reconciled the config reference against the Console binary (correct `DISABLE_REMOTE_DIAGNOSTICS` default, license-gating note, `CHANGESET_REQUIRED_APPROVAL_COUNT` semantics, three previously-undocumented flags surfaced, phantom `HELP` row removed, mutually-exclusive Prometheus modes, required-marking on `AUDIENCE`/`DATABASE_ENCRYPTION_KEY`/`SHARED_SECRET`).

## Validation

| Surface | Result |
|---|---|
| Static docs | PASS: `yarn format-check`, `yarn cspell "**/*"`, `yarn build` |
| Docker quickstart | PASS: cold compose start, hosted-auth redirect, Console admin UI lands on `/app/configure/namespaces`, Verify route reaches upstream app, Console metrics + embedded Prometheus healthy |
| Config reference | PASS: every row audited against `pomerium-console:v0.32.1 serve --help` |
| Kustomize **render** | PASS: documented `?ref=...&timeout=180s` URL: `AUTHENTICATE_SERVICE_URL=0`, `METRICS_ADDR=1`, Console `v0.32.1` |
| Kustomize **apply (REMOTE ref, end-to-end)** | PASS: `kubectl apply -k` against the documented remote URL; ingress-controller pod 1/1 Ready, Console pod 1/1 Ready, `db.GetConsoleConfig succeeded`, license valid, Pomerium CR `global` reconciled the Console ingress (after pre-creating the cert-manager-style TLS secret), Console `/metrics` returns Prometheus exposition through the Service |
| Terraform syntax/plan | PASS: HCL extracted verbatim from install.mdx, `terraform init && validate && plan`: `Plan: 24 to add, 0 change, 0 destroy` |
| Terraform **apply (verbatim docs HCL)** | PASS: `terraform apply -auto-approve` on extracted-from-install.mdx HCL with only `provider "kubernetes"` env-config added; `Apply complete! Resources: 24 added`; both pods 1/1 Ready, license valid, Pomerium CR reconciled both ingresses |
| OS packages — install | PASS: DEB script + manual on Debian 12 + Ubuntu 24.04, RPM script + manual on Rocky 9 |
| OS packages — configure + start | PASS to documented prereq: cold Debian 12 VM, install + edit `/etc/pomerium-console/config.yaml` with real values + `systemctl restart` -> service reaches license validation + DB migrations cleanly. Then fails at `failed to access databroker` because no Pomerium Core is running on the host (matches the documented "A working Pomerium Core deployment" prereq). |
| External Prometheus guide | PASS: Core + Console scrape targets `up{}=1`; `/-/reload` works with `--web.enable-lifecycle` |

## Honest gaps

- Verify route was confirmed reachable; the Verify app's own attestation-token validation was not claimed as passing.
- Console UI Traffic dashboard with real route traffic was not fully revalidated.
- External Data Sources Metrics tab was not fully revalidated.
- Both K8s paths (Kustomize and Terraform) and the OS package configure-and-start path require a running Pomerium Core; this was provided/exercised in the K8s tests via the `Pomerium` CR, but not on the standalone OS-package VM.
- Terraform apply was validated in OrbStack against an in-cluster Postgres reachable via an `ExternalName` alias from the `pomerium-enterprise` namespace; not validated against a production cluster with cert-manager + DNS provider + managed DB.

## AI assistance

Codex drafted and edited the docs, ran final validation, and updated the PR. Claude Opus and read-only subagents performed adversarial review and runtime validation. Human review is still needed for product/version policy.
