### PR TITLE
docs: demote 0-32-0 snapshot to noindex [merge only after production flip]

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -1,2 +1,2 @@
 /*
-  X-Robots-Tag: all
+  X-Robots-Tag: noindex


### PR DESCRIPTION
**Do not merge until the Netlify production branch has been flipped to `main`** (OPE-304 step 3): while `0-32-0` is still the production branch, this `_headers` change would noindex the live canonical docs at www.pomerium.com/docs.

This demotes the 0-32-0 snapshot once `main` becomes the canonical, indexed docs: `X-Robots-Tag` goes noindex while robots.txt stays crawlable — this pin was indexed, so crawlers must be able to fetch pages to see the noindex, and canonicals already point at www.

## AI assistance

Drafted by Claude (Fable 5) as part of the OPE-304 cutover. Manually verified: the merge-timing constraint against the live Netlify production configuration, and that the branch's cspell hook does not scan `_headers` (no pragma needed).
