### PR TITLE
docs: standardize code-server guide with sealed validation

### DIFF
--- a/content/docs/guides/code-server.mdx
+++ b/content/docs/guides/code-server.mdx
@@ -1,165 +1,123 @@
 ---
-# cSpell:ignore codercom codeserver
-
-title: Secure Code-Server with Pomerium Zero
-sidebar_label: Code-server
+title: Secure code-server with Pomerium
+sidebar_label: code-server
 lang: en-US
-keywords:
-  [
-    pomerium,
-    identity access proxy,
-    visual studio code,
-    authentication,
-    authorization,
-    code server,
-    vscode,
-    coder,
-    codercom,
-  ]
-description: In this guide, you'll run code-server VSCode in a Docker container and secure browser access to your project behind Pomerium.
+# cSpell:ignore codercom
+keywords: [pomerium, code-server, vscode, sso, oidc, identity aware proxy]
+description: Run code-server (VS Code in the browser) in Docker and put authentication and authorization in front of it with Pomerium.
 ---
 
 import TabItem from '@theme/TabItem';
 import Tabs from '@theme/Tabs';
 
-# Secure Browser Access to Code-Server Behind Pomerium Zero
+import Config from '/content/examples/guides/code-server/config.yaml.md';
+import Compose from '/content/examples/guides/code-server/docker-compose.yaml.md';
 
-In this guide, you'll run code-server's Visual Studio Code (VSCode) in a Docker container, and secure browser access to your project with Pomerium.
+# Secure code-server with Pomerium
 
