### PR TITLE
docs: only the production build of main is indexable

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -24,3 +24,4 @@ jobs:
       - run: yarn format-check
       - run: yarn cspell
       - run: yarn guide-audit
+      - run: yarn test:robots

--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
     "write-heading-ids": "docusaurus write-heading-ids",
     "format": "prettier --write .",
     "format-check": "prettier --check .",
-    "check": "npm run format-check && npm run cspell && npm run guide-audit",
+    "check": "npm run format-check && npm run cspell && npm run guide-audit && npm run test:robots",
     "cspell": "cspell --gitignore .",
-    "guide-audit": "node scripts/audit-guides.mjs"
+    "guide-audit": "node scripts/audit-guides.mjs",
+    "test:robots": "node --test test/robots-mode.test.js"
   },
   "dependencies": {
     "@docusaurus/core": "^3.10.0",

--- a/plugins/robots-txt-plugin.js
+++ b/plugins/robots-txt-plugin.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
 const path = require('path');
 
-const RELEASE_BRANCH_RE = /^\d+-\d+-\d+$/;
 const ALLOW_TEMPLATE_PATH = path.join(
   __dirname,
   '..',
@@ -9,29 +8,37 @@ const ALLOW_TEMPLATE_PATH = path.join(
   'robots-allow.txt',
 );
 
+// Only the production build of `main` (www.pomerium.com/docs/) is indexable;
+// previews, branch deploys, and numbered snapshots stay noindex.
+const CANONICAL_BRANCH = 'main';
+
+function resolveBranch() {
+  return process.env.HEAD || process.env.BRANCH || '';
+}
+
 function resolveRobotsMode() {
   const forcedMode = process.env.POMERIUM_DOCS_ROBOTS_MODE;
   if (forcedMode === 'allow' || forcedMode === 'disallow') {
     return forcedMode;
   }
 
-  const branch = process.env.HEAD || process.env.BRANCH || '';
-  if (RELEASE_BRANCH_RE.test(branch)) {
+  const branch = resolveBranch();
+  const context = process.env.CONTEXT || '';
+
+  if (context === 'production' && branch === CANONICAL_BRANCH) {
     return 'allow';
   }
 
-  const context = process.env.CONTEXT || '';
-  if (context === 'deploy-preview' || context === 'branch-deploy') {
+  if (context || branch) {
     return 'disallow';
   }
 
-  if (branch) {
-    // Production docs are expected to build from numbered release branches.
-    // If that changes, set POMERIUM_DOCS_ROBOTS_MODE=allow explicitly.
+  // Non-Netlify CI (GitHub Actions sets CI=true, no Netlify CONTEXT): fail closed.
+  if (process.env.CI) {
     return 'disallow';
   }
 
-  // Local/manual builds default to the checked-in allow template.
+  // Local build with no CI/Netlify env: allow, for previewing robots.txt.
   return 'allow';
 }
 
@@ -41,19 +48,65 @@ function buildDisallowRobots(branch, context) {
   if (context) details.push(`context=${context}`);
 
   return [
-    '# Non-release docs build. Block crawlers by default.',
+    '# Non-canonical docs build. Block crawlers by default.',
     details.length > 0
       ? `# ${details.join(' ')}`
       : '# Branch/context unavailable.',
-    '# Stable release branches keep the checked-in allow template.',
+    '# Only the production build of `main` ships the allow template.',
     'User-agent: *',
     'Disallow: /',
     '',
   ].join('\n');
 }
 
+// Toggle X-Robots-Tag in the global `/*` block without disturbing other
+// rules (the /assets/* cache header, scoped per-path overrides).
+function applyRobotsTag(existing, mode) {
+  const directive = `  X-Robots-Tag: ${mode === 'allow' ? 'all' : 'noindex'}`;
+  const lines = (existing || '').split('\n');
+  const start = lines.findIndex((line) => line.trim() === '/*');
+  if (start === -1) {
+    const block = `/*\n${directive}\n`;
+    return existing ? `${block}\n${existing}` : block;
+  }
+  // The /* block runs until the next non-blank, non-indented line.
+  let end = start + 1;
+  while (end < lines.length && (lines[end] === '' || /^\s/.test(lines[end]))) {
+    end += 1;
+  }
+  const block = lines.slice(start, end);
+  const tagIdx = block.findIndex((line) => /X-Robots-Tag:/i.test(line));
+  if (tagIdx === -1) block.splice(1, 0, directive);
+  else block[tagIdx] = directive;
+  return [...lines.slice(0, start), ...block, ...lines.slice(end)].join('\n');
+}
+
 async function readAllowTemplate() {
   return fs.promises.readFile(ALLOW_TEMPLATE_PATH, 'utf8');
+}
+
+async function writeRobotsTxt(outDir, mode, branch, context) {
+  const robotsPath = path.join(outDir, 'robots.txt');
+  const contents =
+    mode === 'allow'
+      ? await readAllowTemplate()
+      : buildDisallowRobots(branch, context);
+  await fs.promises.writeFile(robotsPath, contents, 'utf8');
+}
+
+async function writeHeaders(outDir, mode) {
+  const headersPath = path.join(outDir, '_headers');
+  let existing = '';
+  try {
+    existing = await fs.promises.readFile(headersPath, 'utf8');
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+  }
+  await fs.promises.writeFile(
+    headersPath,
+    applyRobotsTag(existing, mode),
+    'utf8',
+  );
 }
 
 async function pluginRobotsTxt(_context, _options) {
@@ -62,32 +115,20 @@ async function pluginRobotsTxt(_context, _options) {
 
     async postBuild({outDir}) {
       const mode = resolveRobotsMode();
-      const branch = process.env.HEAD || process.env.BRANCH || '';
+      const branch = resolveBranch();
       const context = process.env.CONTEXT || '';
 
-      const robotsPath = path.join(outDir, 'robots.txt');
-      if (mode === 'allow') {
-        await fs.promises.writeFile(
-          robotsPath,
-          await readAllowTemplate(),
-          'utf8',
-        );
-        console.log(
-          `✅ Wrote allow robots.txt template (${branch || 'no-branch'}${context ? `, ${context}` : ''})`,
-        );
-        return;
-      }
+      await writeRobotsTxt(outDir, mode, branch, context);
+      await writeHeaders(outDir, mode);
 
-      await fs.promises.writeFile(
-        robotsPath,
-        buildDisallowRobots(branch, context),
-        'utf8',
-      );
       console.log(
-        `✅ Wrote disallow robots.txt (${branch || 'no-branch'}${context ? `, ${context}` : ''})`,
+        `robots-txt-plugin: mode=${mode} (branch=${branch || '-'}, context=${context || '-'})`,
       );
     },
   };
 }
 
 module.exports = pluginRobotsTxt;
+// For test/robots-mode.test.js.
+module.exports.resolveRobotsMode = resolveRobotsMode;
+module.exports.applyRobotsTag = applyRobotsTag;

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,4 +1,5 @@
-# Non-release docs build. Block crawlers by default.
-# Release branches write the allow template at build time.
+# Fail-closed default. Block crawlers unless the build overrides this.
+# Only the production build of `main` writes the allow template at build time
+# (see plugins/robots-txt-plugin.js).
 User-agent: *
 Disallow: /

--- a/test/robots-mode.test.js
+++ b/test/robots-mode.test.js
@@ -1,0 +1,155 @@
+// Crawler-mode regression tests for plugins/robots-txt-plugin.js.
+// Run: `yarn test:robots`.
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const {test} = require('node:test');
+
+const {
+  resolveRobotsMode,
+  applyRobotsTag,
+} = require('../plugins/robots-txt-plugin');
+
+const ENV_KEYS = [
+  'POMERIUM_DOCS_ROBOTS_MODE',
+  'HEAD',
+  'BRANCH',
+  'CONTEXT',
+  'CI',
+];
+
+function withEnv(env, fn) {
+  const saved = {};
+  for (const key of ENV_KEYS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+  Object.assign(process.env, env);
+  try {
+    return fn();
+  } finally {
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  }
+}
+
+test('production build of main is the only indexable build', () => {
+  assert.equal(
+    withEnv({CONTEXT: 'production', HEAD: 'main'}, resolveRobotsMode),
+    'allow',
+  );
+});
+
+test('numbered release-branch snapshot is noindex (even in production context)', () => {
+  assert.equal(
+    withEnv({CONTEXT: 'branch-deploy', HEAD: '0-32-0'}, resolveRobotsMode),
+    'disallow',
+  );
+  assert.equal(
+    withEnv({CONTEXT: 'production', HEAD: '0-32-0'}, resolveRobotsMode),
+    'disallow',
+  );
+});
+
+test('deploy previews are noindex', () => {
+  assert.equal(
+    withEnv(
+      {CONTEXT: 'deploy-preview', HEAD: 'some-feature-branch'},
+      resolveRobotsMode,
+    ),
+    'disallow',
+  );
+});
+
+test('POMERIUM_DOCS_ROBOTS_MODE override wins', () => {
+  assert.equal(
+    withEnv(
+      {
+        POMERIUM_DOCS_ROBOTS_MODE: 'disallow',
+        CONTEXT: 'production',
+        HEAD: 'main',
+      },
+      resolveRobotsMode,
+    ),
+    'disallow',
+  );
+  assert.equal(
+    withEnv(
+      {
+        POMERIUM_DOCS_ROBOTS_MODE: 'allow',
+        CONTEXT: 'deploy-preview',
+        HEAD: '0-32-0',
+      },
+      resolveRobotsMode,
+    ),
+    'allow',
+  );
+});
+
+test('main as a branch deploy (not yet promoted) is noindex', () => {
+  assert.equal(
+    withEnv({CONTEXT: 'branch-deploy', HEAD: 'main'}, resolveRobotsMode),
+    'disallow',
+  );
+});
+
+test('BRANCH is honored when HEAD is unset', () => {
+  assert.equal(
+    withEnv({CONTEXT: 'production', BRANCH: 'main'}, resolveRobotsMode),
+    'allow',
+  );
+  assert.equal(
+    withEnv({CONTEXT: 'production', BRANCH: '0-32-0'}, resolveRobotsMode),
+    'disallow',
+  );
+});
+
+test('non-Netlify CI fails closed; Netlify (which also sets CI) is unaffected', () => {
+  assert.equal(withEnv({CI: 'true'}, resolveRobotsMode), 'disallow');
+  assert.equal(
+    withEnv(
+      {CI: 'true', CONTEXT: 'production', HEAD: 'main'},
+      resolveRobotsMode,
+    ),
+    'allow',
+  );
+});
+
+test('local build with no Netlify env allows (preview convenience)', () => {
+  assert.equal(withEnv({}, resolveRobotsMode), 'allow');
+});
+
+test('_headers toggle preserves other rules (e.g. asset caching)', () => {
+  const headers = fs.readFileSync(
+    path.join(__dirname, '..', 'static', '_headers'),
+    'utf8',
+  );
+  assert.match(headers, /X-Robots-Tag:\s*noindex/i);
+
+  const allowed = applyRobotsTag(headers, 'allow');
+  assert.match(allowed, /X-Robots-Tag:\s*all/i);
+  assert.doesNotMatch(allowed, /X-Robots-Tag:\s*noindex/i);
+  assert.match(allowed, /Cache-Control: public, max-age=31536000, immutable/);
+
+  const disallowed = applyRobotsTag(allowed, 'disallow');
+  assert.match(disallowed, /X-Robots-Tag:\s*noindex/i);
+  assert.match(
+    disallowed,
+    /Cache-Control: public, max-age=31536000, immutable/,
+  );
+});
+
+test('only the /* block is toggled, scoped overrides are left alone', () => {
+  const headers = [
+    '/api/*',
+    '  X-Robots-Tag: noindex',
+    '',
+    '/*',
+    '  X-Robots-Tag: noindex',
+  ].join('\n');
+  const allowed = applyRobotsTag(headers, 'allow');
+  assert.match(allowed, /\/\*\n\s*X-Robots-Tag:\s*all/);
+  assert.match(allowed, /\/api\/\*\n\s*X-Robots-Tag:\s*noindex/);
+});


### PR DESCRIPTION
This makes the crawler logic deterministic ahead of the main-as-default docs cutover (OPE-304): robots.txt gets the allow template and `X-Robots-Tag: all` only when Netlify builds `main` in the production context; deploy previews, branch deploys, numbered snapshot branches, and non-Netlify CI builds get a disallow robots.txt plus noindex. `POMERIUM_DOCS_ROBOTS_MODE=allow|disallow` stays as an explicit override, and local builds with no CI/Netlify env still produce the allow template for previewing. The plugin also writes `build/_headers`, toggling only the global `/*` block — the test suite asserts scoped rules like the `/assets/*` cache header survive. Branches that don't carry this plugin (today's pinned snapshots) keep setting headers via their checked-in `static/_headers`.

Merging changes nothing user-visible: `main` keeps building as a noindex branch deploy until Netlify's production branch is flipped (tracked in OPE-304). The version-dropdown restructure and the Since badge are split into their own PRs.

## AI assistance

Drafted by Claude (Fable 5): the plugin rewrite and test suite; manual changes: review-driven fixes and wording. Manually verified: local builds, format/cspell/test runs, and the crawler-mode behavior probed on a live Netlify deploy preview.
