### PR TITLE
force upgrade of ip-address package

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "dompurify": ">=3.3.2",
     "fast-uri": ">=3.1.2",
     "fast-xml-parser": ">=5.5.7",
+    "ip-address": ">=10.1.1",
     "lodash": ">=4.18.1",
     "lodash-es": ">=4.18.1",
     "path-to-regexp": "^0.1.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7833,13 +7833,10 @@ invariant@^2.2.4:
   dependencies:
     loose-envify "^1.0.0"
 
-ip-address@^9.0.5:
-  version "9.0.5"
-  resolved "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz"
-  integrity sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==
-  dependencies:
-    jsbn "1.1.0"
-    sprintf-js "^1.1.3"
+ip-address@>=10.1.1, ip-address@^9.0.5:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.2.0.tgz#805fc178b20c518bd4c8548b24fe30892d7f3206"
+  integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==
 
 ipaddr.js@1.9.1:
   version "1.9.1"
@@ -8141,11 +8138,6 @@ js-yaml@^4.1.0, js-yaml@^4.1.1, js-yaml@^4.2.0:
   integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
   dependencies:
     argparse "^2.0.1"
-
-jsbn@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz"
-  integrity sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==
 
 jsesc@^3.0.2, jsesc@~3.1.0:
   version "3.1.0"
@@ -12280,11 +12272,6 @@ spdy@^4.0.2:
     http-deceiver "^1.2.7"
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
-
-sprintf-js@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz"
-  integrity sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
## Summary

Add a 'resolutions' override to update the `ip-address` package, to get the patch for CVE-2026-42338.

## Related

- https://github.com/pomerium/documentation/security/dependabot/140

## AI disclosure

none

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated UPGRADING.md
- [ ] updated CHANGELOG.md
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
