### PR TITLE
docs: standardize MCP bridge guide (non-sealable SKIP + anchor fix)

### DIFF
--- a/content/docs/guides/mcp-bridge.mdx
+++ b/content/docs/guides/mcp-bridge.mdx
@@ -72,7 +72,7 @@ Before you start, confirm all of the following:
 
 :::warning Not for regulated production workloads
 
-Do not rely on this guide for regulated production workloads without additional review. See [MCP Full Reference](/docs/capabilities/mcp/reference#experimental-feature) for current status.
+Do not rely on this guide for regulated production workloads without additional review. See the [MCP Full Reference](/docs/capabilities/mcp/reference) for current status.
 
 :::
 
@@ -290,6 +290,12 @@ You should see a log entry like:
 The reasons in `allow-why-true` come from the PPL evaluator. For this guide's policy that's `domain-ok` (domain matched) and, for tool calls, `mcp-tool-ok` (the tool wasn't blocked by a `deny` rule). The `mcp-tool-parameters` object echoes the arguments the MCP client passed to the tool, which is useful for audit but may contain data you'd rather not retain; redact or drop that field in your log pipeline if that's a concern.
 
 For a blocked call (try `issue_delete`), the same entry should show `"allow-why-false": ["mcp-tool-unauthorized"]` and Pomerium should return `403` to the client.
+
+:::note Validation
+
+This flow depends on a managed Pomerium Zero control plane, Linear's hosted MCP server, and interactive OAuth consent from a real MCP client, so it can't be scripted into an automated test. Verify it by running the four checkpoints above end to end against your own cluster, including the `issue_delete` -> `403` deny check in Checkpoint 4. We last verified this guide manually on 2026-06-05 against a live Zero cluster and Linear's hosted MCP server.
+
+:::
 
 ## Common failure modes
 

--- a/content/examples/guides/mcp-bridge/validate/SKIP
+++ b/content/examples/guides/mcp-bridge/validate/SKIP
@@ -1,0 +1,1 @@
+Non-sealable: needs a managed Pomerium Zero control plane, an external third-party MCP server (Linear), and interactive OAuth consent from a real MCP client. Last validated manually 2026-06-05 against a live Zero cluster and Linear's hosted MCP server.


### PR DESCRIPTION
## What this does

Standardizes the MCP bridge guide (`content/docs/guides/mcp-bridge.mdx`) under the guides-validation harness as a **non-sealable** guide, and fixes a pre-existing broken doc anchor on that page.

This guide bridges a third-party hosted MCP server (Linear) with Pomerium Zero for team SSO via OAuth auto-discovery (RFC 9728). It can't run in the sealed Docker validation harness: it needs a managed Pomerium Zero control plane, an external third-party MCP server, and interactive OAuth consent from a real MCP client. So it takes the non-sealable path rather than a fake fixture.

## Changes

- **`validate/SKIP`** — adds `content/examples/guides/mcp-bridge/validate/SKIP` with a one-line reason and a last-validated date. The validation workflow (`validate-examples.yml`) selects guides by the presence of `validate/compose.validate.yaml`, and reads `SKIP` only to print the opt-out reason for auditability. This makes the omission intentional and audited rather than looking like a forgotten fixture.
- **Broken-anchor fix** — the guide linked to `/docs/capabilities/mcp/reference#experimental-feature`, but that page has no such heading (the experimental notice is a `:::warning` admonition, which generates no anchor). Changed the link to the bare reference page. `yarn build` previously reported a broken anchor on `/docs/guides/mcp-bridge`; it no longer does.
- **Validation note** — adds a reader-facing `:::note Validation` after the Verify section explaining the flow can't be scripted and how to verify it manually (all four checkpoints including the `issue_delete` -> `403` deny check), with the last manual-validation date.

The guide already followed the standard template (What this guide does / When to use / Prerequisites / step-by-step / Verify / Common failure modes / Security considerations / Next steps) and is correctly single-path (Zero-only, no hollow Core tab), since bridging is a Zero-console-driven flow.

## Verification

- `yarn format-check` — clean.
- `yarn cspell` — 0 issues.
- `yarn build` — SUCCESS. The mcp-bridge broken anchor is gone; the only remaining broken anchors in the build output are two pre-existing ones on unrelated pages (`/docs/deploy/enterprise/configure-metrics`, `/docs/deploy/upgrading`), which are out of scope for this PR.
- Validation harness: not applicable (non-sealable; `validate/SKIP` added). The bridge flow was validated manually against a live Zero cluster and Linear's hosted MCP server.

## AI assistance

Claude (Opus 4.8) drafted the `validate/SKIP` marker, the Validation note, the broken-anchor fix, and this PR body. The author reviewed the diff, confirmed the broken-anchor target by inspecting `reference.mdx` and the build output before/after, confirmed the CI workflow's SKIP handling in `validate-examples.yml`, and ran `yarn format-check`, `yarn cspell`, and `yarn build` (all green). The change was also run through the workspace cross-model review helper; feedback adopted: added a last-validated date to both the SKIP file and the note, reframed the note to be reader-centric instead of referencing docs-internal harness vocabulary, and called out the deny-path check.
