### PR TITLE
docs(agents): allow real em dashes in guide review policy

### DIFF
--- a/.agents/skills/guide-review/SKILL.md
+++ b/.agents/skills/guide-review/SKILL.md
@@ -60,7 +60,7 @@ A guide is not publish-ready if any of the following are true:
 - Steps depend on unexplained environment assumptions
 - Moved or deprecated content is listed as an active guide without clear labeling
 - The guide cannot be followed without guessing at key values, sequence, or expected outcomes
-- Prose contains em dashes (`—`, `–`) or emojis (see **Style rules** below)
+- Prose contains emojis or fake em dashes built from double hyphens (`--`) (see **Style rules** below)
 - An acronym is used before being defined (see **Style rules** below). Well-known internet-infrastructure acronyms are exempt; product-specific and guide-local acronyms are not.
 
 ## Minimum evidence requirements
@@ -102,7 +102,7 @@ Every guide should include, at minimum:
 
 These are hard rules. A guide that violates them is not publish-ready regardless of score.
 
-- **No em dashes (`—`) or en dashes (`–`) in prose.** Use a period, comma, colon, parentheses, or rewrite the sentence. Em dashes are a strong LLM-output tell and read inconsistent across the guides set. This rule applies to body prose, callouts, list items, headings, and table cells. It does not apply to code, config, CLI output, or content quoted from external sources.
+- **Em dashes are fine; never fake them.** A real em dash (`—`) is welcome wherever the sentence calls for one, including headings and table cells. What fails review is faking one with a double hyphen (`--`) in prose, or leaning on dashes so heavily that they crowd out ordinary punctuation. Code, config, CLI output, and quoted content are exempt as always.
 - **No emojis anywhere.** No decorative emojis in headings, no status emojis (✅ ❌ ⚠️ 🎉 🚀 💡 etc.) in prose or lists, no emoji bullets. Use plain Markdown and Docusaurus admonitions (`:::note`, `:::tip`, `:::warning`, `:::danger`, `:::info`) for emphasis and tone instead. Unicode symbols that are not emoji (arrows like `→`, checkmarks inside code examples, mathematical symbols) are fine when they carry meaning.
 - **Expand every acronym on first use.** The first time an acronym appears in the guide, write the full term followed by the acronym in parentheses, for example `Security Information and Event Management (SIEM)`, `Client ID Metadata Document (CIMD)`, `Pomerium Policy Language (PPL)`. Subsequent uses may use the short form. This applies to the body, admonitions, tables, diagrams captions, and front-matter descriptions. Widely-understood internet-infrastructure acronyms where spelling out would read as noise (HTTP, HTTPS, HTML, URL, TLS, DNS, IP, JSON, YAML, API, SDK, CLI, UI, OS, VM, CPU, RAM, UUID, SSO, OAuth, OIDC, SAML, JWT, CSV, PDF, MIME, PKI, CA, CRL, CDN, SaaS, IaaS, PaaS, CI, CD, PR, SQL, REST, gRPC, RPC, RFC) are exempt from this rule. Product-specific or guide-local acronyms (for example TE / TI / AS / PRM / DCR / CIMD / PPL / IdP / SIEM / MCP on first use in that guide) are **not** exempt. When in doubt, expand.
 - **Prefer descriptive nouns over bare acronyms in later paragraphs when the guide spans many sections.** If the guide is long enough that a reader might land on a later section without reading the definition, reintroduce the full form once per major section heading, or reword to use a descriptive noun ("the cached upstream token") instead of the bare acronym ("the cached TI"). Readability beats strict consistency.

--- a/.agents/skills/guide-review/references/rubric.md
+++ b/.agents/skills/guide-review/references/rubric.md
@@ -273,7 +273,7 @@ A guide that omits this baseline prereq fails this dimension and cannot score ab
 
 **Weight:** 1x **Question:** Is the guide easy to scan, extract, update, and keep correct over time?
 
-**Style rules (hard fail):** Prose must not contain em dashes (`—`) or en dashes (`–`), and the guide must not contain emojis (decorative, status, or bullets — ✅ ❌ ⚠️ 🎉 🚀 💡 and similar). Use plain punctuation and Docusaurus admonitions (`:::note`, `:::tip`, `:::warning`, `:::danger`, `:::info`) instead. Code, config, CLI output, and quoted external content are exempt. A guide that violates either rule is not publish-ready regardless of its score on this dimension.
+**Style rules (hard fail):** Real em dashes (`—`) are fine in prose; what fails is faking them with double hyphens (`--`). The guide must not contain emojis (decorative, status, or bullets — ✅ ❌ ⚠️ 🎉 🚀 💡 and similar). Use plain punctuation and Docusaurus admonitions (`:::note`, `:::tip`, `:::warning`, `:::danger`, `:::info`) instead. Code, config, CLI output, and quoted external content are exempt. A guide that violates either rule is not publish-ready regardless of its score on this dimension.
 
 **Acronym rule (hard fail):** Every acronym must be expanded on first use in the guide, formatted as full term followed by the acronym in parentheses (for example, `Pomerium Policy Language (PPL)`). Widely-understood internet-infrastructure acronyms (HTTP, HTTPS, URL, TLS, DNS, IP, JSON, YAML, API, SDK, CLI, UI, OS, SSO, OAuth, OIDC, SAML, JWT, CSV, PDF, CDN, SaaS, CI, CD, SQL, REST, RFC, and similar) are exempt. Product-specific or guide-local acronyms (for example TE, TI, AS, PRM, DCR, CIMD, PPL, IdP, SIEM, MCP) are not exempt. For long guides, reintroduce the full form at least once per major section, or substitute a descriptive noun (for example "the cached upstream token" instead of "the cached TI") so that readers who land mid-page are not forced to scroll back to the definition.
 
@@ -328,5 +328,5 @@ Before marking a guide ready for review:
 - The expected end state is explicit
 - The guide helps the reader decide whether to use this pattern
 - The guide can be skimmed without losing the implementation flow
-- No em dashes (`—`) or en dashes (`–`) in prose, and no emojis anywhere in the guide (see dimension 10 style rules)
+- No double-hyphen (`--`) fake em dashes in prose, and no emojis anywhere in the guide (see dimension 10 style rules)
 - Every product-specific or guide-local acronym is expanded on first use (see dimension 10 acronym rule)


### PR DESCRIPTION
Real em dashes are fine in guide prose. This flips the guide-review skill's blanket em/en-dash publish blocker (which the skill's own prose violated three times) into the rule we actually want: use a real em dash where the sentence calls for one, never fake it with a double hyphen (`--`), and don't lean on dashes so hard they crowd out ordinary punctuation. The same change lands in `references/rubric.md` (the hard-fail style rule and the author checklist) so the skill and the rubric it loads can't contradict each other.

## AI assistance

Claude drafted the wording change at my direction and ran the review loop (review-major-change.sh plus codex); both reviewers' only finding, that rubric.md still carried the old ban, is fixed in this commit. Nothing outside the guide-review skill is touched, and the repo format and cspell gates pass locally.