### PR TITLE
docs: update pomerium-cli apt install instructions

### DIFF
--- a/content/docs/deploy/clients/clients.mdx
+++ b/content/docs/deploy/clients/clients.mdx
@@ -87,6 +87,19 @@ See [GitHub Releases](https://github.com/pomerium/cli/releases) for a full list.
 
 Install from [Cloudsmith](https://cloudsmith.io/~pomerium/repos/pomerium/packages/) or GitHub:
 
+For Debian or Ubuntu, configure the Cloudsmith repository with the setup script and install the package through APT:
+
+```bash
+curl -1sLf \
+  'https://dl.cloudsmith.io/public/pomerium/pomerium/setup.deb.sh' \
+  | sudo -E bash
+
+sudo apt-get update
+sudo apt-get install pomerium-cli
+```
+
+For RPM-based distributions, configure the repository manually:
+
 ```abnf title="/etc/yum.repos.d/pomerium-cli.repo"
 [pomerium-pomerium]
 name=pomerium-pomerium


### PR DESCRIPTION
## Summary
- adds Debian/Ubuntu `pomerium-cli` installation steps that use the Cloudsmith APT setup script
- separates the existing manual repository example as RPM-specific guidance

Fixes #1051.

## Validation
- `yarn install --frozen-lockfile`
- `yarn prettier --check content/docs/deploy/clients/clients.mdx`
- `yarn cspell content/docs/deploy/clients/clients.mdx`
- `git diff --check -- content/docs/deploy/clients/clients.mdx`
- `yarn build`

`yarn build` completed successfully with existing warnings about a MUI X license key, an existing MDX cleanup warning in `content/docs/capabilities/native-ssh-access.mdx`, and existing broken anchors outside this change.

## AI assistance disclosure
This contribution was prepared with assistance from OpenAI GPT-5. I reviewed the repository AI policy, issue context, documentation diff, and validation output before submitting.

