### PR TITLE
docs: add immutable cache headers for hashed assets

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -1,2 +1,5 @@
 /*
   X-Robots-Tag: noindex
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
## Summary

- Add `Cache-Control: public, max-age=31536000, immutable` for `/assets/*` in Netlify `_headers` so GCP Cloud CDN (`USE_ORIGIN_HEADERS` mode) actually caches fingerprinted Docusaurus build output (CSS, JS, images).
- Currently Netlify returns `Cache-Control: public, max-age=0, must-revalidate` for all responses, which means the CDN never caches anything and every request passes through to the origin.

Part of [OPE-293](https://linear.app/pomerium/issue/OPE-293).

## Test plan

- [ ] `yarn build` succeeds and `_headers` is present in build output
- [ ] Deploy preview: fingerprinted assets return `Cache-Control: public, max-age=31536000, immutable`
- [ ] Deploy preview: non-asset paths (`/docs/`) still return `max-age=0, must-revalidate`
- [ ] After merge: `Age` header increments on repeated requests through GCP CDN

## AI assistance

Claude Opus 4 drafted the change and PR body; triple-reviewed by domain expert, codex slop detector, and code review agents — no issues found.