### PR TITLE
document client cert SAN tokens

### DIFF
--- a/content/docs/reference/routes/headers.mdx
+++ b/content/docs/reference/routes/headers.mdx
@@ -225,6 +225,8 @@ The following token substitutions are available:
 | :-- | :-- |
 | `${pomerium.access_token}` | OAuth access token from the identity provider\* |
 | `${pomerium.client_cert_fingerprint}` | Short form SHA-256 fingerprint of the presented client certificate (if [downstream mTLS](/docs/internals/certificates-and-tls) is enabled) |
+| `${pomerium.client_cert_san_dns}` | Comma-separated list of any DNS Subject Alternative Names (SANs) from the presented client certificate |
+| `${pomerium.client_cert_san_email}` | Comma-separated list of any email address Subject Alternative Names (SANs) from the presented client certificate |
 | `${pomerium.id_token}` | OIDC ID token from the identity provider\* |
 | `${pomerium.jwt}` | [Pomerium JWT](/docs/capabilities/getting-users-identity) (this is the same value as in the [`X-Pomerium-Jwt-Assertion` header](/docs/reference/routes/pass-identity-headers-per-route)) |
 


### PR DESCRIPTION
## Summary

Add the new client cert SAN substitution tokens to the list under the Set Request Headers option.

## Related

- Docs for PR https://github.com/pomerium/pomerium/pull/6342

## AI disclosure

none

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated UPGRADING.md
- [ ] updated CHANGELOG.md
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
