### PR TITLE
docs: restructure the version dropdown for main as the default docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,13 +126,18 @@ Follow the pattern: `docs: description of change (#PR)` or `docs(scope): descrip
 
 ## Cutting a new docs version
 
-Policy: keep the current release and the one before it live at their versioned docs subdomains; everything older redirects to canonical docs. A release cut touches three places and is not complete until all three land together.
+`main` is the canonical, indexed docs at `www.pomerium.com/docs/` (it is the Netlify production branch; only its production build is indexable — see `plugins/robots-txt-plugin.js`). Numbered release branches are noindex pinned snapshots served at `<version>.docs.pomerium.com`. Policy: keep the latest stable pin and the one before it live; everything older redirects to canonical docs.
 
-1. **Version subdomain + TLS** — coordinate with ops to register the new version's hostname so it resolves and serves a valid cert; at the same time, demote the oldest live version to a redirect. Ops owns this in an internal runbook.
-2. **`src/components/docVersions.json`** — update to the new live set (current release + previous release + `vNext`).
-3. **Navbar dropdown** in `docusaurus.config.ts` (`themeConfig.navbar.items[*].dropdownItemsAfter`) — match the live set in `docVersions.json`. Run `yarn format` + `yarn build` + `yarn cspell "**/*"` before committing.
+A release cut (e.g. `0-33-0`):
 
-Verify after deploy: the new version's hostname returns 200 with a valid cert; the demoted version redirects to canonical docs.
+1. **Cut the branch from `main`.** On the new branch only, override `presets[0].docs.versions.current.label` in `docusaurus.config.ts` to that version (e.g. `v0.33`) so the snapshot doesn't call itself "Latest (main)". The robots plugin needs no per-branch changes — numbered branches build noindex automatically. (Branches cut before this plugin landed carry the old allow-by-regex plugin and need explicit demotion via `static/_headers`.)
+2. **Confirm the pin serves** — Netlify maps `<branch>.docs.pomerium.com` to the branch deploy automatically under the `docs.pomerium.com` custom domain; the GCP docs LB passes unmatched `*.docs.pomerium.com` hosts through to Netlify with the Host header preserved.
+3. **`src/components/docVersions.json` + navbar dropdown** in `docusaurus.config.ts` (`themeConfig.navbar.items[*].dropdownItemsAfter`), on `main`: relabel the new pin "Latest stable (vX.Y)", demote the previous one to plain `vX.Y`, drop the oldest. Keep both files in sync. Backport the same dropdown update to still-live pinned branches. Run `yarn format` + `yarn build` + `yarn cspell "**/*"` before committing.
+4. **Retire the oldest pin** — ops appends it to `redirect_versions` in `infrastructure-terraform/terraform/gcp/public-prd/docs.tf` (applied via Terraform Cloud), which 301s the hostname to canonical docs.
+
+Verify after deploy: the new pin returns 200 with a valid cert and `X-Robots-Tag: noindex`; the retired version 301s to canonical docs; `www.pomerium.com/docs/` still serves `main` with `X-Robots-Tag: all`.
+
+Never merge robots/noindex changes (e.g. `static/_headers`) to a branch while it is Netlify's production branch — they would apply to the live canonical docs, not just a snapshot.
 
 ## AI Usage Policy
 

--- a/content/docs/versions.mdx
+++ b/content/docs/versions.mdx
@@ -1,12 +1,12 @@
 ---
-title: Archived Versions
+title: Documentation Versions
 displayed_sidebar: documentation
 ---
 
 import DocVersions from '@site/src/components/DocVersions';
 
-If you're running a previous version of Pomerium, we suggest [upgrading](/docs/deploy/upgrading.mdx). In addition to fixes and new features, updated versions can patch security issues as they are discovered.
+These docs track `main` (the latest, rolling Pomerium documentation) by default. Each released version is also captured as a pinned snapshot you can browse below.
 
-If you're unable to upgrade Pomerium, you can use the links below to find documentation for previous versions.
+If you're running an older release, we suggest [upgrading](/docs/deploy/upgrading.mdx) — newer versions ship fixes, new features, and security patches.
 
 <DocVersions />

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -63,9 +63,9 @@ const config: Config = {
             extendDefaults: true,
           },
           versions: {
+            // On a numbered release branch, override this label to that version.
             current: {
-              label: 'vNext (upcoming release)',
-              badge: true,
+              label: 'Latest (main)',
             },
           },
         },
@@ -151,7 +151,7 @@ const config: Config = {
           dropdownItemsAfter: [
             {
               to: 'https://0-32-0.docs.pomerium.com/docs',
-              label: 'v0.32',
+              label: 'Latest stable (v0.32)',
             },
             {
               to: 'https://0-31-0.docs.pomerium.com/docs',
@@ -260,7 +260,7 @@ const config: Config = {
         id: process.env.GTM,
       },
     ],
-    // Branch deploys default to disallow; release branches rewrite robots.txt.
+    // Only the production build of `main` is indexable.
     require.resolve('./plugins/robots-txt-plugin'),
     // Generate llms.txt file for LLM consumption
     require.resolve('./plugins/llms-txt-plugin'),

--- a/src/components/DocVersions.js
+++ b/src/components/DocVersions.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import data from './docVersions.json';
 
-const versions = Object.values(data);
+const versions = Object.values(data).sort((a, b) => a.order - b.order);
 
 const DocVersions = () => {
   return (

--- a/src/components/docVersions.json
+++ b/src/components/docVersions.json
@@ -1,14 +1,17 @@
 {
   "0.31.0": {
-    "id": "v0.31.x",
-    "link": "https://0-31-0.docs.pomerium.com/docs"
+    "id": "v0.31",
+    "link": "https://0-31-0.docs.pomerium.com/docs",
+    "order": 3
   },
   "0.32.0": {
-    "id": "v0.32.x",
-    "link": "https://0-32-0.docs.pomerium.com/docs"
+    "id": "Latest stable (v0.32)",
+    "link": "https://0-32-0.docs.pomerium.com/docs",
+    "order": 2
   },
-  "vNext": {
-    "id": "vNext",
-    "link": "https://main.docs.pomerium.com/docs"
+  "main": {
+    "id": "Latest (main)",
+    "link": "https://www.pomerium.com/docs/",
+    "order": 1
   }
 }


### PR DESCRIPTION
Part of the main-as-default docs cutover (OPE-304): the version dropdown drops vNext — `main` is the current version ("Latest (main)"), with "Latest stable (v0.32)" and "v0.31" as pinned snapshots. The versions page copy explains the rolling model, the versions table sorts by an explicit `order` field so `main` lists first, and the AGENTS.md release-cut runbook is rewritten to match.

## AI assistance

Drafted by Claude (Fable 5); manual changes: review-driven wording. Manually verified: local build, format/cspell checks, and the rendered versions page on the Netlify deploy preview.
