### PR TITLE
docs: fix code-block highlighted-line layout breakage (#2281)

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -249,3 +249,13 @@ td > .theme-code-block:last-child {
 .fab {
   font-family: 'Font Awesome 6 Brands';
 }
+
+/* Pin highlighted lines to table-row in numbered code blocks. Docusaurus's
+   `display: block` highlight rule has equal specificity to the table-row rule,
+   so unstable CSS bundle order can let `block` win and shatter the line-number
+   table (#2281, facebook/docusaurus#3678). Higher specificity settles it.
+   Don't remove: the breakage is invisible in `yarn start` and only shows in
+   production bundles. */
+[class*='codeBlockLinesWithNumbering'] .theme-code-block-highlighted-line {
+  display: table-row;
+}


### PR DESCRIPTION
Fixes #2281.

## What was wrong

On code blocks with line numbers, the highlighted line could break the layout: most lines got pushed sideways off the right edge (the `verify-ingress.yaml` block on the K8s quickstart is the reported case). It showed up on the live site but not in `yarn start`, which is why it was hard to pin down.

## Root cause

Line-numbered code blocks render each line as `display: table-row`, so the `<code>` element forms an anonymous CSS table. Docusaurus styles the highlighted line as `display: block`, and that rule has the *same* specificity as the table-row rule. Which one wins is decided purely by the order `mini-css-extract-plugin` emits them, and that order is not stable across builds. The deployed bundle happened to put `display: block` last, so the highlighted line became a block box among table-rows and split the table into fragments that size independently. Dev mode injects CSS in source order, where table-row wins, so it looked fine locally. The Docusaurus theme CSS itself flags this specificity hazard (facebook/docusaurus#3678).

This is global, not specific to the reported page: every numbered-and-highlighted code block in the docs was affected on that build, and a future rebuild could flip the order back with no code change.

## Fix

One CSS rule that pins highlighted lines back to `table-row` in numbered blocks, with a higher-specificity selector so bundle order can no longer decide it. Highlighted lines in non-numbered blocks are untouched.

## Verification

Built for production and served locally, then swept all 12 docs pages that contain a highlighted code block, with the worst-case `display: block` rule force-injected. Every numbered-and-highlighted block (6) renders `table-row` and stays aligned; every non-numbered highlighted block (12) stays `block` and is unchanged. Light and dark mode both checked; the highlight background still paints.

## AI assistance

Claude drafted the CSS fix and this description, and ran the production-build browser verification. I reviewed the root-cause analysis and confirmed the diff and the cross-page sweep results manually.
