### PR TITLE
docs: break up ppl criteria table

### DIFF
--- a/content/docs/internals/ppl.mdx
+++ b/content/docs/internals/ppl.mdx
@@ -152,9 +152,7 @@ deny:
 
 ### Supported PPL Criteria
 
-Below is an exhaustive list of PPL criteria.
-
-Entries marked with `*` denote criteria that are only available in the [Enterprise Console](/docs/deploy/enterprise) PPL builder. All other entries are available in both Pomerium Core and Pomerium Enterprise.
+Below are the available PPL criteria:
 
 | Criterion Name | Data Format | Description |
 | --- | --- | --- |
@@ -163,24 +161,36 @@ Entries marked with `*` denote criteria that are only available in the [Enterpri
 | `claim` | Anything. Typically a string. | Returns true if a token claim matches the supplied value **exactly**. The claim to check is determined via the sub-path. <br/> For example, `claim/family_name: Smith` matches if the user's `family_name` claim is `Smith`. |
 | `client_certificate` | [Certificate matcher] | Returns true if a client presented a TLS certificate matching the provided condition. |
 | `cors_preflight` | Anything. Typically `true`. | Returns true if the incoming request uses the `OPTIONS` method and has both the `Access-Control-Request-Method` and `Origin` headers. Used to allow [CORS pre-flight requests]. |
-| \* `date` | [Date Matcher] | Returns true if the time of the request matches the constraints. |
-| \* `day_of_week` | [Day of Week Matcher] | Returns true if the day of the request matches the constraints. |
 | `device` | [Device matcher] | Returns true if the incoming request includes a valid device ID or type. |
 | `domain` | [String Matcher] | Returns true if the logged-in user's email address domain (the part after `@`) matches the given value. |
 | `email` | [String Matcher] | Returns true if the logged-in user's email address matches the given value. |
-| \* `groups` | [String List Matcher] | Returns true if a user's group ID matches the supplied value **exactly**. `groups` data is only available after a successful directory sync. See [Identity Providers](/docs/integrations/user-identity/identity-providers) for vendor-specific directory sync steps. |
 | `http_method` | [String Matcher] | Returns true if the HTTP method matches the given value. |
 | `http_path` | [String Matcher] | Returns true if the HTTP path matches the given value. |
 | `mcp_tool` | [String Matcher] | Returns true if, for MCP routes, the tool name in a `tools/call` request matches the provided condition. Recommended to use under `deny` to block specific tools or classes of tools without affecting non-tool requests. See [Limit MCP Tool Calling](/docs/capabilities/mcp/limit-mcp-tools). |
 | `invalid_client_certificate` | Anything. Typically `true`. | Returns true if the incoming request does not have a trusted client certificate. By default, a `deny` rule using this criterion is added to all Pomerium policies when [downstream mTLS] is configured (but this default can be changed using the [Enforcement Mode](/docs/reference/downstream-mtls-settings#enforcement-mode) setting.) |
 | `pomerium_routes` | Anything. Typically `true`. | Returns true if the incoming request is for the special `.pomerium` routes. A default `allow` rule using this criterion is added to all Pomerium policies. |
-| \* `record` | variable | Allows policies to be extended using data from [external data sources](/docs/capabilities/integrations). See [Record Matcher](#record-matcher) for more information. |
 | `reject` | Anything. Typically `true`. | Always returns false. The opposite of `accept`. |
 | `source_ip` | String or list of strings, each containing an IP address or CIDR range. | Returns true if the incoming request was from an IP address matching any element of the list. |
-| \* `time_of_day` | [Time of Day Matcher] | Returns true if the time of the request (for the current day) matches the constraints. |
 | `user` | [String Matcher] | Returns `true` if the logged-in user's ID matches the supplied value. (The actual value of the user ID claim depends on how the identity provider sets this value.) |
 
-Entries marked with `*` denote criteria that are only available in the [Enterprise Console](/docs/deploy/enterprise) PPL builder. All other entries are available in both Pomerium Core and Pomerium Enterprise.
+### Zero or Enterprise PPL Criteria
+
+The following PPL criteria are available in Pomerium Zero or the [Enterprise Console](/docs/deploy/enterprise):
+
+| Criterion Name | Data Format | Description |
+| --- | --- | --- |
+| `date` | [Date Matcher] | Returns true if the time of the request matches the constraints. |
+| `day_of_week` | [Day of Week Matcher] | Returns true if the day of the request matches the constraints. |
+| `time_of_day` | [Time of Day Matcher] | Returns true if the time of the request (for the current day) matches the constraints. |
+
+### Enterprise PPL Criteria
+
+The following PPL criteria are only available in the [Enterprise Console](/docs/deploy/enterprise):
+
+| Criterion Name | Data Format | Description |
+| --- | --- | --- |
+| `groups` | [String List Matcher] | Returns true if a user's group ID matches the supplied value **exactly**. `groups` data is only available after a successful directory sync. See [Identity Providers](/docs/integrations/user-identity/identity-providers) for vendor-specific directory sync steps. |
+| `record` | variable | Allows policies to be extended using data from [external data sources](/docs/capabilities/integrations). See [Record Matcher](#record-matcher) for more information. |
 
 :::note Protocol applicability: SSH
 


### PR DESCRIPTION
## Summary
Break up the PPL criteria table into separate products.

## Related
- [ENG-2809](https://linear.app/pomerium/issue/ENG-2809/improve-distinction-of-ppl-criteria-for-open-corezeroenterprise)

## AI disclosure
No AI was used for this PR.

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated UPGRADING.md
- [ ] updated CHANGELOG.md
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
