### PR TITLE
docs: sealed E2E validation harness for guides + Grafana pilot

### DIFF
--- a/.github/workflows/validate-examples.yml
+++ b/.github/workflows/validate-examples.yml
@@ -1,0 +1,90 @@
+name: validate-examples
+
+# Spins up each guide's sealed Docker Compose fixture and proves the full flow,
+# including a real SSO login against the in-network Keycloak. Per-PR runs are gated
+# to the guides that changed; a change to the shared harness (or the nightly
+# schedule) runs every fixture. The harness self-test always runs.
+
+on:
+  pull_request:
+    paths:
+      - 'content/examples/guides/**'
+      - 'scripts/validate-guide-fixtures.sh'
+      - '.github/workflows/validate-examples.yml'
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: validate-examples-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.find.outputs.targets }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - id: find
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          base_dir=content/examples/guides
+          id_re='^[a-z0-9][a-z0-9-]*$'
+
+          # Guides that have opted into validation (well-formed ids only).
+          all=$(find "$base_dir" -mindepth 3 -maxdepth 3 -path '*/validate/compose.validate.yaml' -printf '%h\n' \
+                | sed -E "s#^$base_dir/([^/]+)/validate\$#\1#" | grep -E "$id_re" | sort -u || true)
+
+          full=false
+          changed=""
+          if [ "$EVENT" != "pull_request" ]; then
+            full=true
+          # Fail closed: if we can't compute the changed set (fork PRs, fetch edge
+          # cases), validate everything rather than silently validating nothing.
+          elif [ -z "$BASE" ] || ! changed=$(git diff --name-only "$BASE"...HEAD); then
+            full=true
+          # Shared harness / script / workflow change -> validate everything.
+          elif echo "$changed" | grep -qE "^$base_dir/_harness/|^scripts/validate-guide-fixtures\.sh\$|^\.github/workflows/validate-examples\.yml\$"; then
+            full=true
+          fi
+
+          selected=""
+          for g in $all; do
+            if [ "$full" = true ] || echo "${changed:-}" | grep -q "^$base_dir/$g/"; then
+              selected="$selected $g"
+            fi
+          done
+
+          # Report opt-outs (guides that ship a validate/SKIP marker) for auditability.
+          find "$base_dir" -mindepth 3 -maxdepth 3 -path '*/validate/SKIP' -printf '%h\n' \
+            | sed -E "s#^$base_dir/([^/]+)/validate\$#\1#" | sort -u \
+            | while read -r s; do echo "skipped (validate/SKIP): $s - $(head -1 "$base_dir/$s/validate/SKIP" 2>/dev/null || true)"; done
+
+          # The harness self-test always runs; JSON built with jq so ids can't corrupt it.
+          targets=$(printf '%s\n' '--selftest' $selected | grep -v '^$' | jq -R . | jq -s -c .)
+          echo "targets=$targets" >> "$GITHUB_OUTPUT"
+          echo "Selected targets: $targets"
+
+  validate:
+    needs: discover
+    if: needs.discover.outputs.targets != '[]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJson(needs.discover.outputs.targets) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # Docker + Compose are preinstalled on ubuntu-latest; the Node/Playwright
+      # toolchain runs inside the test-runner container, so nothing else is needed.
+      - run: scripts/validate-guide-fixtures.sh "${{ matrix.target }}"

--- a/content/docs/guides/grafana.mdx
+++ b/content/docs/guides/grafana.mdx
@@ -1,29 +1,32 @@
 ---
-# cSpell:ignore abnf
-
-title: Securing Grafana with Pomerium
+title: Secure Grafana with Pomerium
 sidebar_label: Grafana
 lang: en-US
 keywords:
   [
     pomerium,
     identity access proxy,
-    data,
-    logging,
-    graphing,
     grafana,
+    sso,
+    oidc,
+    jwt,
     authentication,
     authorization,
   ]
-description: This guide covers how to use Pomerium to authenticate and authorize users of Grafana.
+description: Add single sign-on and per-route authorization to Grafana with Pomerium, forwarding a signed identity JWT so Grafana signs users in automatically.
 ---
 
 import TabItem from '@theme/TabItem';
 import Tabs from '@theme/Tabs';
 
-# Secure Grafana with Pomerium Zero
+import Config from '/content/examples/guides/grafana/config.yaml.md';
+import Compose from '/content/examples/guides/grafana/docker-compose.yaml.md';
 
-In this guide, you'll configure Pomerium Zero to provide single sign-on (SSO) access to Grafana with JWT authentication.
+# Secure Grafana with Pomerium
+
+## What this guide does
+
+You'll put Grafana behind Pomerium so that Pomerium handles single sign-on and authorization, then forwards a cryptographically signed identity JWT to Grafana. Grafana verifies that JWT and signs the user in automatically, so there's no second login and no separate Grafana user directory to manage.
 
 <iframe
   width="100%"
@@ -34,102 +37,99 @@ In this guide, you'll configure Pomerium Zero to provide single sign-on (SSO) ac
   mozallowfullscreen="true"
   allowfullscreen="true"></iframe>
 
-### Before you start
+## When to use this guide
 
-This guide uses Docker to run Pomerium Zero and Grafana services in containers.
+Use it when you want one front door for Grafana with your existing identity, and you want Grafana to trust Pomerium for authentication instead of running its own login. If you only need to reach Grafana over a private network without browser SSO, a plain [TCP route](/docs/capabilities/non-http) is a better fit.
 
-To complete this guide, you need:
+## Prerequisites
 
