### PR TITLE
docs: correct localhost.pomerium.io resolution note (#2272)

### DIFF
--- a/content/docs/get-started/fundamentals/core/build-routes.md
+++ b/content/docs/get-started/fundamentals/core/build-routes.md
@@ -109,7 +109,7 @@ The `localhost` part is a **subdomain**, and `pomerium.io` is the **domain name*
 
 :::note
 
-We've hardcoded `localhost.pomerium.io` to always point to `127.0.0.1` so you can use it locally in your development environment.
+Any subdomain of `localhost.pomerium.io` (such as the `grafana.localhost.pomerium.io` route above) resolves to `127.0.0.1`, so you can reach your routes locally without editing `/etc/hosts`.
 
 :::
 


### PR DESCRIPTION
## What this fixes

Closes #2272. The Build Routes tutorial told readers that `localhost.pomerium.io` is "hardcoded to always point to `127.0.0.1`." That's only true for route hostnames under it: `*.localhost.pomerium.io` resolves to `127.0.0.1`, but the bare `localhost.pomerium.io` name has no A record, so `dig localhost.pomerium.io` comes back empty. The reporter read the note literally and hit the gap.

The tutorial itself was never broken: its route is `https://grafana.localhost.pomerium.io`, which resolves fine. Only the note's wording was wrong, and the Helm guide and the Kubernetes quickstart already describe the same behavior correctly as `*.localhost.pomerium.io`.

This reword brings the Build Routes note in line with those, pointing at the actual `grafana.localhost.pomerium.io` route from earlier on the page:

> Any subdomain of `localhost.pomerium.io` (such as the `grafana.localhost.pomerium.io` route above) resolves to `127.0.0.1`, so you can reach your routes locally without editing `/etc/hosts`.

This is a docs-only wording fix. A companion infra change (OPE-323) also adds the bare `localhost.pomerium.io` record so the apex resolves too, but the tutorial doesn't depend on it: its routes are all hostnames like `grafana.localhost.pomerium.io`, and no route URL uses `https://localhost.pomerium.io` directly.

## Validation

- [x] `yarn format-check`
- [x] `yarn cspell "**/*"`
- [x] `yarn build` (no new broken anchors)
- [x] `git diff --check`

## AI assistance

Claude observed the DNS behavior with `dig` (empty bare name, resolving subdomain), grepped the docs to confirm no route URL uses `https://localhost.pomerium.io`, and reworded the note to match the Helm guide and the Kubernetes quickstart. Codex reviewed the change. Reviewed manually before commit.
