### PR TITLE
docs: mark homelab-pipeline guide non-sealable with validation SKIP

### DIFF
--- a/content/docs/guides/homelab-pipeline.mdx
+++ b/content/docs/guides/homelab-pipeline.mdx
@@ -1125,6 +1125,12 @@ Use the same failure model every time: identify the symptom, confirm which syste
 
 ## 13. Validate every change the same way
 
+:::note Validation
+
+This multi-component guide (bare-metal Talos Kubernetes, Terraform Cloud, Argo CD, and a hosted Pomerium Zero control plane) cannot run in the sealed Docker harness used by the single-app guides. The control loop and route behavior were validated manually against the live reference lab on April 3, 2026 -- see the route checks in this section and the [live-lab snapshot](#14-current-live-lab-snapshot). The published install versions are intentionally normalized for a fresh deployment and differ from the lab's running pins, so treat them as a reviewed starting point rather than an exact replica of what the lab ran.
+
+:::
+
 Treat the control loop as part of the system, not as background plumbing.
 
 For every change:

--- a/content/examples/guides/homelab-pipeline/validate/SKIP
+++ b/content/examples/guides/homelab-pipeline/validate/SKIP
@@ -1,0 +1,1 @@
+Non-sealable: bare-metal Talos Kubernetes + Terraform Cloud + Argo CD + Pomerium Zero (managed control plane) cannot run in the sealed Docker harness; validated manually against the live lab on 2026-04-03.


### PR DESCRIPTION
## Summary

The homelab-pipeline guide is a multi-component infrastructure walkthrough (bare-metal Talos Kubernetes, Terraform Cloud, Argo CD, a hosted Pomerium Zero control plane, and Grafana). It is non-sealable: it cannot run in the sealed Docker validation harness that the single-app guides use, because it depends on real hardware, cloud Terraform state, and a managed control plane.

This PR takes the non-sealable path from the standardization playbook rather than forcing a fake fixture:

- Adds `content/examples/guides/homelab-pipeline/validate/SKIP` with a one-line reason so the validation discovery step reports the guide as skipped instead of failing. A SKIP-only directory is never selected by the validation matrix (which keys off `validate/compose.validate.yaml`), so this is CI-safe and does not create a hollow matrix entry.
- Adds a Validation admonition to section 13 explaining that the guide was validated manually against the live reference lab, with an honesty clause noting that the published install versions are normalized for a fresh deployment and intentionally differ from the lab's running pins.

The guide already follows the standard template's spirit as a single coherent path. No hollow Docker tabs were added, no infrastructure was stood up, and the existing version pins (`pomerium v0.32.3`, provider `~> 0.32.0`) already match the repo's current 0.32.x docs line, so no version bumps were needed. All in-guide doc links resolve.

## Validation

- `yarn format-check` -- clean (All matched files use Prettier code style)
- `yarn cspell` -- 271 files checked, 0 issues
- `yarn build` -- `[SUCCESS] Generated static files`; no broken links or broken anchors introduced by this guide (the new `#14-current-live-lab-snapshot` anchor resolves; pre-existing broken-anchor warnings in `configure-metrics`, `upgrading`, and `mcp-bridge` are unrelated)

## AI assistance

Claude (Opus 4.8) drafted the SKIP marker and the Validation admonition, ran the docs checks, and ran the workspace cross-model review helper. The reviewer flagged that the first draft of the note duplicated existing section 13/14 prose and that "validated against the live lab" could be read as claiming the published version pins were run; I adopted both -- trimming the note to the non-redundant point, replacing a forward reference with an anchor link, and adding the version-normalization honesty clause. I verified the green format-check, cspell, and build output myself and confirmed the diff contains no local paths, emails, or internal hostnames.
