### PR TITLE
docs(ssh): add interactive Native SSH guide link (#2277)

### DIFF
--- a/content/docs/capabilities/native-ssh-access.mdx
+++ b/content/docs/capabilities/native-ssh-access.mdx
@@ -25,6 +25,12 @@ import TabItem from '@theme/TabItem';
 
 Pomerium can be used as a native SSH reverse proxy, adding OAuth authentication and flexible Pomerium policy enforcement to standard SSH connections, without the need for tunnels, or custom clients or servers.
 
+:::tip Interactive Tutorial
+
+Try the [**Native SSH Access with Pomerium**](https://usepom.link/ssh-tutorial) interactive tutorial on iximiuz labs for a hands-on walkthrough. It's free to use, but you'll need to create an account.
+
+:::
+
 ## Overview
 
 ![Diagram](./img/ssh/diagram.svg)

--- a/cspell.json
+++ b/cspell.json
@@ -99,6 +99,7 @@
     "insecureskipverify",
     "isready",
     "istio",
+    "iximiuz",
     "jaegertracing",
     "jamf",
     "journalctl",


### PR DESCRIPTION
## Summary

Ran the backport script block from #2277 as labeling it for backport failed.

## AI disclosure

No AI was used.

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated UPGRADING.md
- [ ] updated CHANGELOG.md
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
