### PR TITLE
docs: add inline Since badge for version-added metadata

### DIFF
--- a/content/docs/reference/routes/from.mdx
+++ b/content/docs/reference/routes/from.mdx
@@ -21,7 +21,7 @@ import EnterpriseConfiguration from '../../../../src/components/EnterpriseConfig
 
 The **From** URL is the externally accessible URL for a proxied HTTP request.
 
-Specifying `tcp+https` or `udp+https` for the scheme enables [TCP proxying](/docs/capabilities/non-http/) or [UDP proxying](/docs/capabilities/non-http/udp) (available since v0.29) support for the route. You may map more than one port through the same hostname by specifying a different `:port` in the URL.
+Specifying `tcp+https` for the scheme enables [TCP proxying](/docs/capabilities/non-http/) support for the route; `udp+https` enables [UDP proxying](/docs/capabilities/non-http/udp). <Since version="0.29" /> You may map more than one port through the same hostname by specifying a different `:port` in the URL.
 
 Specifying `ssh` for the scheme enables [native SSH proxying](/docs/capabilities/native-ssh-access).
 

--- a/plugins/llms-txt-plugin.js
+++ b/plugins/llms-txt-plugin.js
@@ -27,6 +27,12 @@ function preCleanDocusaurusMDX(raw) {
   raw = raw.replace(/<\/?Tabs[^>]*>/g, '');
   raw = raw.replace(/<\/?TabItem[^>]*>/g, '');
 
+  // Convert inline <Since version="x.y" /> badges to plain text
+  raw = raw.replace(
+    /<Since\s+version=["']v?([^"']+)["']\s*\/>/g,
+    '(added in v$1)',
+  );
+
   // Unwrap admonition blocks but keep their body text (handles indented blocks too)
   raw = raw.replace(
     /^[ \t]*:::(info|note|caution|tip|danger|important|success|failure|admonition|enterprise|warning)[^\n]*\n([\s\S]*?)^[ \t]*:::\s*$/gm,

--- a/src/components/Since/index.js
+++ b/src/components/Since/index.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import styles from './styles.module.css';
+
+// Inline "Added in vX.Y" badge, registered globally via
+// src/theme/MDXComponents.js: ## My feature <Since version="0.33.0" />
+export default function Since({version}) {
+  if (!version) return null;
+  const label = String(version).startsWith('v') ? version : `v${version}`;
+  return (
+    <span className={styles.since} title={`Added in Pomerium ${label}`}>
+      Added in {label}
+    </span>
+  );
+}

--- a/src/components/Since/styles.module.css
+++ b/src/components/Since/styles.module.css
@@ -1,0 +1,23 @@
+.since {
+  display: inline-block;
+  margin-left: 0.4rem;
+  padding: 0.05rem 0.5rem;
+  border: 1px solid var(--ifm-color-primary-lighter);
+  border-radius: 999px;
+  background-color: var(
+    --ifm-color-primary-contrast-background,
+    rgba(111, 67, 231, 0.1)
+  );
+  color: var(--ifm-color-primary-darker);
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.6;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+[data-theme='dark'] .since {
+  border-color: var(--ifm-color-primary-dark);
+  background-color: rgba(140, 105, 236, 0.18);
+  color: var(--ifm-color-primary-lightest);
+}

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -1,0 +1,8 @@
+import Since from '@site/src/components/Since';
+import MDXComponents from '@theme-original/MDXComponents';
+
+// Make <Since/> available in MDX without a per-file import.
+export default {
+  ...MDXComponents,
+  Since,
+};


### PR DESCRIPTION
Adds an inline `<Since version="x.y" />` badge marking when a capability landed — useful once docs track `main` (OPE-304) and readers may be on an older pinned release. Registered globally via `src/theme/MDXComponents.js` so MDX needs no per-file import; the llms.txt generator renders it as plain "(added in vX.Y)" text. One demonstration conversion on the routes `from` reference page.

## AI assistance

Drafted by Claude (Fable 5); manual changes: review-driven fixes (badge placement, llms.txt rendering). Manually verified: local build, badge rendering on the deploy preview, and llms.txt output (no literal JSX, correct "(added in v0.29)" text).