-## What is Code-server?
+[code-server](https://github.com/coder/code-server) runs [Visual Studio Code](https://code.visualstudio.com/) on a remote machine and serves the full editor in your browser. It is handy when you want VS Code from any device, work across several machines, or keep your development environment off your laptop. Because that browser session has a shell, your files, and your extensions, it needs to be locked down before it ever faces the internet.
 
-[Code-server](https://github.com/coder/code-server) is an open-source tool that allows you to run [VSCode](https://code.visualstudio.com/), a popular integrated development environment (IDE), on a **remote server** through the browser. This setup essentially turns VSCode into a cloud-based IDE, providing flexibility and accessibility advantages.
+## What this guide does
 
-Code-server is particularly popular among developers who want the full power of VSCode, but need to work in a cloud-based environment. This is ideal if you work on multiple machines, need to access your development environment remotely, or you have limited local resources.
+This guide puts code-server behind Pomerium so that every request is authenticated and authorized before it reaches the editor. code-server itself runs with its own password disabled (`--auth none`); Pomerium becomes the single front door, applying your identity provider's login and your access policy. The result is VS Code in the browser that only the people you name can open.
 
-## How to secure Code-server with Pomerium
+![A code-server VS Code project running in the browser behind Pomerium.](img/code-server/vscode-pomerium.png)
 
-Code-server requires [password authentication](https://coder.com/docs/code-server/latest/guide#expose-code-server) by default. By securing code-server behind Pomerium, you can remove code-server's password requirement and configure Pomerium to add [authentication](/docs/capabilities/authentication) and [authorization](/docs/capabilities/authorization) to an online instance of VSCode.
+## When to use this guide
 
-This guide shows you how to secure code-server with Pomerium. Here are the steps you'll follow:
+Reach for this setup when you run code-server for yourself or a team and want centralized SSO and access control instead of a shared static password. It fits any HTTP application that simply needs protecting: Pomerium handles the login and policy, and code-server stays unaware that anything is in front of it.
 
-1. Install code-server and run it in a Docker container
+## Prerequisites
 
-1. Access your code-server project in the browser listening on `localhost`
+- A working Pomerium deployment. If you don't have one, start with the [quickstart](/docs/get-started/quickstart).
+- [Docker](https://docs.docker.com/install/) and [Docker Compose](https://docs.docker.com/compose/install/).
+- A domain you control, with a DNS record pointing at the host that runs Pomerium.
 
-1. Configure Pomerium to safely expose your code-server instance
+## How the request flows
 
-By the end, you will have a minimal, real-world code-server instance that allows developer teams to write code using VSCode in the browser.
+A browser request reaches Pomerium first. Pomerium terminates TLS, runs authentication and authorization, and upgrades the WebSocket connection the editor needs. Only after a request is allowed does it forward to code-server on the internal Docker network at `code-server:8080`. code-server's own port is never published to the host, so there is no way to reach the editor except through the proxy.
 
-![A code-server VSCode project running in the browser behind Pomerium.](img/code-server/vscode-pomerium.png)
+## Configure Pomerium
 
-### Before you start
+Add a route for code-server. The route requires an authenticated user, sends traffic to the code-server container, and enables WebSockets, which code-server needs for the live editor connection.
 
-This guide uses Docker to run Pomerium Zero and Code-Server services in containers.
+<Tabs queryString="type">
+<TabItem value="zero" label="Pomerium Zero" default>
 
-To complete this guide, you need:
+In the [Zero Console](https://console.pomerium.app):
 
-- A [Pomerium Zero](http://console.pomerium.app/create-account) account
-- [Docker](https://docs.docker.com/install/) and [Docker Compose](https://docs.docker.com/compose/install/)
+1. Create a **Policy** that allows the identities you want. A common starting point is an **Allow** block that matches your email domain (the part after `@`).
+2. Create a **Route**:
+   - **From**: the external URL for code-server, for example `https://code-server.yourdomain.com`.
+   - **To**: the internal address of the container, `http://code-server:8080`.
+   - Attach the policy you created.
+   - On the **Timeouts** tab, enable **Allow Websockets**.
+3. Save the route.
 
-## Configure Pomerium Zero
+Pomerium Zero uses the hosted authenticate service, so there is nothing else to wire up for login.
 
-### Create a policy
+</TabItem>
+<TabItem value="core" label="Pomerium Core">
 
-In the Zero Console:
+Add the route below to your Pomerium `config.yaml`. It uses the hosted authenticate service, so you don't run a separate identity provider, and it requests TLS certificates automatically from Let's Encrypt.
 
-1. Go to **Policies**
-2. Select **New Policy**
-3. Give it a **Name** and an (optional) **Description**
-4. Add an **Allow Block** and select an **AND** operator
-5. Keep the **Domain** criteria and replace **Value** with the domain portion of your email address (the part after “@”)
+<Config />
 
-Save your policy.
+Replace `code-server.yourdomain.com` with your own external hostname and `you@example.com` with the email that should be allowed in. `allow_websockets: true` keeps the editor's live connection working through the proxy.
 
-### Create a route
+:::tip
 
-In the Zero Console:
-
-1. Select **Routes**
-2. Add a **New Route**
-3. Give it a **Name** (like Codeserver)
-4. In `From:`, add the external URL to our Codeserver route
-5. In `To:`, add the internal URL
-6. In the **Policies** field, select the Codeserver policy
-7. Select the **Timeouts** tab and **Allow Websockets**
-8. Select the **Headers** tab and **Preserve Host Header**
-
-## Add Docker Compose Services
-
-First, make sure your `docker-compose.yaml` file contains the images to run Pomerium Zero and Codeserver:
-
-```yaml {7,14} showLineNumbers
-pomerium:
-  image: pomerium/pomerium:latest
-  ports:
-    - 443:443
-  restart: always
-  environment:
-    POMERIUM_ZERO_TOKEN: <CLUSTER_TOKEN>
-    XDG_CACHE_HOME: /var/cache
-  volumes:
-    - pomerium-cache:/var/cache
-  networks:
-    main:
-      aliases:
-        - authenticate.<CLUSTER_SUBDOMAIN>.pomerium.app
-codeserver:
-  image: codercom/code-server:latest
-  networks:
-    main: {}
-  ports:
-    - 8080:8080
-  command: --auth none --disable-telemetry /home/coder/project
-  volumes:
-    - ./code-server:/home/coder/project
-    - ./code-server-config/.config:/home/coder/.config
-```
-
-In line `7`, replace `CLUSTER_TOKEN` with your own.
-
-In line `14`, replace `CLUSTER_SUBDOMAIN` with your own. For example, if your starter domain is `loquacious-cyborg-2214.pomerium.app`, the URL would be `authenticate.loquacious-cyborg-2214.pomerium.app`.
-
-## Access Code-server
-
-Run `docker compose up` and go to your external URL.
-
-After authenticating against our hosted Identity Provider, Pomerium will redirect you to your code-server instance.
-
-## Build a project in Code-server
-
-Now that you can access VSCode in your browser, test out code-server by building a quick HTML project.
-
-1. Create an `index.html` file and add the following code:
-
-```html
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Code-Server Sample</title>
-  </head>
-  <body>
-    <h1 style="color:blueviolet">Check out more from Pomerium:</h1>
-    <ul style="font-size: 20px;">
-      <li><a href="<https://www.pomerium.com/docs/guides>">Guides</a></li>
-      <li><a href="<https://www.pomerium.com/blog/>">Blog</a></li>
-      <li><a href="<https://www.pomerium.com/docs>">Documentation</a></li>
-    </ul>
-    <h2 style="color:blueviolet">Happy coding!</h2>
-  </body>
-</html>
-```
-
-1. Go to **Extensions** and install [Live Server](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer)
-2. Right-click `index.html` and select **Open with Live Server**
-3. Select any of the links to learn more about Pomerium
-
-Great job! You successfully deployed code-server.
-
-:::note
-
-When the code-server container is rebuilt, any files outside of `/home/coder/project` are reset, removing any dependencies (such as go and make). In a real remote development workflow, you could mount additional volumes, or [use a custom code-server container](https://github.com/cdr/deploy-code-server/tree/main/deploy-container) with these dependencies installed.
+To self-host your identity provider instead of using the hosted authenticate service, see the [Keycloak / OIDC fallback](/docs/integrations/user-identity/oidc).
 
 :::
+
+</TabItem>
+</Tabs>
+
+## Configure code-server
+
+Run code-server with authentication turned off so Pomerium is the only gate. The container listens on port `8080`, which is the address the Pomerium route points at. Your project files and the editor's configuration live in named volumes so they survive container restarts.
+
+If you prefer not to disable code-server's own login, you can instead set `PASSWORD` or `HASHED_PASSWORD`, but with Pomerium in front the extra prompt is redundant.
+
+## Run the stack
+
+The Compose file runs Pomerium and code-server together on a shared network.
+
+<Compose />
+
+Bring it up:
+
+```bash
+docker compose up -d
+```
+
+If you run Pomerium Core, place the `config.yaml` from the previous step next to this `docker-compose.yaml`. With Pomerium Zero, replace the mounted `config.yaml` on the `pomerium` service with a `POMERIUM_ZERO_TOKEN` environment variable holding your cluster token; the `To` address `http://code-server:8080` works because both containers share this Compose network.
+
+When you are done, tear the stack down with `docker compose down -v`. The `-v` flag also removes the named volumes, which wipes your project files and editor configuration, so omit it if you want to keep them.
+
+## Verify the setup
+
+1. Open `https://code-server.yourdomain.com` in a fresh browser session. Pomerium should redirect you to your identity provider to sign in.
+2. Sign in as an allowed user. Pomerium redirects you back and the VS Code interface loads.
+3. Confirm the editor is fully interactive: open a file, type in it, and use the terminal. A working editor means the WebSocket upgrade is passing through the route.
+
+## Common failure modes
+
+- **The editor loads but stays blank or disconnects.** WebSockets aren't passing through. Make sure the route has `allow_websockets: true` (Core) or **Allow Websockets** enabled (Zero).
+- **You see code-server's own password screen instead of your identity provider.** code-server still has authentication enabled. Start it with `--auth none` (or remove the `PASSWORD` you set) so Pomerium is the sole gate.
+- **Pomerium returns a 502 or upstream error.** The route's **To** address doesn't match the container. It should be `http://code-server:8080` on the shared Compose network.
+
+## Security considerations
+
+A code-server session is a remote shell with access to your files. Treat the upstream as sensitive:
+
+- **Never expose port `8080` directly.** Don't publish the code-server container's port to the host or the internet. It must only be reachable from Pomerium on the internal Docker network, so the policy can't be bypassed.
+- **Disable code-server's password instead of leaving a second weak gate.** With `--auth none`, identity and access control live entirely in Pomerium, where you can manage them centrally and audit them.
+- **Scope the policy tightly.** Start from a specific email or group rather than a broad domain match, since the editor grants a lot of capability to anyone who gets in.
+
+## Next steps
+
+- Tighten access with [authorization policy](/docs/capabilities/authorization).
+- Review [routing options](/docs/capabilities/routing) for timeouts and headers.
+- Mount additional volumes or build a custom code-server image if your workflow needs language toolchains preinstalled, since anything outside `/home/coder/project` resets when the container is rebuilt.

--- a/content/examples/guides/code-server/config.yaml
+++ b/content/examples/guides/code-server/config.yaml
@@ -1,0 +1,19 @@
+# Pomerium Core configuration for code-server. Uses the hosted authenticate service,
+# so you don't run your own identity provider. To self-host the IdP, see the Keycloak
+# guide: https://www.pomerium.com/docs/integrations/user-identity/oidc
+authenticate_service_url: https://authenticate.pomerium.app
+
+# Obtain TLS certificates automatically from Let's Encrypt.
+autocert: true
+
+routes:
+  - from: https://code-server.yourdomain.com
+    to: http://code-server:8080
+    # code-server uses WebSockets for the editor connection, so the route must
+    # allow them.
+    allow_websockets: true
+    policy:
+      - allow:
+          or:
+            - email:
+                is: you@example.com

--- a/content/examples/guides/code-server/config.yaml.md
+++ b/content/examples/guides/code-server/config.yaml.md
@@ -1,0 +1,21 @@
+```yaml title="config.yaml"
+# Pomerium Core configuration for code-server. Uses the hosted authenticate service,
+# so you don't run your own identity provider. To self-host the IdP, see the Keycloak
+# guide: https://www.pomerium.com/docs/integrations/user-identity/oidc
+authenticate_service_url: https://authenticate.pomerium.app
+
+# Obtain TLS certificates automatically from Let's Encrypt.
+autocert: true
+
+routes:
+  - from: https://code-server.yourdomain.com
+    to: http://code-server:8080
+    # code-server uses WebSockets for the editor connection, so the route must
+    # allow them.
+    allow_websockets: true
+    policy:
+      - allow:
+          or:
+            - email:
+                is: you@example.com
+```

--- a/content/examples/guides/code-server/docker-compose.yaml
+++ b/content/examples/guides/code-server/docker-compose.yaml
@@ -1,0 +1,23 @@
+services:
+  pomerium:
+    image: pomerium/pomerium:latest
+    volumes:
+      - ./config.yaml:/pomerium/config.yaml:ro
+      - pomerium-cache:/data
+    ports:
+      - 443:443
+      - 80:80
+    restart: always
+
+  code-server:
+    image: codercom/code-server:latest
+    command: --auth none --disable-telemetry /home/coder/project
+    volumes:
+      - code-server-project:/home/coder/project
+      - code-server-config:/home/coder/.config
+    restart: always
+
+volumes:
+  pomerium-cache:
+  code-server-project:
+  code-server-config:

--- a/content/examples/guides/code-server/docker-compose.yaml.md
+++ b/content/examples/guides/code-server/docker-compose.yaml.md
@@ -1,0 +1,25 @@
+```yaml title="docker-compose.yaml"
+services:
+  pomerium:
+    image: pomerium/pomerium:latest
+    volumes:
+      - ./config.yaml:/pomerium/config.yaml:ro
+      - pomerium-cache:/data
+    ports:
+      - 443:443
+      - 80:80
+    restart: always
+
+  code-server:
+    image: codercom/code-server:latest
+    command: --auth none --disable-telemetry /home/coder/project
+    volumes:
+      - code-server-project:/home/coder/project
+      - code-server-config:/home/coder/.config
+    restart: always
+
+volumes:
+  pomerium-cache:
+  code-server-project:
+  code-server-config:
+```

--- a/content/examples/guides/code-server/validate/compose.validate.yaml
+++ b/content/examples/guides/code-server/validate/compose.validate.yaml
@@ -1,0 +1,45 @@
+# Sealed E2E validation for the code-server guide. Reuses the shared harness
+# (Keycloak + certs + headless runner) and adds code-server + a Pomerium wired to the
+# in-network IdP. code-server just needs protecting behind Pomerium, so the default
+# access check applies (route requires auth; allowed user reaches the editor).
+# Note: the default check asserts auth-required + allowed-user-reaches-upstream over
+# HTTP; it does not open an editor WebSocket, so allow_websockets is exercised by
+# config validity here, not by a live WS upgrade assertion.
+# Run with: scripts/validate-guide-fixtures.sh code-server
+
+include:
+  - ../../_harness/compose/compose.harness.yaml
+
+services:
+  code-server:
+    image: codercom/code-server@sha256:6d46b83ea0687ab1826ec029b6d0e6342bbd55cc5c29b98258463e7faee16d1e
+    command: --auth none --disable-telemetry /home/coder/project
+    networks:
+      default:
+        aliases:
+          - code-server
+
+  pomerium:
+    image: pomerium/pomerium@sha256:e10d1d267af24f581157f485d9b0bc08469e2428675b696a08e42ceb09b2279c
+    command: ['--config', '/pomerium/config.yaml']
+    volumes:
+      - certs:/certs:ro
+      - ./pomerium.validate.yaml:/pomerium/config.yaml:ro
+    depends_on:
+      certs-init:
+        condition: service_completed_successfully
+      keycloak:
+        condition: service_healthy
+      code-server:
+        condition: service_started
+    networks:
+      default:
+        aliases:
+          - authenticate.localhost.pomerium.io
+          - code-server.localhost.pomerium.io
+    healthcheck:
+      test: ['CMD', 'pomerium', 'health']
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 10s

--- a/content/examples/guides/code-server/validate/pomerium.validate.yaml
+++ b/content/examples/guides/code-server/validate/pomerium.validate.yaml
@@ -1,0 +1,39 @@
+# Validation-only Pomerium config for the code-server guide: self-hosted authenticate
+# + in-network Keycloak so the full SSO flow runs sealed. The published guide uses the
+# hosted authenticate service instead (see ../config.yaml.md).
+# Test-only. Never use these secrets in production.
+
+address: :443
+authenticate_service_url: https://authenticate.localhost.pomerium.io
+
+idp_provider: oidc
+idp_provider_url: http://keycloak.localhost.pomerium.io:8080/realms/pomerium-e2e
+idp_client_id: pomerium
+idp_client_secret: pomerium-e2e-secret
+idp_scopes:
+  - openid
+  - profile
+  - email
+  - groups
+
+certificate_file: /certs/pomerium.crt
+certificate_key_file: /certs/pomerium.key
+
+cookie_secret: dj5y7E03ULP9YebCgHNIXmxWnWfYlVXCgwbm9IEdysI=
+shared_secret: 0CdEkgO02jgxmgSC2AdkqIbFELAN4CGw0v0RY85xNr4=
+
+log_level: info
+
+jwt_claims_headers:
+  X-Pomerium-Claim-Email: email
+  X-Pomerium-Claim-Groups: groups
+
+routes:
+  - from: https://code-server.localhost.pomerium.io
+    to: http://code-server:8080
+    allow_websockets: true
+    pass_identity_headers: true
+    policy:
+      - allow:
+          or:
+            - authenticated_user: true


### PR DESCRIPTION
## What this does

Rewrites the code-server guide to the standard Pomerium guides template and adds a sealed end-to-end validation fixture, mirroring the grafana reference implementation.

code-server (VS Code in the browser) is an HTTP application that just needs protecting behind Pomerium. The guide now leads with what the setup does and when to use it, walks through a Pomerium Zero (default) and Pomerium Core tab, explains the request flow and the trust boundary, and ends with verification checkpoints, common failure modes, and security considerations. code-server runs with `--auth none` so Pomerium is the single gate, and the route enables `allow_websockets: true` for the editor connection.

## Files

- `content/docs/guides/code-server.mdx` — rewritten to the standard template (zero/core tabs, hosted authenticate, Keycloak/OIDC fallback, imported compose + config snippets).
- `content/examples/guides/code-server/docker-compose.yaml` + `config.yaml` — runnable reader mirrors, with byte-identical `.md` fenced copies the guide imports.
- `content/examples/guides/code-server/validate/` — sealed fixture: `compose.validate.yaml` (includes the shared harness, defines Pomerium + code-server, images pinned by digest) and `pomerium.validate.yaml` (config.base + the code-server route). Uses the harness default access check; no custom spec needed.

## Validation

Sealed fixture ran green locally:

```
Running 2 tests using 1 worker

  ✓  1 [chromium] › access.spec.ts:9:5 › unauthenticated request is redirected to the identity provider (791ms)
  ✓  2 [chromium] › access.spec.ts:14:5 › authenticated user reaches the upstream (1.4s)

  2 passed (2.5s)
>> code-server: PASS
```

The default check asserts auth-required plus allowed-user-reaches-upstream over HTTP; it does not open an editor WebSocket, so `allow_websockets` is exercised by config validity rather than a live WS upgrade assertion (noted in the compose header).

Docs checks (node 22.22.2): `yarn format-check` clean, `yarn cspell "**/*"` 0 issues, `yarn build` SUCCESS with no new broken links (the remaining broken-anchor warnings are pre-existing and unrelated: configure-metrics, upgrading, mcp-bridge).

## AI assistance

Claude (Opus) drafted the guide rewrite and the validation fixture, ran the sealed validation and the docs checks, and pinned the validation images by digest. I reviewed the content, the trust-boundary framing, and verified the green validate output and successful build shown above. The change was run through the workspace review helper: adopted the reviewer's fixes (expanded an `IdP` acronym to "identity provider", added a request-flow section and a `docker compose down -v` teardown note, clarified the Zero compose substitution, and added an honest note that the default check does not assert the live WebSocket upgrade); rejected pinning the reader-facing images (the harness convention keeps reader files on `:latest` and pins only the validation fixture) and the suggestion to add a separate Zero compose file or a failure-mode table, which would diverge from the standard single-compose template.
