### PR TITLE
document signout redirect runtime flag

### DIFF
--- a/content/docs/reference/runtime-flags.md
+++ b/content/docs/reference/runtime-flags.md
@@ -35,6 +35,7 @@ The available flags are:
 | Runtime Flag | Description | Default |
 | :-- | :-- | :-- |
 | `add_extra_metrics_labels` | Enables adding extra labels to metrics (host and installation id). | `true` |
+| `allow_any_sign_out_redirect_uri` | Allows the `pomerium_redirect_uri` query parameter on the `/.pomerium/sign_out` endpoint to override the sign-out redirect. | `false` |
 | `authorize_use_synced_data` | Enables synced data for querying the databroker for certain types of data. | `true` |
 | `config_hot_reload` | Enables automatic config reloading triggered whenever a configuration file is written to (either the main Pomerium configuration file or a file referenced from the main configuration). In some rare cases this may not work correctly, so this setting provides a way to disable this behavior. (See issue [#5079](https://github.com/pomerium/pomerium/issues/5079) for more context.) | `true` |
 | `debug_admin_endpoints` | Enables the admin endpoints for the debug listener. | `false` |

--- a/content/docs/reference/signout-redirect-url.mdx
+++ b/content/docs/reference/signout-redirect-url.mdx
@@ -18,7 +18,11 @@ import Tabs from '@theme/Tabs';
 
 **Signout Redirect URL** is the URL the user will be redirected to after signing out.
 
-You can overwrite this behavior by passing the query param `pomerium_redirect_uri` or post value `pomerium_redirect_uri` to the `/.pomerium/sign_out/` endpoint.
+:::note
+
+When the `allow_any_sign_out_redirect_uri` [runtime flag](/docs/reference/runtime-flags) is enabled, the redirect URL can be overridden by setting the `pomerium_redirect_uri` query parameter or POST form value on the `/.pomerium/sign_out` endpoint.
+
+:::
 
 ## How to configure
 


### PR DESCRIPTION
## Summary

Document the new `allow_any_sign_out_redirect_uri` runtime flag.

## Related

- docs update for https://github.com/pomerium/pomerium/pull/6358

## AI disclosure

none

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated UPGRADING.md
- [ ] updated CHANGELOG.md
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
