### PR TITLE
fix native SSH setup heading comments

### DIFF
--- a/content/docs/capabilities/native-ssh-access.mdx
+++ b/content/docs/capabilities/native-ssh-access.mdx
@@ -125,7 +125,7 @@ This creates three host keys which support different algorithms for compatibilit
 - `pomerium_ssh_host_rsa_key` (default 3072 bits)
 - `pomerium_ssh_host_ecdsa_key` (default 256 bits)
 
-### 3. Configure pomerium<!-- note: reverse-tunneling.mdx refers to these steps by number -->
+### 3. Configure Pomerium<!-- note: reverse-tunneling.mdx refers to these steps by number -->
 
 Add SSH configuration to your `config.yaml`:
 

--- a/content/docs/capabilities/native-ssh-access.mdx
+++ b/content/docs/capabilities/native-ssh-access.mdx
@@ -82,8 +82,7 @@ sequenceDiagram
   - Identity provider with Authorization Code OAuth enabled
 - Network connectivity between Pomerium and SSH servers
 
-{/* note: reverse-tunneling.mdx refers to these steps by number */}
-### 1. Generate User CA Key Pair
+### 1. Generate User CA Key Pair<!-- note: reverse-tunneling.mdx refers to these steps by number -->
 
 Generate a key pair that Pomerium will use to sign SSH certificates:
 
@@ -110,8 +109,7 @@ The User CA key is a standard SSH keypair, not a certificate or certificate-key.
 
 :::
 
-{/* note: reverse-tunneling.mdx refers to these steps by number */}
-### 2. Generate SSH Host Keys
+### 2. Generate SSH Host Keys<!-- note: reverse-tunneling.mdx refers to these steps by number -->
 
 Generate new SSH host keys for your Pomerium instance.
 
@@ -127,8 +125,7 @@ This creates three host keys which support different algorithms for compatibilit
 - `pomerium_ssh_host_rsa_key` (default 3072 bits)
 - `pomerium_ssh_host_ecdsa_key` (default 256 bits)
 
-{/* note: reverse-tunneling.mdx refers to these steps by number */}
-### 3. Configure pomerium
+### 3. Configure pomerium<!-- note: reverse-tunneling.mdx refers to these steps by number -->
 
 Add SSH configuration to your `config.yaml`:
 
@@ -161,8 +158,7 @@ Configure SSH in the Zero Console under **Settings** > **SSH**:
 </TabItem>
 </Tabs>
 
-{/* note: reverse-tunneling.mdx refers to these steps by number */}
-### 4. Add SSH routes
+### 4. Add SSH routes<!-- note: reverse-tunneling.mdx refers to these steps by number -->
 
 Add SSH routes for each upstream server, for example:
 
@@ -183,8 +179,7 @@ routes:
 
 Note the use of the `ssh://` scheme for both `from` and `to`.
 
-{/* note: reverse-tunneling.mdx refers to these steps by number */}
-### 5. Configure Upstream Servers
+### 5. Configure Upstream Servers<!-- note: reverse-tunneling.mdx refers to these steps by number -->
 
 1. Copy the User CA public key (`pomerium_user_ca_key.pub`) to your upstream servers. It can be placed in any (root-owned) location - for example, `/etc/pomerium/` or `/var/lib/pomerium/`. You may also place it in `/etc/ssh/` if desired.
 

--- a/content/docs/capabilities/native-ssh-access.mdx
+++ b/content/docs/capabilities/native-ssh-access.mdx
@@ -82,7 +82,8 @@ sequenceDiagram
   - Identity provider with Authorization Code OAuth enabled
 - Network connectivity between Pomerium and SSH servers
 
-### 1. Generate User CA Key Pair {/* note: reverse-tunneling.mdx refers to these steps by number */}
+{/* note: reverse-tunneling.mdx refers to these steps by number */}
+### 1. Generate User CA Key Pair
 
 Generate a key pair that Pomerium will use to sign SSH certificates:
 
@@ -109,7 +110,8 @@ The User CA key is a standard SSH keypair, not a certificate or certificate-key.
 
 :::
 
-### 2. Generate SSH Host Keys {/* note: reverse-tunneling.mdx refers to these steps by number */}
+{/* note: reverse-tunneling.mdx refers to these steps by number */}
+### 2. Generate SSH Host Keys
 
 Generate new SSH host keys for your Pomerium instance.
 
@@ -125,7 +127,8 @@ This creates three host keys which support different algorithms for compatibilit
 - `pomerium_ssh_host_rsa_key` (default 3072 bits)
 - `pomerium_ssh_host_ecdsa_key` (default 256 bits)
 
-### 3. Configure Pomerium {/* note: reverse-tunneling.mdx refers to these steps by number */}
+{/* note: reverse-tunneling.mdx refers to these steps by number */}
+### 3. Configure pomerium
 
 Add SSH configuration to your `config.yaml`:
 
@@ -158,7 +161,8 @@ Configure SSH in the Zero Console under **Settings** > **SSH**:
 </TabItem>
 </Tabs>
 
-### 4. Add SSH routes {/* note: reverse-tunneling.mdx refers to these steps by number */}
+{/* note: reverse-tunneling.mdx refers to these steps by number */}
+### 4. Add SSH routes
 
 Add SSH routes for each upstream server, for example:
 
@@ -179,7 +183,8 @@ routes:
 
 Note the use of the `ssh://` scheme for both `from` and `to`.
 
-### 5. Configure Upstream Servers {/* note: reverse-tunneling.mdx refers to these steps by number */}
+{/* note: reverse-tunneling.mdx refers to these steps by number */}
+### 5. Configure Upstream Servers
 
 1. Copy the User CA public key (`pomerium_user_ca_key.pub`) to your upstream servers. It can be placed in any (root-owned) location - for example, `/etc/pomerium/` or `/var/lib/pomerium/`. You may also place it in `/etc/ssh/` if desired.
 


### PR DESCRIPTION
## Summary

The comment text was being rendered into the page's table of contents. Switching the comments to use HTML comment syntax appears to fix this.

(I tried moving these to the line right before the heading, but then the `prettier` pre-commit check wanted to insert a blank line in between, which might make it easier to miss the comment.)

## Related

https://linear.app/pomerium/issue/ENG-4054/docs-native-ssh-guide-table-of-contents-has-extraneous-text

## AI disclosure

none

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated UPGRADING.md
- [ ] updated CHANGELOG.md
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
