### PR TITLE
chore(sitemap): emit <lastmod> for faster Google recrawl

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -81,6 +81,8 @@ const config: Config = {
         },
         sitemap: {
           filename: 'docs/sitemap.xml',
+          // Emit <lastmod> so Google prioritizes recrawl of changed pages.
+          lastmod: 'date',
           // Keep the docs sitemap restricted to canonical docs routes.
           ignorePatterns: ['/', '/docs/examples/**', '/examples/**'],
         },

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -84,7 +84,14 @@ const config: Config = {
           // Emit <lastmod> so Google prioritizes recrawl of changed pages.
           lastmod: 'date',
           // Keep the docs sitemap restricted to canonical docs routes.
-          ignorePatterns: ['/', '/docs/examples/**', '/examples/**'],
+          ignorePatterns: [
+            '/',
+            '/blog',
+            '/blog/**',
+            '/category/**',
+            '/docs/examples/**',
+            '/examples/**',
+          ],
         },
       } satisfies Preset.Options,
     ],


### PR DESCRIPTION
## Summary

Improves the docs sitemap used at `https://www.pomerium.com/docs/sitemap.xml` after the OPE-315 Googlebot redirect-loop recovery.

Changes:

- Adds Docusaurus sitemap `lastmod: 'date'` so generated URLs carry source-backed `<lastmod>` values instead of omitting the tag entirely.
- Excludes `/blog`, `/blog/**`, and `/category/**` from the docs sitemap so the docs sitemap only advertises docs-owned URLs.

## Why

The redirect-loop fix makes docs fetchable again. This change gives Google a cleaner recrawl input after that fix:

- `<lastmod>` gives Google an explicit freshness signal for changed docs pages.
- Removing non-doc URLs avoids mixing marketing/blog/category discovery into the docs sitemap.

This is not the root-cause fix for deindexing. The root cause is fixed in infrastructure PR #449. This PR is the follow-up sitemap cleanup to speed and simplify recovery.

## Validation

Local production build verified:

- `CONTEXT=production BRANCH=main yarn build`
- Generated docs sitemap has 248 URLs.
- Generated docs sitemap has 0 `/blog` or `/category` URLs.
- Generated docs sitemap has real per-page `<lastmod>` values from source metadata, not one uniform build timestamp.

## Follow-up After Deploy

- Resubmit `https://www.pomerium.com/docs/sitemap.xml` in Search Console.
- Re-run URL Inspection on representative docs pages after Google has re-read the sitemap.

Tracking: OPE-315.

AI assistance: Codex and Claude helped draft and verify the sitemap changes. The generated sitemap output and production build were manually reviewed before handoff.
