### PR TITLE
docs(tcp): document forward-proxy behavior for pomerium-cli tcp

### DIFF
--- a/content/docs/capabilities/non-http/tcp.mdx
+++ b/content/docs/capabilities/non-http/tcp.mdx
@@ -150,6 +150,26 @@ routes:
     to: http://second-proxy.example.corp.com:10003
 ```
 
+### Connecting through an HTTP forward proxy {#forward-proxy}
+
+In some networks the client running `pomerium-cli` has no direct outbound internet access, and all external HTTPS must traverse an HTTP/HTTPS forward proxy (for example, Squid). A common question is whether `pomerium-cli tcp` can be pointed at such a proxy with the standard `HTTP_PROXY` / `HTTPS_PROXY` environment variables.
+
+As of Pomerium v0.32, the answer is no: **the TCP tunnel does not traverse a forward proxy.** The behavior splits across the two kinds of connection the client makes:
+
+| Connection the CLI makes | Honors `HTTP_PROXY` / `HTTPS_PROXY`? |
+| --- | --- |
+| Authentication / token requests (the OIDC login flow) | Yes |
+| The TCP tunnel itself (the initial connection check and the `CONNECT`) | No — dialed directly |
+
+Because the tunnel connection is dialed directly to the Pomerium endpoint, in a network that allows no direct outbound HTTPS the tunnel fails to connect. The authentication step _would_ honor the proxy, but the tunnel's direct dial fails first: in a proxy-only network the CLI's initial connection check fails before authentication is ever attempted. This is distinct from the [Bastion host](#bastion-host) feature above: a bastion is Pomerium itself reachable at an alternate address, not an arbitrary forward proxy, so pointing `pomerium-cli` at a Squid instance as if it were a bastion does not work.
+
+There are also no `pomerium-cli` flags or configuration files for forward-proxy settings; the standard environment variables are the only proxy mechanism, and they apply only to the authentication requests as shown above.
+
+To use `pomerium-cli tcp` from such a network, use one of the following:
+
+- **Allow a narrow direct-egress exception** on the proxy or firewall for just the Pomerium endpoint (the [`address`](/docs/reference/address) host on port `443`). The tunnel then connects directly to Pomerium while the rest of the network stays proxy-only.
+- **Run `pomerium-cli` on a jump host** that has direct egress to the Pomerium endpoint, and reach its local listener from the client (for example, an SSH `-L` local forward to the jump host).
+
 :::info TCP examples
 
 The guides below demonstrate how to proxy TCP tunnels with Pomerium to well-known services:


### PR DESCRIPTION
## Summary

Adds a **Connecting through an HTTP forward proxy** section to the TCP capabilities page (`/docs/capabilities/non-http/tcp#forward-proxy`).

It documents that `pomerium-cli tcp` does **not** route the tunnel through an HTTP/HTTPS forward proxy (e.g. Squid): only the authentication/token requests honor `HTTP_PROXY`/`HTTPS_PROXY`, while the tunnel's initial connection check and the `CONNECT` are dialed directly. It distinguishes this from the existing Bastion host feature (Pomerium-as-bastion, not an arbitrary proxy) and gives two workarounds: a narrow direct-egress allowlist for the Pomerium endpoint, or a jump host with direct egress reached over SSH `-L`.

## Why

Recurring question from PoC/enterprise customers whose client networks have no direct outbound HTTPS and must egress through a forward proxy. The behavior was undocumented, leading to confusion (e.g. attempts to use Squid as a bastion). Complements the existing "Two ports, one transport" / L4-edge guidance for egress-restricted environments. Relates to ENG-4040.

## Verification

Behavior verified end-to-end in a Squid + Pomerium docker-compose lab (Pomerium server v0.32.0; `pomerium-cli` built from v0.32.1-rc.1 source). With the client restricted to proxy-only egress and `HTTPS_PROXY` set, the tunnel's probe and `CONNECT` dial the Pomerium endpoint directly and the proxy logs nothing for the tunnel; a control request through the same proxy is logged. Both documented workarounds were exercised and returned the upstream payload. `yarn format-check`, `yarn cspell`, and `yarn build` pass.

## AI assistance

Drafted with Claude Code (Opus). Claude built the docker-compose proof lab, ran the tests, and wrote this docs section. The behavior and the proofs were then independently re-run and verified by a human (clean `docker compose up`, all checks green), and the wording was corrected for precision (the auth-helper fetch is what honors the proxy; the 302 comes from the direct tunnel attempt).