### PR TITLE
docs: remove Direct access grants from Keycloak instructions

### DIFF
--- a/content/docs/integrations/user-identity/keycloak.mdx
+++ b/content/docs/integrations/user-identity/keycloak.mdx
@@ -90,7 +90,7 @@ Sign in with `admin` / `admin`.
 1. Go to **Clients** > **Create client**.
 1. **Client type**: **OpenID Connect**.
 1. **Client ID**: `mynewclient`.
-1. Enable **Standard flow** and **Direct access grants**.
+1. Enable **Standard flow**.
 1. **Save**.
 
 ![Create a client](./img/keycloak/keycloak-create-client.gif)


### PR DESCRIPTION
## Summary

This PR removes the instruction to enable the "Direct access grants" setting from the Keycloak client creation steps.

## Details

Currently, the docs instruct readers to enable the "Direct access grants" setting when creating a Keycloak client. However, the Resource Owner Password Credentials (ROPC) grant — the formal name for Direct access grants — is considered legacy and "**MUST NOT** be used" ([RFC 9700](https://datatracker.ietf.org/doc/html/rfc9700#name-resource-owner-password-cre)).

I confirmed that the Keycloak integration works correctly without enabling Direct access grants.

## Related

None

## AI disclosure

Claude was used to proofread and refine the wording of this PR description.

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated UPGRADING.md
- [ ] updated CHANGELOG.md
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
