### PR TITLE
docs: re-pin hedgedoc image to live 1.10.8 digest

### DIFF
--- a/content/examples/guides/hedgedoc/docker-compose.yaml
+++ b/content/examples/guides/hedgedoc/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
 
   hedgedoc:
     # Check https://hedgedoc.org/latest-release for the current stable release.
-    image: quay.io/hedgedoc/hedgedoc@sha256:423f411721e70969332ba04ae434a1d643f3572f4966817c15c7b493ab3e448d # 1.10.8
+    image: quay.io/hedgedoc/hedgedoc@sha256:abdb6b08815d5bc5832b52d983d983ac678895e9fa0d76aaad80d08c5d70812b # 1.10.8
     environment:
       - CMD_DB_URL=postgres://hedgedoc:password@database:5432/hedgedoc
       - CMD_DOMAIN=hedgedoc.yourdomain.com

--- a/content/examples/guides/hedgedoc/docker-compose.yaml.md
+++ b/content/examples/guides/hedgedoc/docker-compose.yaml.md
@@ -12,7 +12,7 @@ services:
 
   hedgedoc:
     # Check https://hedgedoc.org/latest-release for the current stable release.
-    image: quay.io/hedgedoc/hedgedoc@sha256:423f411721e70969332ba04ae434a1d643f3572f4966817c15c7b493ab3e448d # 1.10.8
+    image: quay.io/hedgedoc/hedgedoc@sha256:abdb6b08815d5bc5832b52d983d983ac678895e9fa0d76aaad80d08c5d70812b # 1.10.8
     environment:
       - CMD_DB_URL=postgres://hedgedoc:password@database:5432/hedgedoc
       - CMD_DOMAIN=hedgedoc.yourdomain.com

--- a/content/examples/guides/hedgedoc/validate/compose.validate.yaml
+++ b/content/examples/guides/hedgedoc/validate/compose.validate.yaml
@@ -24,7 +24,7 @@ services:
           - database
 
   hedgedoc:
-    image: quay.io/hedgedoc/hedgedoc@sha256:423f411721e70969332ba04ae434a1d643f3572f4966817c15c7b493ab3e448d # 1.10.8
+    image: quay.io/hedgedoc/hedgedoc@sha256:abdb6b08815d5bc5832b52d983d983ac678895e9fa0d76aaad80d08c5d70812b # 1.10.8
     environment:
       CMD_DB_URL: postgres://hedgedoc:password@database:5432/hedgedoc
       CMD_DOMAIN: hedgedoc.localhost.pomerium.io


### PR DESCRIPTION
## What

The scheduled `validate-examples` workflow ([run 28283214920](https://github.com/pomerium/documentation/actions/runs/28283214920)) failed on `validate (hedgedoc)`:

```
quay.io/hedgedoc/hedgedoc@sha256:423f411... -> manifest unknown
```

HedgeDoc rebuilt and re-pushed the `1.10.8` tag under a new digest, and quay.io garbage-collected the old orphaned manifest. Verified against the registry: old digest -> HTTP 404, tag `1.10.8` now -> `sha256:abdb6b08...` -> HTTP 200.

## Fix

Re-pin to the live `1.10.8` digest in the three files that carry it (same version, comment unchanged):

- `content/examples/guides/hedgedoc/docker-compose.yaml`
- `content/examples/guides/hedgedoc/docker-compose.yaml.md`
- `content/examples/guides/hedgedoc/validate/compose.validate.yaml`

Kept the digest pin rather than floating to `:1.10.8` so CI stays reproducible and tag drift fails loudly instead of silently pulling different bytes.

## Verification

Ran the exact CI command locally: `scripts/validate-guide-fixtures.sh hedgedoc` -> `>> hedgedoc: PASS`, all 3 Playwright assertions green.

## Follow-up (not this PR)

This is the second quay mutable-tag GC to break a pinned digest. Worth a Renovate/dependabot digest-bump config so the next one is a bot PR, not a manual fix.

## AI assistance

Claude (Opus 4.8) diagnosed the failure, verified the registry state, drafted the digest change and this PR body. Bobby reviewed and triggered the fix. Manual verification: `scripts/validate-guide-fixtures.sh hedgedoc` run locally to PASS before push.