-- A [Pomerium Zero](https://console.pomerium.app/create-account) account
+This guide assumes you've completed the [Quickstart](/docs/get-started/quickstart), so you already have Pomerium running and signing users in through the hosted authenticate service.
+
+You also need:
+
 - [Docker](https://docs.docker.com/install/) and [Docker Compose](https://docs.docker.com/compose/install/)
+- A domain you control for the Grafana route (this guide uses `grafana.yourdomain.com`)
 
-## Configure Pomerium Zero
+:::tip Prefer to self-host the identity provider?
 
-### Create a Grafana route
+This guide uses the hosted authenticate service so you don't have to run an IdP. To run your own instead, follow [Keycloak + Pomerium](/docs/integrations/user-identity/oidc) and swap the `authenticate_service_url` / `idp_*` settings into the config below.
 
-First, build a route that points to the Grafana service.
+:::
 
-In the Zero Console:
+## Configure Pomerium
 
-1. Create a **Route** and name it
-2. In **From**, select `https://` and enter the external URL
-3. In **To**, enter the internal URL
-4. In the **Policies** field, select `Any Authenticated User` ![Creating a Grafana route in the Zero Console](./img/grafana/grafana-create-route.gif)
+<Tabs queryString="type">
+<TabItem value="zero" label="Pomerium Zero" default>
 
-Instruct Pomerium to forward the user's JWT as a cryptographically signed HTTP header with the [Pass Identity Headers](/docs/reference/routes/pass-identity-headers-per-route) setting.
+In the [Zero Console](https://console.pomerium.app):
 
-1. Select the **Headers** tab
-1. Apply **Pass Identity Headers**
-1. Save the route changes
+1. Create a **Route**. In **From**, enter `https://grafana.<your-starter-domain>`; in **To**, enter `http://grafana:3000`.
+2. Set the policy to **Any Authenticated User**.
+
+   ![Creating a Grafana route in the Zero Console](./img/grafana/grafana-create-route.gif)
+
+3. On the **Headers** tab, enable **Pass Identity Headers** and save.
 
    ![Configuring the headers settings for the Grafana route in the Zero Console](./img/grafana/pass-identity-headers.png)
 
-:::note
+Zero manages the route's TLS certificate and the signing key behind its starter domain, so Grafana's JWKS URL is your authenticate service: `https://authenticate.<your-starter-domain>/.well-known/pomerium/jwks.json`. Use that value for `GF_AUTH_JWT_JWK_SET_URL` in the next section.
 
-See the [**Sign in to Grafana**](https://grafana.com/docs/grafana/latest/setup-grafana/sign-in-to-grafana/) docs for steps on accessing Grafana with initial admin settings. You may want to sign in as the admin user to Grafana before configuring Pomerium to forward the JWT. This way, you can add yourself as a user and assign yourself `Admin` privileges.
+</TabItem>
+<TabItem value="core" label="Pomerium Core">
 
-:::
+Create a `config.yaml`. It routes `grafana.yourdomain.com` to the Grafana container, passes identity headers, and sets a `signing_key` so Pomerium publishes a JWKS that Grafana can verify the forwarded assertion against.
+
+<Config />
+
+Replace `grafana.yourdomain.com` with your domain, `you@example.com` with your email, and generate your own `signing_key` with the command in the comment. With Core, Grafana's JWKS URL is the route's own well-known endpoint (`https://grafana.yourdomain.com/.well-known/pomerium/jwks.json`), which is what the Compose file below uses.
+
+</TabItem>
+</Tabs>
 
 ## Configure Grafana
 
-Add the Grafana configuration below to the Docker Compose file running Pomerium Zero. The Grafana environment variables configure Grafana to accept JWTs from the incoming request and what claims to look for.
+Grafana's [JWT authentication](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/jwt/) reads the assertion Pomerium forwards and signs the user in. The key settings:
 
-```yaml title="docker-compose.yaml" {14,22,27} showLineNumbers
-pomerium:
-  image: pomerium/pomerium:v0.25.1
-  ports:
-    - 443:443
-  restart: always
-  environment:
-    POMERIUM_ZERO_TOKEN: <CLUSTER_TOKEN>
-    XDG_CACHE_HOME: /var/cache
-  volumes:
-    - pomerium-cache:/var/cache
-  networks:
-    main:
-      aliases:
-        - authenticate.<CLUSTER_STARTER_SUBDOMAIN>.pomerium.app
-grafana:
-  image: grafana/grafana:latest
-  ports:
-    - 3000:3000
-  networks:
-    main: {}
-  environment:
-    - GF_AUTH_SIGNOUT_REDIRECT_URL=https://grafana.<CLUSTER_STARTER_SUBDOMAIN>.pomerium.app/.pomerium/sign_out
-    - GF_AUTH_JWT_ENABLED=true
-    - GF_AUTH_JWT_HEADER_NAME=X-Pomerium-Jwt-Assertion
-    - GF_AUTH_JWT_EMAIL_CLAIM=sub
-    - GF_AUTH_JWT_USERNAME_CLAIM=sub
-    - GF_AUTH_JWT_JWK_SET_URL=https://authenticate.<CLUSTER_STARTER_SUBDOMAIN>.pomerium.app/.well-known/pomerium/jwks.json
-    - GF_AUTH_JWT_CACHE_TTL=60m
-    - GF_AUTH_JWT_AUTO_SIGN_UP=true
-  volumes:
-    - ./grafana-storage:/var/lib/grafana
-```
+- `GF_AUTH_JWT_HEADER_NAME=X-Pomerium-Jwt-Assertion` — the header Pomerium sends the signed identity JWT in.
+- `GF_AUTH_JWT_JWK_SET_URL` — where Grafana fetches Pomerium's public keys to verify the JWT (see the URL for your path above).
+- `GF_AUTH_JWT_EMAIL_CLAIM` / `GF_AUTH_JWT_USERNAME_CLAIM=email` — which claim becomes the Grafana account.
+- `GF_AUTH_JWT_AUTO_SIGN_UP=true` — create the Grafana user on first sign-in.
 
-In lines `14`, `22`, and `27`, replace `CLUSTER_STARTER_SUBDOMAIN` with your own.
+## Run the stack
 
-For example, if your starter domain is `curious-cat-9999.pomerium.app`, you would replace `CLUSTER_STARTER_DOMAIN` in lines `14`, `22`, and `27` with `curious-cat-9999`.
+The Compose file runs Pomerium Core and Grafana together (for Zero, drop the `pomerium` service and use the `compose.yaml` from the Quickstart with your `POMERIUM_ZERO_TOKEN`, keeping the `grafana` service below):
 
-:::info Use Custom Domain
+<Compose />
 
-You can add your own custom domain to replace the generated starter domain assigned to your cluster. See the [**Custom Domains**](/docs/capabilities/custom-domains) page for specific instructions.
-
-:::
-
-Now, apply your changeset. Then, run the following command to start Docker:
+Start it:
 
 ```bash
-docker compose up
+docker compose up -d
 ```
 
-## Access Grafana with JWT Authentication
+## Verify the setup
 
-In your browser, access the external route you built that points to Grafana.
+1. **The route requires authentication.** In a fresh browser, open `https://grafana.yourdomain.com`. You should be redirected to sign in, not straight into Grafana.
+2. **An allowed user gets in.** Sign in. Pomerium redirects you back to Grafana.
+3. **JWT SSO works.** Grafana signs you in automatically. Open `/profile` and confirm your name, email, and username show **Synced via JWT**.
 
-Grafana will automatically sign you in with your JWT. You can verify the JWT worked by going to the `/profile` page and looking at your profile preferences:
+   ![Name, Email, and Username fields that say Synced via JWT in the user's profile page in Grafana](./img/grafana/pz-grafana-user-preferences.png)
 
-![Name, Email, and Username fields that say Synced via JWT in the user's profile page in Grafana](./img/grafana/pz-grafana-user-preferences.png)
+This guide ships a sealed end-to-end test (`content/examples/guides/grafana/validate/`) that runs exactly these checks against an in-network identity provider on every change.
 
-Success!
+## Common failure modes
+
+- **Grafana shows its own login form instead of signing you in.** The JWT didn't verify. Check `GF_AUTH_JWT_JWK_SET_URL` is reachable from the Grafana container and that Pomerium has a `signing_key` (Core) so the JWKS isn't empty.
+- **`failed to verify JWT: no keys found` in Grafana logs.** Same cause: no published signing key. Generate and set `signing_key` in `config.yaml`.
+- **Redirect loop or certificate errors.** Make sure DNS for `grafana.yourdomain.com` points at Pomerium and that `autocert` could reach Let's Encrypt on ports 80/443.
+
+## Security considerations
+
+- Grafana trusts any request carrying a JWT it can verify, so **don't expose Grafana directly** — only Pomerium should reach `grafana:3000`. Keep it off published ports and on the internal Docker network.
+- `GF_AUTH_JWT_AUTO_SIGN_UP=true` grants a Grafana account to every user your Pomerium policy allows. Scope the route policy (group or domain) to who should have access, and manage Grafana org roles separately.
+
+## Next steps
+
+- [Build policies](/docs/get-started/fundamentals/zero/zero-build-policies)
+- [Pass identity headers](/docs/reference/routes/pass-identity-headers-per-route)
+- [Custom domains](/docs/capabilities/custom-domains)

--- a/content/docs/guides/mcp-bridge.mdx
+++ b/content/docs/guides/mcp-bridge.mdx
@@ -72,7 +72,7 @@ Before you start, confirm all of the following:
 
 :::warning Not for regulated production workloads
 
-Do not rely on this guide for regulated production workloads without additional review. See [MCP Full Reference](/docs/capabilities/mcp/reference#experimental-feature) for current status.
+Do not rely on this guide for regulated production workloads without additional review. See the [MCP Full Reference](/docs/capabilities/mcp/reference) for current status.
 
 :::
 
@@ -290,6 +290,12 @@ You should see a log entry like:
 The reasons in `allow-why-true` come from the PPL evaluator. For this guide's policy that's `domain-ok` (domain matched) and, for tool calls, `mcp-tool-ok` (the tool wasn't blocked by a `deny` rule). The `mcp-tool-parameters` object echoes the arguments the MCP client passed to the tool, which is useful for audit but may contain data you'd rather not retain; redact or drop that field in your log pipeline if that's a concern.
 
 For a blocked call (try `issue_delete`), the same entry should show `"allow-why-false": ["mcp-tool-unauthorized"]` and Pomerium should return `403` to the client.
+
+:::note Validation
+
+This flow depends on a managed Pomerium Zero control plane, Linear's hosted MCP server, and interactive OAuth consent from a real MCP client, so it can't be scripted into an automated test. Verify it by running the four checkpoints above end to end against your own cluster, including the `issue_delete` -> `403` deny check in Checkpoint 4. We last verified this guide manually on 2026-06-05 against a live Zero cluster and Linear's hosted MCP server.
+
+:::
 
 ## Common failure modes
 

--- a/content/examples/guides/_harness/README.md
+++ b/content/examples/guides/_harness/README.md
@@ -1,0 +1,68 @@
+# Guide validation harness
+
+Shared scaffolding that proves a guide's **entire** flow — including a real SSO
+login — inside a sealed Docker Compose environment. CI runs it on every change to a
+guide's example; you can run it locally too.
+
+This directory is internal tooling. It is never imported into a published guide and
+is excluded from spell-check and formatting (it lives under `content/examples/`).
+
+## Why this exists
+
+Published guides recommend **Pomerium Zero** / the **hosted authenticate service**,
+which need real cloud calls, public DNS, and an interactive browser login and so
+cannot be sealed. To validate deterministically, the harness swaps that one piece
+for an **in-network Keycloak** — the same self-hosted IdP the guides link as the
+[Keycloak fallback](/docs/integrations/user-identity/keycloak) — and drives the
+login with a headless browser. Everything else (routing, TLS, policy, identity
+headers, the upstream app) is exactly what the guide ships.
+
+## What's here
+
+- `gen-certs.sh` — writes a CA + wildcard `*.localhost.pomerium.io` leaf into the
+  shared `certs` volume. One cert covers every route host.
+- `keycloak/` — realm export (`pomerium-e2e`) + users, imported at startup. Seeded
+  user: `alice@company.com` / `password123` (groups `admins`, `engineering`).
+- `pomerium/config.base.yaml` — template for a guide's validation-only Pomerium
+  config (self-hosted authenticate + Keycloak + test secrets).
+- `compose/compose.harness.yaml` — the reusable services: `certs-init`, `keycloak`,
+  and the `test-runner` (headless browser). A guide `include:`s this.
+- `browser/` — the Playwright runner image. `lib/authn.ts` drives the login;
+  `tests/access.spec.ts` is the default check for any HTTP upstream (route requires
+  auth; allowed user reaches the app). Guides whose upstream consumes identity
+  (JWT/headers) add their own `assert.spec.ts` and reuse `../lib/authn`.
+- `selftest/` — proves the harness itself against `pomerium/verify`.
+
+## Run it
+
+```bash
+# Prove the harness:
+scripts/validate-guide-fixtures.sh --selftest
+
+# Validate one guide:
+scripts/validate-guide-fixtures.sh grafana
+```
+
+The runner exits non-zero on any failure; the script dumps container logs on
+failure and always tears the stack down (`down -v`).
+
+## Add validation to a guide
+
+In `content/examples/guides/<id>/validate/`:
+
+1. `compose.validate.yaml` — `include:` `../../_harness/compose/compose.harness.yaml`,
+   then define the guide's `pomerium` (mounting `pomerium.validate.yaml` + the
+   `certs` volume, with `authenticate.localhost.pomerium.io` and
+   `<id>.localhost.pomerium.io` network aliases) and the upstream service. Point
+   `test-runner` at the route with `depends_on` and, for an app-specific check,
+   mount a spec and set `PW_TEST_DIR`.
+2. `pomerium.validate.yaml` — copy `_harness/pomerium/config.base.yaml`, append the
+   guide's route.
+3. (optional) `url.txt` — the route URL if it isn't `https://<id>.localhost.pomerium.io`.
+4. (optional) `assert.spec.ts` — app-specific success check; reuse `../lib/authn`.
+
+Guides that can't be sealed (cloud, Kubernetes, hardware) simply omit `validate/`;
+add `validate/SKIP` with a one-line reason so the discovery step can report it.
+
+Everything here is **test-only**. The Keycloak admin is open and the Pomerium
+secrets are static and public. Never reuse them anywhere real.

--- a/content/examples/guides/_harness/browser/Dockerfile
+++ b/content/examples/guides/_harness/browser/Dockerfile
@@ -1,0 +1,9 @@
+# Headless-browser test runner for the guide-validation harness.
+# The Playwright base image ships the matching browser binaries, so the only
+# dependency to install is @playwright/test itself (pinned in package.json).
+FROM mcr.microsoft.com/playwright:v1.49.0-noble
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --no-audit --no-fund
+COPY . .
+CMD ["npx", "playwright", "test"]

--- a/content/examples/guides/_harness/browser/lib/authn.ts
+++ b/content/examples/guides/_harness/browser/lib/authn.ts
@@ -1,0 +1,44 @@
+import { Page } from "@playwright/test";
+
+// The in-network Keycloak hostname. Login is "complete" once the browser leaves it.
+export const KEYCLOAK_HOST = "keycloak.localhost.pomerium.io";
+
+export interface TestUser {
+  email: string;
+  password: string;
+  groups: string[];
+  department: string;
+}
+
+// Seeded in _harness/keycloak/pomerium-e2e-users-0.json (passwords are uniform).
+export const alice: TestUser = {
+  email: "alice@company.com",
+  password: "password123",
+  groups: ["admins", "engineering"],
+  department: "engineering",
+};
+export const bob: TestUser = {
+  email: "bob@example.com",
+  password: "password123",
+  groups: ["contractors"],
+  department: "sales",
+};
+
+// Drive the full interactive SSO login: hit a protected URL, get bounced through
+// Pomerium to Keycloak, submit credentials, and wait for the redirect back.
+// Host-agnostic so every guide reuses it regardless of its route host.
+export async function login(
+  page: Page,
+  targetUrl: string,
+  user: TestUser = alice,
+): Promise<void> {
+  await page.goto(targetUrl, { waitUntil: "domcontentloaded", timeout: 30000 });
+  await page.waitForURL((url) => url.hostname === KEYCLOAK_HOST, { timeout: 30000 });
+
+  await page.getByLabel(/username/i).fill(user.email);
+  // Exact match avoids hitting the "Show password" toggle.
+  await page.getByLabel("Password", { exact: true }).fill(user.password);
+  await page.getByRole("button", { name: /sign in/i }).click();
+
+  await page.waitForURL((url) => url.hostname !== KEYCLOAK_HOST, { timeout: 30000 });
+}

--- a/content/examples/guides/_harness/browser/package.json
+++ b/content/examples/guides/_harness/browser/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "pomerium-guides-harness-runner",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Headless-browser runner that proves a guide's full SSO flow against the in-network Keycloak.",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.49.0"
+  }
+}

--- a/content/examples/guides/_harness/browser/playwright.config.ts
+++ b/content/examples/guides/_harness/browser/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Runs inside the harness network. POMERIUM_URL is the route under test;
+// PW_TEST_DIR lets a guide point at its own assertion spec instead of the
+// default identity check. ignoreHTTPSErrors covers the harness's self-signed CA,
+// so the browser never needs the CA installed.
+export default defineConfig({
+  testDir: process.env.PW_TEST_DIR || "./tests",
+  reporter: [["list"]],
+  use: {
+    ignoreHTTPSErrors: true,
+    trace: "retain-on-failure",
+    actionTimeout: 15000,
+    navigationTimeout: 30000,
+  },
+  timeout: 60000,
+  expect: { timeout: 15000 },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+});

--- a/content/examples/guides/_harness/browser/tests/access.spec.ts
+++ b/content/examples/guides/_harness/browser/tests/access.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "@playwright/test";
+import { login, alice } from "../lib/authn";
+
+// Universal access checks for any HTTP upstream behind Pomerium: the route must
+// require authentication, and an allowed user must reach the app after login.
+// Guides whose upstream consumes identity (JWT/headers) add their own assertion.
+const BASE = process.env.POMERIUM_URL as string;
+
+test("unauthenticated request is redirected to the identity provider", async ({ page }) => {
+  await page.goto(BASE, { waitUntil: "domcontentloaded" });
+  await expect(page).toHaveURL(/keycloak\.localhost\.pomerium\.io/);
+});
+
+test("authenticated user reaches the upstream", async ({ page }) => {
+  await login(page, BASE, alice);
+
+  const res = await page.request.get(BASE, { ignoreHTTPSErrors: true });
+  expect(res.status(), "upstream should respond OK after login").toBeLessThan(400);
+});

--- a/content/examples/guides/_harness/compose/compose.harness.yaml
+++ b/content/examples/guides/_harness/compose/compose.harness.yaml
@@ -1,0 +1,67 @@
+# Shared validation harness: the in-network IdP + cert bootstrap + browser runner
+# that every guide fixture reuses. A per-guide validate/compose.validate.yaml pulls
+# this in with `include:` and adds its own `pomerium` + upstream services.
+#
+# Paths here are relative to THIS file (content/examples/guides/_harness/compose/),
+# which is how Compose resolves paths inside an included file.
+#
+# Test-only. Never use these secrets, certs, or the open Keycloak admin anywhere real.
+
+services:
+  # One-shot: writes the CA + wildcard leaf into the shared `certs` volume, then exits.
+  certs-init:
+    image: alpine:3.21
+    volumes:
+      - certs:/certs
+      - ../gen-certs.sh:/gen-certs.sh:ro
+    command: ['/bin/sh', '/gen-certs.sh']
+
+  # In-network OIDC identity provider, seeded entirely from realm JSON (no clicks).
+  # Realm `pomerium-e2e`, client `pomerium`/`pomerium-e2e-secret`,
+  # user alice@company.com / password123 (groups: admins, engineering).
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.5.2
+    command:
+      - start-dev
+      - --import-realm
+      - --health-enabled=true
+      - --http-port=8080
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      KC_HTTP_ENABLED: 'true'
+      KC_HOSTNAME: keycloak.localhost.pomerium.io
+      KC_HOSTNAME_STRICT: 'false'
+      KC_PROXY_HEADERS: xforwarded
+    volumes:
+      - ../keycloak/:/opt/keycloak/data/import/:ro
+    networks:
+      default:
+        aliases:
+          - keycloak.localhost.pomerium.io
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          "exec 3<>/dev/tcp/127.0.0.1/9000; echo -e 'GET /health/ready HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3; cat <&3 | grep -q '\"status\": \"UP\"'",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+
+  # Headless-browser test runner. Started on demand (profile `test`), not by `up`,
+  # so the stack can come up healthy first. The per-guide POMERIUM_URL selects the
+  # route under test; PW_TEST_DIR lets a guide point at its own assertion spec.
+  test-runner:
+    profiles: ['test']
+    build:
+      context: ../browser
+    environment:
+      POMERIUM_URL: ${POMERIUM_URL:?set POMERIUM_URL to the route under test}
+      PW_TEST_DIR: ${PW_TEST_DIR:-./tests}
+    volumes:
+      - certs:/certs:ro
+
+volumes:
+  certs:

--- a/content/examples/guides/_harness/gen-certs.sh
+++ b/content/examples/guides/_harness/gen-certs.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+# Generate a local CA and a wildcard *.localhost.pomerium.io leaf certificate
+# for the sealed guide-validation harness. Test-only, never used in production.
+#
+# A single wildcard cert covers every route host the guides use
+# (authenticate.localhost.pomerium.io, verify.localhost.pomerium.io,
+# grafana.localhost.pomerium.io, ...), so individual guides never touch this.
+
+set -e
+
+CERTS_DIR="${CERTS_DIR:-/certs}"
+DOMAIN="localhost.pomerium.io"
+DAYS_VALID=365
+
+# Skip if a still-valid cert already exists (idempotent across runs).
+if [ -f "$CERTS_DIR/pomerium.crt" ] && [ -f "$CERTS_DIR/pomerium.key" ]; then
+    if openssl x509 -checkend 86400 -noout -in "$CERTS_DIR/pomerium.crt" 2>/dev/null; then
+        echo "Certificates already exist and are valid, skipping generation"
+        exit 0
+    fi
+fi
+
+if ! command -v openssl >/dev/null 2>&1; then
+    apk add --no-cache openssl >/dev/null 2>&1
+fi
+
+mkdir -p "$CERTS_DIR"
+
+openssl genrsa -out "$CERTS_DIR/ca.key" 4096
+openssl req -new -x509 -days $DAYS_VALID -key "$CERTS_DIR/ca.key" \
+    -out "$CERTS_DIR/ca.crt" \
+    -subj "/C=US/ST=Test/L=Test/O=Pomerium Guides Harness/CN=Pomerium Guides Harness CA"
+
+cat > "$CERTS_DIR/openssl.cnf" << EOF
+[req]
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+prompt = no
+
+[req_distinguished_name]
+C = US
+ST = Test
+L = Test
+O = Pomerium Guides Harness
+CN = *.${DOMAIN}
+
+[v3_req]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = *.${DOMAIN}
+DNS.2 = ${DOMAIN}
+DNS.3 = localhost
+IP.1 = 127.0.0.1
+EOF
+
+openssl genrsa -out "$CERTS_DIR/pomerium.key" 2048
+openssl req -new -key "$CERTS_DIR/pomerium.key" \
+    -out "$CERTS_DIR/pomerium.csr" \
+    -config "$CERTS_DIR/openssl.cnf"
+openssl x509 -req -days $DAYS_VALID \
+    -in "$CERTS_DIR/pomerium.csr" \
+    -CA "$CERTS_DIR/ca.crt" \
+    -CAkey "$CERTS_DIR/ca.key" \
+    -CAcreateserial \
+    -out "$CERTS_DIR/pomerium.crt" \
+    -extensions v3_req \
+    -extfile "$CERTS_DIR/openssl.cnf"
+
+rm -f "$CERTS_DIR/pomerium.csr" "$CERTS_DIR/openssl.cnf"
+chmod 644 "$CERTS_DIR"/*.crt "$CERTS_DIR"/*.key
+
+echo "Certificates generated:"
+openssl x509 -in "$CERTS_DIR/pomerium.crt" -noout -subject -dates -ext subjectAltName

--- a/content/examples/guides/_harness/keycloak/pomerium-e2e-realm.json
+++ b/content/examples/guides/_harness/keycloak/pomerium-e2e-realm.json
@@ -1,0 +1,1545 @@
+{
+  "id" : "544bdfbc-0237-44f2-947e-c31ff38b1adc",
+  "realm" : "pomerium-e2e",
+  "displayName" : "Pomerium E2E Testing",
+  "notBefore" : 0,
+  "defaultSignatureAlgorithm" : "RS256",
+  "revokeRefreshToken" : false,
+  "refreshTokenMaxReuse" : 0,
+  "accessTokenLifespan" : 15,
+  "accessTokenLifespanForImplicitFlow" : 15,
+  "ssoSessionIdleTimeout" : 30,
+  "ssoSessionMaxLifespan" : 120,
+  "ssoSessionIdleTimeoutRememberMe" : 0,
+  "ssoSessionMaxLifespanRememberMe" : 0,
+  "offlineSessionIdleTimeout" : 300,
+  "offlineSessionMaxLifespanEnabled" : false,
+  "offlineSessionMaxLifespan" : 600,
+  "clientSessionIdleTimeout" : 0,
+  "clientSessionMaxLifespan" : 0,
+  "clientOfflineSessionIdleTimeout" : 0,
+  "clientOfflineSessionMaxLifespan" : 0,
+  "accessCodeLifespan" : 60,
+  "accessCodeLifespanUserAction" : 60,
+  "accessCodeLifespanLogin" : 60,
+  "actionTokenGeneratedByAdminLifespan" : 300,
+  "actionTokenGeneratedByUserLifespan" : 60,
+  "oauth2DeviceCodeLifespan" : 600,
+  "oauth2DevicePollingInterval" : 5,
+  "enabled" : true,
+  "sslRequired" : "none",
+  "registrationAllowed" : false,
+  "registrationEmailAsUsername" : false,
+  "rememberMe" : false,
+  "verifyEmail" : false,
+  "loginWithEmailAllowed" : true,
+  "duplicateEmailsAllowed" : false,
+  "resetPasswordAllowed" : false,
+  "editUsernameAllowed" : false,
+  "bruteForceProtected" : false,
+  "permanentLockout" : false,
+  "maxTemporaryLockouts" : 0,
+  "bruteForceStrategy" : "MULTIPLE",
+  "maxFailureWaitSeconds" : 900,
+  "minimumQuickLoginWaitSeconds" : 60,
+  "waitIncrementSeconds" : 60,
+  "quickLoginCheckMilliSeconds" : 1000,
+  "maxDeltaTimeSeconds" : 43200,
+  "failureFactor" : 30,
+  "roles" : {
+    "realm" : [ {
+      "id" : "7c1a75a0-0ffe-4c43-b536-bd57b9ccffd5",
+      "name" : "offline_access",
+      "description" : "${role_offline-access}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "544bdfbc-0237-44f2-947e-c31ff38b1adc",
+      "attributes" : { }
+    }, {
+      "id" : "ce50d51f-ad66-4e52-a927-e7887e833c9f",
+      "name" : "default-roles-pomerium-e2e",
+      "description" : "${role_default-roles}",
+      "composite" : true,
+      "composites" : {
+        "realm" : [ "offline_access", "uma_authorization" ],
+        "client" : {
+          "account" : [ "view-profile", "manage-account" ]
+        }
+      },
+      "clientRole" : false,
+      "containerId" : "544bdfbc-0237-44f2-947e-c31ff38b1adc",
+      "attributes" : { }
+    }, {
+      "id" : "b4abeb32-d135-4099-9075-b7d3098a36d1",
+      "name" : "uma_authorization",
+      "description" : "${role_uma_authorization}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "544bdfbc-0237-44f2-947e-c31ff38b1adc",
+      "attributes" : { }
+    } ],
+    "client" : {
+      "realm-management" : [ {
+        "id" : "4b7e0822-60c0-49a8-959a-05420eff5d69",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "bf2da1dc-7214-414c-9dc5-714ed12d4a39",
+        "attributes" : { }
+      }, {
+        "id" : "d2cc2a5e-f4f1-41a3-a15c-3408da58964a",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "bf2da1dc-7214-414c-9dc5-714ed12d4a39",
+        "attributes" : { }
+      }, {
+        "id" : "8da34cac-e874-4bdf-a170-0dcc6c457301",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "bf2da1dc-7214-414c-9dc5-714ed12d4a39",
+        "attributes" : { }
+      }, {
+        "id" : "20e692d0-6059-44c9-9754-6f527fe0671c",
+        "name" : "view-authorization",
+        "description" : "${role_view-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "bf2da1dc-7214-414c-9dc5-714ed12d4a39",
+        "attributes" : { }
+      }, {
+        "id" : "53a32ba8-3b3d-42f6-bff9-d25f5880d352",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "bf2da1dc-7214-414c-9dc5-714ed12d4a39",
+        "attributes" : { }
+      }, {
+        "id" : "7138de8f-a444-4cc6-a55e-fb51551d3171",
+        "name" : "manage-authorization",
+        "description" : "${role_manage-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "bf2da1dc-7214-414c-9dc5-714ed12d4a39",
+        "attributes" : { }
+      }, {
+        "id" : "a411ae55-3fd5-449f-9950-5b21189d4738",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "bf2da1dc-7214-414c-9dc5-714ed12d4a39",
+        "attributes" : { }
+      }, {
+        "id" : "09af94b7-18a5-4d74-8d9a-b7f919887760",
+        "name" : "query-users",
+        "description" : "${role_query-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "bf2da1dc-7214-414c-9dc5-714ed12d4a39",
+        "attributes" : { }
+      }, {
+        "id" : "0f5a9734-c705-4968-80e6-aba58fd93731",
+        "name" : "realm-admin",
+        "description" : "${role_realm-admin}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "view-events", "manage-clients", "view-identity-providers", "view-authorization", "impersonation", "manage-authorization", "query-users", "create-client", "manage-users", "view-users", "view-clients", "query-groups", "manage-identity-providers", "query-clients", "manage-events", "query-realms", "view-realm", "manage-realm" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "bf2da1dc-7214-414c-9dc5-714ed12d4a39",
+        "attributes" : { }
+      }, {
+        "id" : "69113d35-105b-47ea-8b7a-32429c25c5ef",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "bf2da1dc-7214-414c-9dc5-714ed12d4a39",
+        "attributes" : { }
+      }, {
+        "id" : "d32dc457-26ba-4341-a185-d3e88995e6f1",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-groups", "query-users" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "bf2da1dc-7214-414c-9dc5-714ed12d4a39",
+        "attributes" : { }
+      }, {
+        "id" : "ce53a0ef-88fc-4969-926e-6b28cd034fe0",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-clients" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "bf2da1dc-7214-414c-9dc5-714ed12d4a39",
+        "attributes" : { }
+      }, {
+        "id" : "f26406e9-7b11-46d4-bdd8-e4f209bb8522",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "bf2da1dc-7214-414c-9dc5-714ed12d4a39",
+        "attributes" : { }
+      }, {
+        "id" : "f968d51c-fb03-4779-9881-1b7549afd28f",
+        "name" : "query-clients",
+        "description" : "${role_query-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "bf2da1dc-7214-414c-9dc5-714ed12d4a39",
+        "attributes" : { }
+      }, {
+        "id" : "39ae0d3a-799b-46b2-ae83-bf6dea64dcaf",
+        "name" : "query-groups",
+        "description" : "${role_query-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "bf2da1dc-7214-414c-9dc5-714ed12d4a39",
+        "attributes" : { }
+      }, {
+        "id" : "8cdc1540-df10-4ae7-b2d4-9a3d26c2b745",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "bf2da1dc-7214-414c-9dc5-714ed12d4a39",
+        "attributes" : { }
+      }, {
+        "id" : "6dd50ef3-4f05-43bf-bc6a-6f5d94d6b6f2",
+        "name" : "query-realms",
+        "description" : "${role_query-realms}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "bf2da1dc-7214-414c-9dc5-714ed12d4a39",
+        "attributes" : { }
+      }, {
+        "id" : "fb41b55b-95ff-4db9-b524-1e17bfc7feb1",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "bf2da1dc-7214-414c-9dc5-714ed12d4a39",
+        "attributes" : { }
+      }, {
+        "id" : "420efd91-8d13-4742-899e-d876b517aee5",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "bf2da1dc-7214-414c-9dc5-714ed12d4a39",
+        "attributes" : { }
+      } ],
+      "security-admin-console" : [ ],
+      "admin-cli" : [ ],
+      "pomerium" : [ ],
+      "account-console" : [ ],
+      "broker" : [ {
+        "id" : "934f7dd9-46e4-48f7-aeaf-bb6085c79afa",
+        "name" : "read-token",
+        "description" : "${role_read-token}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "7d310794-7441-4267-82d7-07d8fa993c44",
+        "attributes" : { }
+      } ],
+      "account" : [ {
+        "id" : "28f24be2-9492-4632-b74a-e9bdb13fd478",
+        "name" : "view-profile",
+        "description" : "${role_view-profile}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "6adb95ee-8899-4dda-9f88-3f7657bda45e",
+        "attributes" : { }
+      }, {
+        "id" : "6392da00-be41-43cd-b134-6dfffbfa9942",
+        "name" : "delete-account",
+        "description" : "${role_delete-account}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "6adb95ee-8899-4dda-9f88-3f7657bda45e",
+        "attributes" : { }
+      }, {
+        "id" : "b8a1fd10-e2d6-4df8-a219-293fcc479d82",
+        "name" : "view-applications",
+        "description" : "${role_view-applications}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "6adb95ee-8899-4dda-9f88-3f7657bda45e",
+        "attributes" : { }
+      }, {
+        "id" : "ac40461f-d700-4e4b-bdd6-6ddf8af186de",
+        "name" : "view-consent",
+        "description" : "${role_view-consent}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "6adb95ee-8899-4dda-9f88-3f7657bda45e",
+        "attributes" : { }
+      }, {
+        "id" : "305cdf8c-ace3-4b8f-941e-9a3747ef517e",
+        "name" : "manage-account",
+        "description" : "${role_manage-account}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "manage-account-links" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "6adb95ee-8899-4dda-9f88-3f7657bda45e",
+        "attributes" : { }
+      }, {
+        "id" : "576ac925-47c9-4748-a14c-125a4bf63ed1",
+        "name" : "view-groups",
+        "description" : "${role_view-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "6adb95ee-8899-4dda-9f88-3f7657bda45e",
+        "attributes" : { }
+      }, {
+        "id" : "fa27b54d-af72-4d46-9efd-e1ec00a335e7",
+        "name" : "manage-account-links",
+        "description" : "${role_manage-account-links}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "6adb95ee-8899-4dda-9f88-3f7657bda45e",
+        "attributes" : { }
+      }, {
+        "id" : "b7890079-3ce0-47be-9bab-688a49eea6f8",
+        "name" : "manage-consent",
+        "description" : "${role_manage-consent}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "view-consent" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "6adb95ee-8899-4dda-9f88-3f7657bda45e",
+        "attributes" : { }
+      } ]
+    }
+  },
+  "groups" : [ {
+    "id" : "317c27c7-a98a-45de-959c-6ece92347210",
+    "name" : "admins",
+    "path" : "/admins",
+    "subGroups" : [ ],
+    "attributes" : { },
+    "realmRoles" : [ ],
+    "clientRoles" : { }
+  }, {
+    "id" : "5a46a6b8-a214-4407-880c-2646e650bf67",
+    "name" : "contractors",
+    "path" : "/contractors",
+    "subGroups" : [ ],
+    "attributes" : { },
+    "realmRoles" : [ ],
+    "clientRoles" : { }
+  }, {
+    "id" : "365f905a-7e8b-4855-b883-69addce89b1e",
+    "name" : "engineering",
+    "path" : "/engineering",
+    "subGroups" : [ ],
+    "attributes" : { },
+    "realmRoles" : [ ],
+    "clientRoles" : { }
+  } ],
+  "defaultRole" : {
+    "id" : "ce50d51f-ad66-4e52-a927-e7887e833c9f",
+    "name" : "default-roles-pomerium-e2e",
+    "description" : "${role_default-roles}",
+    "composite" : true,
+    "clientRole" : false,
+    "containerId" : "544bdfbc-0237-44f2-947e-c31ff38b1adc"
+  },
+  "requiredCredentials" : [ "password" ],
+  "otpPolicyType" : "totp",
+  "otpPolicyAlgorithm" : "HmacSHA1",
+  "otpPolicyInitialCounter" : 0,
+  "otpPolicyDigits" : 6,
+  "otpPolicyLookAheadWindow" : 1,
+  "otpPolicyPeriod" : 30,
+  "otpPolicyCodeReusable" : false,
+  "otpSupportedApplications" : [ "totpAppFreeOTPName", "totpAppGoogleName", "totpAppMicrosoftAuthenticatorName" ],
+  "localizationTexts" : { },
+  "webAuthnPolicyRpEntityName" : "keycloak",
+  "webAuthnPolicySignatureAlgorithms" : [ "ES256", "RS256" ],
+  "webAuthnPolicyRpId" : "",
+  "webAuthnPolicyAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyRequireResidentKey" : "not specified",
+  "webAuthnPolicyUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyCreateTimeout" : 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyAcceptableAaguids" : [ ],
+  "webAuthnPolicyExtraOrigins" : [ ],
+  "webAuthnPolicyPasswordlessRpEntityName" : "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms" : [ "ES256", "RS256" ],
+  "webAuthnPolicyPasswordlessRpId" : "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey" : "Yes",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement" : "required",
+  "webAuthnPolicyPasswordlessCreateTimeout" : 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
+  "webAuthnPolicyPasswordlessExtraOrigins" : [ ],
+  "clientScopeMappings" : {
+    "account" : [ {
+      "client" : "account-console",
+      "roles" : [ "manage-account", "view-groups" ]
+    } ]
+  },
+  "clients" : [ {
+    "id" : "6adb95ee-8899-4dda-9f88-3f7657bda45e",
+    "clientId" : "account",
+    "name" : "${client_account}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/pomerium-e2e/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/pomerium-e2e/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "post.logout.redirect.uris" : "+"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ ],
+    "optionalClientScopes" : [ ]
+  }, {
+    "id" : "01fde21d-0f9e-41bb-a108-fee39f0baf0a",
+    "clientId" : "account-console",
+    "name" : "${client_account-console}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/pomerium-e2e/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/pomerium-e2e/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "299773e3-9540-47b9-8153-6ca8d48c4f39",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ],
+    "defaultClientScopes" : [ ],
+    "optionalClientScopes" : [ ]
+  }, {
+    "id" : "6c3bdcdd-8dbb-4f33-a248-6c786f4fa985",
+    "clientId" : "admin-cli",
+    "name" : "${client_admin-cli}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : false,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "client.use.lightweight.access.token.enabled" : "true"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ ],
+    "optionalClientScopes" : [ ]
+  }, {
+    "id" : "7d310794-7441-4267-82d7-07d8fa993c44",
+    "clientId" : "broker",
+    "name" : "${client_broker}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "true"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ ],
+    "optionalClientScopes" : [ ]
+  }, {
+    "id" : "71b68298-3f6c-4957-a115-10fec0862965",
+    "clientId" : "pomerium",
+    "name" : "Pomerium E2E Client",
+    "description" : "OIDC client for Pomerium E2E acceptance tests",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "pomerium-e2e-secret",
+    "redirectUris" : [ "https://authenticate.localhost.pomerium.io/oauth2/callback", "https://authenticate.localhost.pomerium.io:8443/oauth2/callback" ],
+    "webOrigins" : [ "https://app.localhost.pomerium.io:8443", "https://authenticate.localhost.pomerium.io", "https://app.localhost.pomerium.io", "https://authenticate.localhost.pomerium.io:8443" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : true,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "oidc.ciba.grant.enabled" : "false",
+      "backchannel.logout.session.required" : "true",
+      "post.logout.redirect.uris" : "https://authenticate.localhost.pomerium.io:8443/.pomerium/signed_out##https://authenticate.localhost.pomerium.io/.pomerium/signed_out##https://app.localhost.pomerium.io:8443/.pomerium/signed_out##https://app.localhost.pomerium.io/.pomerium/signed_out",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "backchannel.logout.revoke.offline.tokens" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "5ac0ce22-552d-4a7c-802c-460b211f4cf9",
+      "name" : "department",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "department",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "department",
+        "jsonType.label" : "String",
+        "userinfo.token.claim" : "true"
+      }
+    }, {
+      "id" : "80915a0b-d928-4872-8321-01cc139278d8",
+      "name" : "audience-mapper",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "included.client.audience" : "pomerium",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    } ],
+    "defaultClientScopes" : [ "openid", "profile", "groups", "email" ],
+    "optionalClientScopes" : [ "offline_access" ]
+  }, {
+    "id" : "bf2da1dc-7214-414c-9dc5-714ed12d4a39",
+    "clientId" : "realm-management",
+    "name" : "${client_realm-management}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "true"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ ],
+    "optionalClientScopes" : [ ]
+  }, {
+    "id" : "4b514c14-a2a8-470d-afc4-8fd938d22001",
+    "clientId" : "security-admin-console",
+    "name" : "${client_security-admin-console}",
+    "rootUrl" : "${authAdminUrl}",
+    "baseUrl" : "/admin/pomerium-e2e/console/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/admin/pomerium-e2e/console/*" ],
+    "webOrigins" : [ "+" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "realm_client" : "false",
+      "client.use.lightweight.access.token.enabled" : "true",
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "4437f235-ad1b-4ef5-a363-15497b032eef",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "introspection.token.claim" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ ],
+    "optionalClientScopes" : [ ]
+  } ],
+  "clientScopes" : [ {
+    "id" : "8d2c7a4b-c978-419e-a160-d754bc3e00d1",
+    "name" : "email",
+    "description" : "Email address",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "f3fc1de0-5c51-4390-b912-26c52e31bef3",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String",
+        "userinfo.token.claim" : "true"
+      }
+    }, {
+      "id" : "97a2175a-7eba-4ca7-9bbd-e398bf9d0ee2",
+      "name" : "email verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "emailVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email_verified",
+        "jsonType.label" : "boolean",
+        "userinfo.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "ad96d448-e748-436c-8299-d5d3399dec79",
+    "name" : "offline_access",
+    "description" : "OpenID Connect built-in scope: offline_access",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "consent.screen.text" : "${offlineAccessScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    }
+  }, {
+    "id" : "fc10557d-d9f6-441a-8b2b-10daafdb18f1",
+    "name" : "openid",
+    "description" : "OpenID Connect scope",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true"
+    }
+  }, {
+    "id" : "c069f504-840b-405f-b2ec-238bcabe0d28",
+    "name" : "profile",
+    "description" : "User profile",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "b564d403-1435-4f6f-af51-b82484ec62d9",
+      "name" : "profile",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    } ]
+  }, {
+    "id" : "5097454b-3efa-42be-bc77-daf0076abd2c",
+    "name" : "groups",
+    "description" : "Group membership claim",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "consent.screen.text" : "Group membership",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "1fc86929-9396-49e2-9b14-ef1a03e7cae0",
+      "name" : "groups",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-group-membership-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "full.path" : "false",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "groups",
+        "userinfo.token.claim" : "true"
+      }
+    } ]
+  } ],
+  "defaultDefaultClientScopes" : [ "profile", "email" ],
+  "defaultOptionalClientScopes" : [ "offline_access", "groups" ],
+  "browserSecurityHeaders" : {
+    "contentSecurityPolicyReportOnly" : "",
+    "xContentTypeOptions" : "nosniff",
+    "referrerPolicy" : "no-referrer",
+    "xRobotsTag" : "none",
+    "xFrameOptions" : "SAMEORIGIN",
+    "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer" : { },
+  "eventsEnabled" : false,
+  "eventsListeners" : [ "jboss-logging" ],
+  "enabledEventTypes" : [ ],
+  "adminEventsEnabled" : false,
+  "adminEventsDetailsEnabled" : false,
+  "identityProviders" : [ ],
+  "identityProviderMappers" : [ ],
+  "components" : {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
+      "id" : "51237ab7-9ae0-4007-b9c2-30b777c1eaf8",
+      "name" : "Max Clients Limit",
+      "providerId" : "max-clients",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "max-clients" : [ "200" ]
+      }
+    }, {
+      "id" : "33bf3486-bc76-46b7-be9a-f22863070eca",
+      "name" : "Full Scope Disabled",
+      "providerId" : "scope",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "6b9bcda0-76eb-401b-bf87-c72fcd0358c2",
+      "name" : "Trusted Hosts",
+      "providerId" : "trusted-hosts",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "host-sending-registration-request-must-match" : [ "true" ],
+        "client-uris-must-match" : [ "true" ]
+      }
+    }, {
+      "id" : "331e2660-7a3b-4caa-93a8-5416b109b6fe",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "saml-user-property-mapper", "oidc-usermodel-attribute-mapper", "oidc-full-name-mapper", "saml-user-attribute-mapper", "oidc-usermodel-property-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-address-mapper", "saml-role-list-mapper" ]
+      }
+    }, {
+      "id" : "97d05fb6-fe7e-415f-b3fb-92e270bbcfd4",
+      "name" : "Consent Required",
+      "providerId" : "consent-required",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "e59d83e5-83ae-4092-925e-7036099dbae8",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "oidc-full-name-mapper", "oidc-address-mapper", "saml-role-list-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-usermodel-property-mapper", "saml-user-attribute-mapper", "oidc-usermodel-attribute-mapper", "saml-user-property-mapper" ]
+      }
+    }, {
+      "id" : "c6f659b4-1889-4def-8995-01d18d04c430",
+      "name" : "Allowed Registration Web Origins",
+      "providerId" : "registration-web-origins",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "6141cc5c-3063-4b97-8473-9130bdc52b82",
+      "name" : "Allowed Registration Web Origins",
+      "providerId" : "registration-web-origins",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "e51b2c8b-811b-4381-8d7b-44cb69a38f47",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "5620c883-78ac-4bf8-8c2c-d67dd0d56743",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    } ],
+    "org.keycloak.userprofile.UserProfileProvider" : [ {
+      "id" : "630dfe90-a029-43ff-96ba-0e9254388427",
+      "providerId" : "declarative-user-profile",
+      "subComponents" : { },
+      "config" : {
+        "kc.user.profile.config" : [ "{\"attributes\":[{\"name\":\"username\",\"displayName\":\"${username}\",\"validations\":{\"length\":{\"min\":3,\"max\":255},\"username-prohibited-characters\":{},\"up-username-not-idn-homograph\":{}},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"email\",\"displayName\":\"${email}\",\"validations\":{\"email\":{},\"length\":{\"max\":255}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"firstName\",\"displayName\":\"${firstName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"lastName\",\"displayName\":\"${lastName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"department\",\"displayName\":\"Department\",\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\"]},\"multivalued\":false}],\"groups\":[{\"name\":\"user-metadata\",\"displayHeader\":\"User metadata\",\"displayDescription\":\"Attributes, which refer to user metadata\"}]}" ]
+      }
+    } ],
+    "org.keycloak.keys.KeyProvider" : [ {
+      "id" : "d15a7cd3-0aa1-4aa6-8ee6-e3f5e20d82cf",
+      "name" : "rsa-generated",
+      "providerId" : "rsa-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEoQIBAAKCAQEAoLbjdyHYdpsA4FAe0qgYa8jtWdJXtIwhB0bkyAAfr9Pi/3V6j471ywEOBxfw/ZUtv6LnMsB8zhJJMPGY3DYUE3up/gjrS7VGNAdFsQTt+Ja5Fl2rVKgvO1a1sCAtUBesaJT6yIcyfIrbwAHgNUWnP+buqeHw49QFUSEWZfFUzBsyS31ouqiO0v+XC5jQucvNO6c2mCghMwqdiq1gneXYemqFkxuLtXLq6kXgeUeIkF8UDk520v0l8yyoH6NZOFWv5miAhJJVH67VhhnIEW3yu3Lrs3TNjCNj9NAmgKB96/+xk35ns5J25lj84Dcpw5Y0SUV9iqn17O9hrhGfyfnk7QIDAQABAoH/BJnQwJx0o3t6GyDnqp/izQ6jcrEJu14RdWLXnlvz6KrBNMd7K7o8nWLkKiq+93ANtNpxMf/PODkoH/pN3EHsGLay6VY6A+nEbqfNs+5KiEhr7kKTfaGeRvMORTIP9raZW6jGCic/MNxvV7EUN29CCKsBPFdgAfq5WrvxNU14f+mYLldg1r6prxMRwYWXgKjL3WX7N3FocxAs7sHZ9VyQs5WC2Sy8QGr+9XG2W5vEx/46nGC2Zgw/SBEApRyevxvzl1N7E8YlCrhuwa8qBqvqGuECQKez0ahENNNiwLxUhf9nvxegfA81Mtkvj/BK4HIzqJuVVWRqG4koxYtAoBWBAoGBANA9GaF08XLJu0tli7YECu62c0nBRudoOtixDMkAxN+SGOOE5kGKUOBBbWsYdsM1GV0w1o3TYGt6dQ3zNTl5atU2vhW+esz0gDylgaYTIlsYAfLheO71ojiQGge0ghEFvQhao76IhPSMZSw8oM70BCD8M0iIE62QoZ+Vt0Fv8nrlAoGBAMWTXQJsnnBQmHpx6/+ZOczaGvIE2JPz2RgwDTwgDEU9CsSUHzbbqORdukVeCoEjrLThfTzanSKuUxnld0D1/BEUYc2WkU4eTpqagQtZoqDPMdCnR80QmsX/mu7h5SkmIX+R9BVrAmlbrvqqkC+2vA9SW+c9qI8nHX3cS7cIfrlpAoGARfeBmSI1zh/B8n9YBfwtwC9FZU6viCkZPJ2gchj0DTqFakzJINRcgDz7irRZkxVQRGOYc2bGStaGZf2FsJ3/K0yNabjqgdrVC4uAmFBthrX2Uak4fPHDY8XnOReJbDbFYP0zb11nbtONWuO0FFUg3gRfJsux8OtboscnH7GBg5ECgYB/0KaB8/zHkgwiYmKXFuwijxKRcPsfM8hE8okNVXo6rJOzulM7LP1kxxHC4GSRSJ/o4FshrBetoPLXtO/iEYBBGFtxIa/cxpR5ReyniBRCTeffIOi9S7mkz4fOdErIxQc0vRoXZQPJXuui9AaVJ3UfwFr+DJBoE5jrnEFLJm68yQKBgQCdrtmrGgIXjj/Ni+PdnylRVDqY/uyujXHeJApczQvCuhnwLqc/ifqu7un6hUA6ZfI0B7eFDeqT+ZDTp5lQyqK5Et1JL4j5PeX4+TiA4+eu0FWVjgk/8Yxwukw07Q+UMiJmzr29HeBDiF3XY00HwFUjxQfbSJRLvL0do8No2vwURQ==" ],
+        "keySize" : [ "2048" ],
+        "certificate" : [ "MIICpzCCAY8CBgGcVJpe3DANBgkqhkiG9w0BAQsFADAXMRUwEwYDVQQDDAxwb21lcml1bS1lMmUwHhcNMjYwMjEzMDEyMzQ4WhcNMzYwMjEzMDEyNTI4WjAXMRUwEwYDVQQDDAxwb21lcml1bS1lMmUwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCgtuN3Idh2mwDgUB7SqBhryO1Z0le0jCEHRuTIAB+v0+L/dXqPjvXLAQ4HF/D9lS2/oucywHzOEkkw8ZjcNhQTe6n+COtLtUY0B0WxBO34lrkWXatUqC87VrWwIC1QF6xolPrIhzJ8itvAAeA1Rac/5u6p4fDj1AVRIRZl8VTMGzJLfWi6qI7S/5cLmNC5y807pzaYKCEzCp2KrWCd5dh6aoWTG4u1curqReB5R4iQXxQOTnbS/SXzLKgfo1k4Va/maICEklUfrtWGGcgRbfK7cuuzdM2MI2P00CaAoH3r/7GTfmezknbmWPzgNynDljRJRX2KqfXs72GuEZ/J+eTtAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAHD+wuhFiIHLW304KDB5sJ0FkvdPlornPzOdC8ZbiXRolq73zTZ0hPKltFD5fOGQBlOk7wwaLxdrHBeCC5ezTVSzqFVBZStn29IDDW2XHtbGUOiooK5rYZc+6FekmijcolhttRnTviJwZss2Gw9Cob+qWPO/i8U6KJo+rrij31ScUXh6dHqGqRc6s68PzArOgeSJHODjiS9d+8M4xzbiXL8Tgran0qY/aQLwS60f8mBgQgBf0Wp7k8gAEP8u4Isu07ogLYP11pi9ur0VTq6zFPkhpwhV85ksxOf1DrJBh+G0LB/hR0WUixXlSsfatwfFERffbY63ffN/mRUcP3eb95A=" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "c700c44b-d06c-4695-92d9-8241bc644e35",
+      "name" : "fallback-AES",
+      "providerId" : "aes-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "a2ca1afa-0f22-4795-ba55-7384de26d620" ],
+        "secret" : [ "wMmHausigt6yDN_vZ5artw" ],
+        "priority" : [ "-100" ]
+      }
+    }, {
+      "id" : "71ae4eed-18b6-41d4-9ae6-2f81fa9c95ef",
+      "name" : "fallback-HS512",
+      "providerId" : "hmac-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "764a30ca-737b-4fdf-bc13-f0a1216186c9" ],
+        "secret" : [ "8z7--a4qNVnCbm1UKlsVXs25FrwaMCY5GGv_P0gFsnnyWcdtJhpa2jz50UwiHl9bpHEQpxN2oFv6UT_c6NEhT4We6kJsz003aaumL9Z2VVMUDPG96x9Y1swtiM-hQkBJVmpBaMkgL5HNjBxT_kiTLbBf4WS_SejkqL0Py2iiJwk" ],
+        "priority" : [ "-100" ],
+        "algorithm" : [ "HS512" ]
+      }
+    } ]
+  },
+  "internationalizationEnabled" : false,
+  "authenticationFlows" : [ {
+    "id" : "2b033161-6ce5-48df-bd44-e3122f7f50cf",
+    "alias" : "Account verification options",
+    "description" : "Method with which to verify the existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-email-verification",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Verify Existing Account by Re-authentication",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "b42be03e-e2b2-49ba-bd30-226843858690",
+    "alias" : "Browser - Conditional 2FA",
+    "description" : "Flow to determine if any 2FA is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorConfig" : "browser-conditional-credential",
+      "authenticator" : "conditional-credential",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "webauthn-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-recovery-authn-code-form",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 50,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "6c5725f1-36c9-4ff5-85b9-f40d3bf544a5",
+    "alias" : "Browser - Conditional Organization",
+    "description" : "Flow to determine if the organization identity-first login is to be used",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "organization",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "f3934678-9924-4e9b-a2db-9e948683a837",
+    "alias" : "Direct Grant - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "eb5cf786-e50a-4f03-ba28-4965a08ff859",
+    "alias" : "First Broker Login - Conditional Organization",
+    "description" : "Flow to determine if the authenticator that adds organization members is to be used",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "idp-add-organization-member",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "c52d24d7-a23f-4352-ae66-dd332529547c",
+    "alias" : "First broker login - Conditional 2FA",
+    "description" : "Flow to determine if any 2FA is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorConfig" : "first-broker-login-conditional-credential",
+      "authenticator" : "conditional-credential",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "webauthn-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-recovery-authn-code-form",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 50,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "76e9ad5e-3c05-4a31-8ce8-c81c717f10b1",
+    "alias" : "Handle Existing Account",
+    "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-confirm-link",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Account verification options",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "55df7745-d473-4fa2-985b-e817e7053ebb",
+    "alias" : "Organization",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 10,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Browser - Conditional Organization",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "0f16e7ae-4020-4bc1-9850-57bdf4d453c7",
+    "alias" : "Reset - Conditional OTP",
+    "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "5524ef0b-93cf-44c9-9909-18eab3fd3a0d",
+    "alias" : "User creation or linking",
+    "description" : "Flow for the existing/non-existing user alternatives",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "create unique user config",
+      "authenticator" : "idp-create-user-if-unique",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Handle Existing Account",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "4116756a-54d1-4fce-ae90-9ddfef42a393",
+    "alias" : "Verify Existing Account by Re-authentication",
+    "description" : "Reauthentication of existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "First broker login - Conditional 2FA",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "9c6a4106-f24d-4ab4-90c8-ae5e3acd5eb6",
+    "alias" : "browser",
+    "description" : "Browser based authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-cookie",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "identity-provider-redirector",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 25,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 26,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Organization",
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "forms",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "3bdc5347-6dc6-47be-8548-3e17c7da8db6",
+    "alias" : "clients",
+    "description" : "Base authentication for clients",
+    "providerId" : "client-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "client-secret",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-secret-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-x509",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "caecaa46-d8a0-49e5-91f2-12676e2ca3b9",
+    "alias" : "direct grant",
+    "description" : "OpenID Connect Resource Owner Grant",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "direct-grant-validate-username",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Direct Grant - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "581c33d0-da3c-41b1-863c-48cdc246c006",
+    "alias" : "docker auth",
+    "description" : "Used by Docker clients to authenticate against the IDP",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "docker-http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "288b2fdb-b7c0-49a6-b4aa-4beb6532f629",
+    "alias" : "first broker login",
+    "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "review profile config",
+      "authenticator" : "idp-review-profile",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "User creation or linking",
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 60,
+      "autheticatorFlow" : true,
+      "flowAlias" : "First Broker Login - Conditional Organization",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "92101c3b-b459-494e-a670-b238842fd8df",
+    "alias" : "forms",
+    "description" : "Username, password, otp and other auth forms.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Browser - Conditional 2FA",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "c2e1d906-2bfa-4c48-a664-9bdba38c868d",
+    "alias" : "registration",
+    "description" : "Registration flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-page-form",
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : true,
+      "flowAlias" : "registration form",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "e13b3468-ebdf-473d-8713-b2b0b192068f",
+    "alias" : "registration form",
+    "description" : "Registration form",
+    "providerId" : "form-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-user-creation",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-password-action",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 50,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-recaptcha-action",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 60,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-terms-and-conditions",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 70,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "ede18962-3ca5-41c8-864e-639452d2eb4b",
+    "alias" : "reset credentials",
+    "description" : "Reset credentials for a user if they forgot their password or something",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "reset-credentials-choose-user",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-credential-email",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 40,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Reset - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "7832da9a-dc5d-4060-9f98-c20edfc5fe74",
+    "alias" : "saml ecp",
+    "description" : "SAML ECP Profile Authentication Flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  } ],
+  "authenticatorConfig" : [ {
+    "id" : "5d00fc5d-03ac-493c-86f6-b6db3d200ba3",
+    "alias" : "browser-conditional-credential",
+    "config" : {
+      "credentials" : "webauthn-passwordless"
+    }
+  }, {
+    "id" : "9766ab87-d590-448a-ae3d-e75b1631edec",
+    "alias" : "create unique user config",
+    "config" : {
+      "require.password.update.after.registration" : "false"
+    }
+  }, {
+    "id" : "b1422c43-a839-43c5-809e-57021208216e",
+    "alias" : "first-broker-login-conditional-credential",
+    "config" : {
+      "credentials" : "webauthn-passwordless"
+    }
+  }, {
+    "id" : "0e41524f-8570-4591-9ed0-f43f31e46087",
+    "alias" : "review profile config",
+    "config" : {
+      "update.profile.on.first.login" : "missing"
+    }
+  } ],
+  "requiredActions" : [ {
+    "alias" : "delete_account",
+    "name" : "Delete Account",
+    "providerId" : "delete_account",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 60,
+    "config" : { }
+  } ],
+  "browserFlow" : "browser",
+  "registrationFlow" : "registration",
+  "directGrantFlow" : "direct grant",
+  "resetCredentialsFlow" : "reset credentials",
+  "clientAuthenticationFlow" : "clients",
+  "dockerAuthenticationFlow" : "docker auth",
+  "firstBrokerLoginFlow" : "first broker login",
+  "attributes" : {
+    "cibaBackchannelTokenDeliveryMode" : "poll",
+    "cibaExpiresIn" : "120",
+    "cibaAuthRequestedUserHint" : "login_hint",
+    "oauth2DeviceCodeLifespan" : "600",
+    "oauth2DevicePollingInterval" : "5",
+    "parRequestUriLifespan" : "60",
+    "cibaInterval" : "5",
+    "realmReusableOtpCode" : "false"
+  },
+  "keycloakVersion" : "26.5.2",
+  "userManagedAccessAllowed" : false,
+  "organizationsEnabled" : false,
+  "verifiableCredentialsEnabled" : false,
+  "adminPermissionsEnabled" : false,
+  "clientProfiles" : {
+    "profiles" : [ ]
+  },
+  "clientPolicies" : {
+    "policies" : [ ]
+  }
+}

--- a/content/examples/guides/_harness/keycloak/pomerium-e2e-users-0.json
+++ b/content/examples/guides/_harness/keycloak/pomerium-e2e-users-0.json
@@ -1,0 +1,104 @@
+{
+  "realm" : "pomerium-e2e",
+  "users" : [ {
+    "id" : "1573f02e-e9f6-4928-926c-436600de1137",
+    "username" : "alice",
+    "firstName" : "Alice",
+    "lastName" : "TestUser",
+    "email" : "alice@company.com",
+    "emailVerified" : true,
+    "attributes" : {
+      "department" : [ "engineering" ]
+    },
+    "enabled" : true,
+    "createdTimestamp" : 1771009758633,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "f869c18a-995f-4acb-a72a-042890ad6f88",
+      "type" : "password",
+      "createdDate" : 1771009758717,
+      "secretData" : "{\"value\":\"yz7wet/ZFCa44fBGIKhKXT/7ZYWZXPeKtT1cAjq6s3E=\",\"salt\":\"DjNm9yrwCrGu0WQBYNZ6Tw==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-pomerium-e2e" ],
+    "notBefore" : 0,
+    "groups" : [ "/admins", "/engineering" ]
+  }, {
+    "id" : "b2d7e3b8-2e34-40b1-809b-562138ec994b",
+    "username" : "bob",
+    "firstName" : "Bob",
+    "lastName" : "TestUser",
+    "email" : "bob@example.com",
+    "emailVerified" : true,
+    "attributes" : {
+      "department" : [ "sales" ]
+    },
+    "enabled" : true,
+    "createdTimestamp" : 1771009758856,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "67354853-6fde-4a54-b217-e23458d952b0",
+      "type" : "password",
+      "createdDate" : 1771009758889,
+      "secretData" : "{\"value\":\"ptTb/MlCpcgIFRIKq72ySTfNedRCX2F+4iFupjq34mY=\",\"salt\":\"Qe9+ya3c0txQrS3Qrzs+Kw==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-pomerium-e2e" ],
+    "notBefore" : 0,
+    "groups" : [ "/contractors" ]
+  }, {
+    "id" : "e229bec7-edbf-4698-8b38-9b66f33e6071",
+    "username" : "charlie",
+    "firstName" : "Charlie",
+    "lastName" : "TestUser",
+    "email" : "charlie@company.com",
+    "emailVerified" : true,
+    "attributes" : {
+      "department" : [ "engineering" ]
+    },
+    "enabled" : true,
+    "createdTimestamp" : 1771009758945,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "ca6acbf3-e1e8-4b5f-b146-e98624fcb863",
+      "type" : "password",
+      "createdDate" : 1771009758968,
+      "secretData" : "{\"value\":\"wwW3tje12vFwERFj/pwvPKCO5h/CK26aSODwTUlpwDE=\",\"salt\":\"HS+zo20VuHy5mcPawTvcog==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-pomerium-e2e" ],
+    "notBefore" : 0,
+    "groups" : [ "/engineering" ]
+  }, {
+    "id" : "e018b7e4-0c5a-445b-b280-e27dd6f294a9",
+    "username" : "diana",
+    "firstName" : "Diana",
+    "lastName" : "TestUser",
+    "email" : "diana@external.org",
+    "emailVerified" : true,
+    "attributes" : {
+      "department" : [ "operations" ]
+    },
+    "enabled" : true,
+    "createdTimestamp" : 1771009759025,
+    "totp" : false,
+    "credentials" : [ {
+      "id" : "cc7699e2-8ad6-4c4a-a295-6b801316dd7f",
+      "type" : "password",
+      "createdDate" : 1771009759049,
+      "secretData" : "{\"value\":\"ljGv6RJ8nVNzvpaB6Ar03bdZS+ExEEFUQzf6UiPnBuE=\",\"salt\":\"S7XBMXvySndHXuSnSQkfpg==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-pomerium-e2e" ],
+    "notBefore" : 0,
+    "groups" : [ "/admins" ]
+  } ]
+}

--- a/content/examples/guides/_harness/pomerium/config.base.yaml
+++ b/content/examples/guides/_harness/pomerium/config.base.yaml
@@ -1,0 +1,39 @@
+# TEMPLATE — copy into a guide's validate/pomerium.validate.yaml and append the
+# guide's own `routes:`. This is the validation-only Pomerium config: it swaps the
+# guide's reader-facing hosted authenticate for the in-network Keycloak so the whole
+# SSO flow runs sealed. The published guide keeps showing hosted authenticate / Zero.
+# Test-only. Never use these secrets in production.
+
+address: :443
+authenticate_service_url: https://authenticate.localhost.pomerium.io
+
+idp_provider: oidc
+idp_provider_url: http://keycloak.localhost.pomerium.io:8080/realms/pomerium-e2e
+idp_client_id: pomerium
+idp_client_secret: pomerium-e2e-secret
+idp_scopes:
+  - openid
+  - profile
+  - email
+  - groups
+
+certificate_file: /certs/pomerium.crt
+certificate_key_file: /certs/pomerium.key
+
+cookie_secret: dj5y7E03ULP9YebCgHNIXmxWnWfYlVXCgwbm9IEdysI=
+shared_secret: 0CdEkgO02jgxmgSC2AdkqIbFELAN4CGw0v0RY85xNr4=
+
+log_level: info
+
+jwt_claims_headers:
+  X-Pomerium-Claim-Email: email
+  X-Pomerium-Claim-Groups: groups
+
+# routes:
+#   - from: https://<guide-id>.localhost.pomerium.io
+#     to: http://<upstream>:<port>
+#     pass_identity_headers: true
+#     policy:
+#       - allow:
+#           or:
+#             - authenticated_user: true

--- a/content/examples/guides/_harness/selftest/compose.yaml
+++ b/content/examples/guides/_harness/selftest/compose.yaml
@@ -1,0 +1,48 @@
+# Harness self-test: proves the shared harness end-to-end against pomerium/verify
+# before any real guide depends on it. Run with:
+#   scripts/validate-guide-fixtures.sh --selftest
+
+include:
+  - ../compose/compose.harness.yaml
+
+services:
+  verify:
+    image: pomerium/verify@sha256:6d9dd40deae8d3ae7517485febf6fd4e7de2692e9dc1a2859c00e3426559af96
+    networks:
+      default:
+        aliases:
+          - verify
+
+  pomerium:
+    image: pomerium/pomerium@sha256:e10d1d267af24f581157f485d9b0bc08469e2428675b696a08e42ceb09b2279c
+    command: ['--config', '/pomerium/config.yaml']
+    volumes:
+      - certs:/certs:ro
+      - ./pomerium.yaml:/pomerium/config.yaml:ro
+    depends_on:
+      certs-init:
+        condition: service_completed_successfully
+      keycloak:
+        condition: service_healthy
+      verify:
+        condition: service_started
+    networks:
+      default:
+        aliases:
+          - authenticate.localhost.pomerium.io
+          - verify.localhost.pomerium.io
+    healthcheck:
+      test: ['CMD', 'pomerium', 'health']
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 10s
+
+  test-runner:
+    depends_on:
+      pomerium:
+        condition: service_healthy
+    environment:
+      PW_TEST_DIR: /app/guide-tests
+    volumes:
+      - ./:/app/guide-tests:ro

--- a/content/examples/guides/_harness/selftest/compose.yaml
+++ b/content/examples/guides/_harness/selftest/compose.yaml
@@ -37,12 +37,3 @@ services:
       timeout: 5s
       retries: 30
       start_period: 10s
-
-  test-runner:
-    depends_on:
-      pomerium:
-        condition: service_healthy
-    environment:
-      PW_TEST_DIR: /app/guide-tests
-    volumes:
-      - ./:/app/guide-tests:ro

--- a/content/examples/guides/_harness/selftest/identity.spec.ts
+++ b/content/examples/guides/_harness/selftest/identity.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "@playwright/test";
+import { login, alice } from "../lib/authn";
+
+// Default assertion for guides whose upstream is pomerium/verify (it echoes the
+// request it received at /json). Guides with a different upstream point
+// PW_TEST_DIR at their own spec instead and reuse ../lib/authn.
+const BASE = process.env.POMERIUM_URL as string;
+
+test.use({ baseURL: BASE });
+
+test("unauthenticated request is redirected to the identity provider", async ({ page }) => {
+  await page.goto(BASE, { waitUntil: "domcontentloaded" });
+  await expect(page).toHaveURL(/keycloak\.localhost\.pomerium\.io/);
+});
+
+test("authenticated user reaches the upstream with identity headers", async ({ page }) => {
+  await login(page, BASE, alice);
+
+  const res = await page.request.get(`${BASE}/json`, { ignoreHTTPSErrors: true });
+  expect(res.ok(), "verify /json should be reachable after login").toBeTruthy();
+
+  const data = await res.json();
+  const email = data.headers?.["X-Pomerium-Claim-Email"]?.[0];
+  expect(email, "upstream should receive the email identity header").toBe(alice.email);
+});
+
+test("Pomerium user endpoint exposes the authenticated identity", async ({ page }) => {
+  await login(page, BASE, alice);
+
+  const res = await page.request.get(`${BASE}/.pomerium/user`, { ignoreHTTPSErrors: true });
+  expect(res.ok(), "/.pomerium/user should return OK").toBeTruthy();
+
+  const user = await res.json();
+  expect(user.email).toBe(alice.email);
+});

--- a/content/examples/guides/_harness/selftest/pomerium.yaml
+++ b/content/examples/guides/_harness/selftest/pomerium.yaml
@@ -1,0 +1,38 @@
+# Pomerium config for the harness self-test. Identical in shape to what every
+# guide's validate/ config uses: self-hosted authenticate + in-network Keycloak +
+# static test secrets + claim headers. Only the routes differ per guide.
+# Test-only. Never use these secrets in production.
+
+address: :443
+authenticate_service_url: https://authenticate.localhost.pomerium.io
+
+idp_provider: oidc
+idp_provider_url: http://keycloak.localhost.pomerium.io:8080/realms/pomerium-e2e
+idp_client_id: pomerium
+idp_client_secret: pomerium-e2e-secret
+idp_scopes:
+  - openid
+  - profile
+  - email
+  - groups
+
+certificate_file: /certs/pomerium.crt
+certificate_key_file: /certs/pomerium.key
+
+cookie_secret: dj5y7E03ULP9YebCgHNIXmxWnWfYlVXCgwbm9IEdysI=
+shared_secret: 0CdEkgO02jgxmgSC2AdkqIbFELAN4CGw0v0RY85xNr4=
+
+log_level: info
+
+jwt_claims_headers:
+  X-Pomerium-Claim-Email: email
+  X-Pomerium-Claim-Groups: groups
+
+routes:
+  - from: https://verify.localhost.pomerium.io
+    to: http://verify:8000
+    pass_identity_headers: true
+    policy:
+      - allow:
+          or:
+            - authenticated_user: true

--- a/content/examples/guides/grafana/config.yaml
+++ b/content/examples/guides/grafana/config.yaml
@@ -1,0 +1,23 @@
+# Pomerium Core configuration for Grafana. Uses the hosted authenticate service, so
+# you don't run your own identity provider. To self-host the IdP, see the Keycloak
+# guide: https://www.pomerium.com/docs/integrations/user-identity/oidc
+authenticate_service_url: https://authenticate.pomerium.app
+
+# Obtain TLS certificates automatically from Let's Encrypt.
+autocert: true
+
+# Signs the identity assertion Pomerium forwards to Grafana, and is published at the
+# route's /.well-known/pomerium/jwks.json for Grafana to verify against. Generate
+# your own and keep it secret:
+#   openssl ecparam -genkey -name prime256v1 -noout | base64
+signing_key: REPLACE_WITH_BASE64_ENCODED_EC_P256_PRIVATE_KEY
+
+routes:
+  - from: https://grafana.yourdomain.com
+    to: http://grafana:3000
+    pass_identity_headers: true
+    policy:
+      - allow:
+          or:
+            - email:
+                is: you@example.com

--- a/content/examples/guides/grafana/config.yaml.md
+++ b/content/examples/guides/grafana/config.yaml.md
@@ -1,0 +1,25 @@
+```yaml title="config.yaml"
+# Pomerium Core configuration for Grafana. Uses the hosted authenticate service, so
+# you don't run your own identity provider. To self-host the IdP, see the Keycloak
+# guide: https://www.pomerium.com/docs/integrations/user-identity/oidc
+authenticate_service_url: https://authenticate.pomerium.app
+
+# Obtain TLS certificates automatically from Let's Encrypt.
+autocert: true
+
+# Signs the identity assertion Pomerium forwards to Grafana, and is published at the
+# route's /.well-known/pomerium/jwks.json for Grafana to verify against. Generate
+# your own and keep it secret:
+#   openssl ecparam -genkey -name prime256v1 -noout | base64
+signing_key: REPLACE_WITH_BASE64_ENCODED_EC_P256_PRIVATE_KEY
+
+routes:
+  - from: https://grafana.yourdomain.com
+    to: http://grafana:3000
+    pass_identity_headers: true
+    policy:
+      - allow:
+          or:
+            - email:
+                is: you@example.com
+```

--- a/content/examples/guides/grafana/docker-compose.yaml
+++ b/content/examples/guides/grafana/docker-compose.yaml
@@ -1,0 +1,29 @@
+services:
+  pomerium:
+    image: pomerium/pomerium:latest
+    volumes:
+      - ./config.yaml:/pomerium/config.yaml:ro
+      - pomerium-cache:/data
+    ports:
+      - 443:443
+      - 80:80
+    restart: always
+
+  grafana:
+    image: grafana/grafana:latest
+    environment:
+      - GF_AUTH_JWT_ENABLED=true
+      - GF_AUTH_JWT_HEADER_NAME=X-Pomerium-Jwt-Assertion
+      - GF_AUTH_JWT_EMAIL_CLAIM=email
+      - GF_AUTH_JWT_USERNAME_CLAIM=email
+      - GF_AUTH_JWT_JWK_SET_URL=https://grafana.yourdomain.com/.well-known/pomerium/jwks.json
+      - GF_AUTH_JWT_AUTO_SIGN_UP=true
+      - GF_AUTH_JWT_CACHE_TTL=60m
+      - GF_AUTH_SIGNOUT_REDIRECT_URL=https://grafana.yourdomain.com/.pomerium/sign_out
+    volumes:
+      - grafana-storage:/var/lib/grafana
+    restart: always
+
+volumes:
+  pomerium-cache:
+  grafana-storage:

--- a/content/examples/guides/grafana/docker-compose.yaml.md
+++ b/content/examples/guides/grafana/docker-compose.yaml.md
@@ -1,0 +1,31 @@
+```yaml title="docker-compose.yaml"
+services:
+  pomerium:
+    image: pomerium/pomerium:latest
+    volumes:
+      - ./config.yaml:/pomerium/config.yaml:ro
+      - pomerium-cache:/data
+    ports:
+      - 443:443
+      - 80:80
+    restart: always
+
+  grafana:
+    image: grafana/grafana:latest
+    environment:
+      - GF_AUTH_JWT_ENABLED=true
+      - GF_AUTH_JWT_HEADER_NAME=X-Pomerium-Jwt-Assertion
+      - GF_AUTH_JWT_EMAIL_CLAIM=email
+      - GF_AUTH_JWT_USERNAME_CLAIM=email
+      - GF_AUTH_JWT_JWK_SET_URL=https://grafana.yourdomain.com/.well-known/pomerium/jwks.json
+      - GF_AUTH_JWT_AUTO_SIGN_UP=true
+      - GF_AUTH_JWT_CACHE_TTL=60m
+      - GF_AUTH_SIGNOUT_REDIRECT_URL=https://grafana.yourdomain.com/.pomerium/sign_out
+    volumes:
+      - grafana-storage:/var/lib/grafana
+    restart: always
+
+volumes:
+  pomerium-cache:
+  grafana-storage:
+```

--- a/content/examples/guides/grafana/validate/assert.spec.ts
+++ b/content/examples/guides/grafana/validate/assert.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "@playwright/test";
+import { login, alice } from "../lib/authn";
+
+// App-specific success for Grafana: after the Pomerium SSO login, Grafana should
+// auto-sign-in the same identity via the forwarded Pomerium JWT assertion.
+const BASE = process.env.POMERIUM_URL as string;
+
+test("unauthenticated request is redirected to the identity provider", async ({ page }) => {
+  await page.goto(BASE, { waitUntil: "domcontentloaded" });
+  await expect(page).toHaveURL(/keycloak\.localhost\.pomerium\.io/);
+});
+
+test("JWT SSO signs the authenticated user into Grafana", async ({ page }) => {
+  await login(page, BASE, alice);
+
+  // Grafana's own user API reflects the JWT-authenticated identity. Pomerium
+  // attaches the signed assertion to every upstream request, so this call
+  // authenticates to Grafana as alice.
+  const res = await page.request.get(`${BASE}/api/user`, { ignoreHTTPSErrors: true });
+  expect(res.ok(), "Grafana /api/user should be reachable after SSO").toBeTruthy();
+
+  const user = await res.json();
+  expect(user.email, "Grafana should sign in the Pomerium identity").toBe(alice.email);
+});

--- a/content/examples/guides/grafana/validate/compose.validate.yaml
+++ b/content/examples/guides/grafana/validate/compose.validate.yaml
@@ -50,12 +50,3 @@ services:
       timeout: 5s
       retries: 30
       start_period: 10s
-
-  test-runner:
-    depends_on:
-      pomerium:
-        condition: service_healthy
-    environment:
-      PW_TEST_DIR: /app/guide-tests
-    volumes:
-      - ./:/app/guide-tests:ro

--- a/content/examples/guides/grafana/validate/compose.validate.yaml
+++ b/content/examples/guides/grafana/validate/compose.validate.yaml
@@ -1,0 +1,61 @@
+# Sealed E2E validation for the Grafana guide. Reuses the shared harness (Keycloak +
+# certs + headless runner) and adds Grafana + a Pomerium wired to the in-network IdP.
+# Run with: scripts/validate-guide-fixtures.sh grafana
+
+include:
+  - ../../_harness/compose/compose.harness.yaml
+
+services:
+  grafana:
+    image: grafana/grafana@sha256:8b37a2f028f164ce7b9889e1765b9d6ee23fec80f871d156fbf436d6198d32b7
+    environment:
+      GF_AUTH_JWT_ENABLED: 'true'
+      GF_AUTH_JWT_HEADER_NAME: X-Pomerium-Jwt-Assertion
+      GF_AUTH_JWT_EMAIL_CLAIM: email
+      GF_AUTH_JWT_USERNAME_CLAIM: email
+      GF_AUTH_JWT_JWK_SET_URL: https://grafana.localhost.pomerium.io/.well-known/pomerium/jwks.json
+      GF_AUTH_JWT_AUTO_SIGN_UP: 'true'
+      GF_AUTH_JWT_CACHE_TTL: 60m
+      # Trust the harness CA so Grafana can fetch Pomerium's JWKS over TLS.
+      # Validation-only; the published guide uses the public hosted authenticate cert.
+      SSL_CERT_FILE: /certs/ca.crt
+    volumes:
+      - certs:/certs:ro
+    networks:
+      default:
+        aliases:
+          - grafana
+
+  pomerium:
+    image: pomerium/pomerium@sha256:e10d1d267af24f581157f485d9b0bc08469e2428675b696a08e42ceb09b2279c
+    command: ['--config', '/pomerium/config.yaml']
+    volumes:
+      - certs:/certs:ro
+      - ./pomerium.validate.yaml:/pomerium/config.yaml:ro
+    depends_on:
+      certs-init:
+        condition: service_completed_successfully
+      keycloak:
+        condition: service_healthy
+      grafana:
+        condition: service_started
+    networks:
+      default:
+        aliases:
+          - authenticate.localhost.pomerium.io
+          - grafana.localhost.pomerium.io
+    healthcheck:
+      test: ['CMD', 'pomerium', 'health']
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 10s
+
+  test-runner:
+    depends_on:
+      pomerium:
+        condition: service_healthy
+    environment:
+      PW_TEST_DIR: /app/guide-tests
+    volumes:
+      - ./:/app/guide-tests:ro

--- a/content/examples/guides/grafana/validate/pomerium.validate.yaml
+++ b/content/examples/guides/grafana/validate/pomerium.validate.yaml
@@ -1,0 +1,43 @@
+# Validation-only Pomerium config for the Grafana guide: self-hosted authenticate +
+# in-network Keycloak so the full SSO flow runs sealed. The published guide uses the
+# hosted authenticate service instead (see ../config.yaml.md).
+# Test-only. Never use these secrets in production.
+
+address: :443
+authenticate_service_url: https://authenticate.localhost.pomerium.io
+
+idp_provider: oidc
+idp_provider_url: http://keycloak.localhost.pomerium.io:8080/realms/pomerium-e2e
+idp_client_id: pomerium
+idp_client_secret: pomerium-e2e-secret
+idp_scopes:
+  - openid
+  - profile
+  - email
+  - groups
+
+certificate_file: /certs/pomerium.crt
+certificate_key_file: /certs/pomerium.key
+
+cookie_secret: dj5y7E03ULP9YebCgHNIXmxWnWfYlVXCgwbm9IEdysI=
+shared_secret: 0CdEkgO02jgxmgSC2AdkqIbFELAN4CGw0v0RY85xNr4=
+
+# Stable signing key so Pomerium publishes a JWKS that Grafana can verify the
+# forwarded assertion against. Test-only key (also shown in the Keycloak guide);
+# never reuse in production.
+signing_key: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSVA2TUN5UFI5OUNmSEVkU0s4cVdzbk51Q0RyMVZ3ay93RER1RVhyQitELzZvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFQ0JTK3gyQnJRNVJqNHJFcU5PSEVsUFVESXJiRlNhRitoWEhEL1RYby9rQWVKU1lJSjJHVwpZMnE0a0NPNTU4RmdoYmxDTUplYVdjV1luT3JuZkpxeXRnPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
+
+log_level: info
+
+jwt_claims_headers:
+  X-Pomerium-Claim-Email: email
+  X-Pomerium-Claim-Groups: groups
+
+routes:
+  - from: https://grafana.localhost.pomerium.io
+    to: http://grafana:3000
+    pass_identity_headers: true
+    policy:
+      - allow:
+          or:
+            - authenticated_user: true

--- a/content/examples/guides/mcp-bridge/validate/SKIP
+++ b/content/examples/guides/mcp-bridge/validate/SKIP
@@ -1,0 +1,1 @@
+Non-sealable: needs a managed Pomerium Zero control plane, an external third-party MCP server (Linear), and interactive OAuth consent from a real MCP client. Last validated manually 2026-06-05 against a live Zero cluster and Linear's hosted MCP server.

--- a/scripts/validate-guide-fixtures.sh
+++ b/scripts/validate-guide-fixtures.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# cspell:ignore selftest gdir endgroup inblk
+# Spin up a guide's sealed validation fixture, run its headless-browser (or CLI)
+# checks against the in-network Keycloak, and tear everything down.
+#
+# Usage:
+#   scripts/validate-guide-fixtures.sh --selftest      # prove the shared harness
+#   scripts/validate-guide-fixtures.sh <guide-id>      # validate one guide
+#
+# A guide opts in simply by having content/examples/guides/<id>/validate/
+# compose.validate.yaml. Override the route under test with validate/url.txt.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GUIDES="$ROOT/content/examples/guides"
+GUIDE="${1:?usage: validate-guide-fixtures.sh <guide-id|--selftest>}"
+
+if [ "$GUIDE" = "--selftest" ]; then
+  COMPOSE="$GUIDES/_harness/selftest/compose.yaml"
+  PROJECT="guides-selftest"
+  POMERIUM_URL="https://verify.localhost.pomerium.io"
+else
+  DIR="$GUIDES/$GUIDE/validate"
+  COMPOSE="$DIR/compose.validate.yaml"
+  PROJECT="guide-$GUIDE"
+  if [ -f "$DIR/url.txt" ]; then
+    POMERIUM_URL="$(tr -d '[:space:]' < "$DIR/url.txt")"
+  else
+    POMERIUM_URL="https://$GUIDE.localhost.pomerium.io"
+  fi
+fi
+
+if [ ! -f "$COMPOSE" ]; then
+  echo "No validation fixture for '$GUIDE' (expected $COMPOSE)" >&2
+  exit 2
+fi
+
+export POMERIUM_URL
+dc() { docker compose -p "$PROJECT" -f "$COMPOSE" "$@"; }
+
+# Reader-facing *.yaml.md files are imported into the guide; their fenced contents
+# must stay byte-identical to the runnable mirror users actually run.
+# fence_body prints the lines inside the first fenced code block (fence-aware, so a
+# guide whose .md adds surrounding prose still compares the right region).
+fence_body() { awk 'inblk && /^```/{exit} inblk{print} /^```/{inblk=1}' "$1"; }
+check_mirror() {
+  md="$1"; plain="$2"
+  [ -f "$md" ] && [ -f "$plain" ] || return 0
+  if ! diff -q <(fence_body "$md") "$plain" >/dev/null; then
+    echo "Mirror drift: $md differs from $plain" >&2
+    diff <(fence_body "$md") "$plain" >&2 || true
+    exit 1
+  fi
+}
+if [ "$GUIDE" != "--selftest" ]; then
+  gdir="$GUIDES/$GUIDE"
+  check_mirror "$gdir/docker-compose.yaml.md" "$gdir/docker-compose.yaml"
+  check_mirror "$gdir/config.yaml.md" "$gdir/config.yaml"
+fi
+
+cleanup() {
+  status=$?
+  if [ "$status" -ne 0 ]; then
+    echo "::group::$PROJECT logs (failure)"; dc logs --no-color || true; echo "::endgroup::"
+  fi
+  dc down -v --remove-orphans >/dev/null 2>&1 || true
+  exit "$status"
+}
+trap cleanup EXIT
+
+echo ">> $GUIDE: building and starting stack (POMERIUM_URL=$POMERIUM_URL)"
+# test-runner (the only built-from-source image) is held back by its profile and
+# built on the `run` below; everything else is pulled, so no --build needed here.
+dc up -d --wait
+
+echo ">> $GUIDE: running validation checks"
+dc run --rm --build test-runner
+
+echo ">> $GUIDE: PASS"

--- a/scripts/validate-guide-fixtures.sh
+++ b/scripts/validate-guide-fixtures.sh
@@ -89,6 +89,7 @@ fi
 if [ -n "$spec_dir" ]; then
   run_opts=(-v "$spec_dir:/app/guide-tests:ro" -e PW_TEST_DIR=/app/guide-tests)
 fi
-dc run --rm --build "${run_opts[@]}" test-runner
+# Empty-array-safe expansion (works on macOS bash 3.2 under `set -u`).
+dc run --rm --build ${run_opts[@]+"${run_opts[@]}"} test-runner
 
 echo ">> $GUIDE: PASS"

--- a/scripts/validate-guide-fixtures.sh
+++ b/scripts/validate-guide-fixtures.sh
@@ -74,6 +74,21 @@ echo ">> $GUIDE: building and starting stack (POMERIUM_URL=$POMERIUM_URL)"
 dc up -d --wait
 
 echo ">> $GUIDE: running validation checks"
-dc run --rm --build test-runner
+# The harness owns the test-runner service; a guide never redefines it (that would
+# conflict with the imported resource on stock Docker Compose). A guide-specific
+# spec is injected here at `run` time instead: if validate/assert.spec.ts exists
+# (or the selftest's identity spec), mount it and point Playwright at it.
+run_opts=()
+if [ "$GUIDE" = "--selftest" ]; then
+  spec_dir="$GUIDES/_harness/selftest"
+elif [ -f "$GUIDES/$GUIDE/validate/assert.spec.ts" ]; then
+  spec_dir="$GUIDES/$GUIDE/validate"
+else
+  spec_dir=""
+fi
+if [ -n "$spec_dir" ]; then
+  run_opts=(-v "$spec_dir:/app/guide-tests:ro" -e PW_TEST_DIR=/app/guide-tests)
+fi
+dc run --rm --build "${run_opts[@]}" test-runner
 
 echo ">> $GUIDE: PASS"


### PR DESCRIPTION
## What

Foundation for standardizing and validating every docs guide. Adds a reusable, fully self-contained Docker Compose harness that proves a guide's entire flow -- including a real SSO login -- in a sealed box, wires it into CI as a permanent gate, and converts the Grafana guide to the new standard as the pilot.

## How it works

Published guides recommend Pomerium Zero / the hosted authenticate service, which can't be sealed (cloud, public DNS, interactive login). The committed CI fixture swaps that one piece for an in-network Keycloak -- the same IdP we document as the self-hosted fallback -- and drives the login with headless Playwright. Everything else (routing, TLS, policy, identity headers, the upstream app) is exactly what the guide ships.

- `content/examples/guides/_harness/` -- shared harness (cert bootstrap, Keycloak realm+users, compose fragment, Playwright runner, selftest).
- `scripts/validate-guide-fixtures.sh <id|--selftest>` -- spins a fixture up, runs the checks, tears it down.
- `.github/workflows/validate-examples.yml` -- changed-guide matrix on PRs, full matrix on harness changes / nightly; the harness selftest always runs.
- `content/examples/guides/grafana/` + rewritten `content/docs/guides/grafana.mdx` -- the pilot (dual Zero/Core tabs, hosted authenticate, Keycloak fallback link).

## Verified locally

- `validate-guide-fixtures.sh --selftest` -> 3/3 (unauth->IdP redirect; authed user reaches verify with identity headers; `/.pomerium/user` identity).
- `validate-guide-fixtures.sh grafana` -> 2/2 (unauth->IdP redirect; real Keycloak login then Grafana JWT auto-signin).
- `yarn build`, `yarn format-check`, `yarn cspell` all clean.

This is the base branch for the per-guide standardization PRs that follow.

## AI assistance

Drafted with Claude (Opus): the harness, CI workflow, validation script, and Grafana guide rewrite. Reviewed by two independent agents plus the workspace review helper; incorporated digest-pinned validation images, fail-closed CI discovery, and drift-guard/JSON hardening. All validation commands above were run and confirmed green manually.
