### PR TITLE
docs: cache /docs/* and llms.txt at Netlify's CDN

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -3,3 +3,16 @@
 
 /assets/*
   Cache-Control: public, max-age=31536000, immutable
+
+# s-maxage lets the user-facing GCP Cloud CDN cache pages and .md for 5 min; its
+# CACHE_ALL_STATIC mode skips html/markdown without an explicit directive. Short,
+# since GCP isn't purged on deploy.
+/docs/*
+  Cache-Control: public, max-age=0, s-maxage=300, must-revalidate
+
+# /docs.md is a sibling of /docs/, not under it, so the splat above misses it.
+/docs.md
+  Cache-Control: public, max-age=0, s-maxage=300, must-revalidate
+
+/llms*.txt
+  Cache-Control: public, max-age=0, s-maxage=300, must-revalidate


### PR DESCRIPTION
## What
Make the user-facing GCP Cloud CDN cache docs pages, `.md` sidecars, and `llms*.txt`. Added to `static/_headers`:

```
/docs/*      Cache-Control: public, max-age=0, s-maxage=300, must-revalidate
/docs.md     same   # landing sidecar, sibling of /docs/, not matched by the splat
/llms*.txt   same   # llms.txt, llms-full.txt, llms-index.txt
```

## Why
Users and agents hit GCP Cloud CDN (www.pomerium.com -> GCP LB -> Netlify). Verified live: the docs backend is `enableCDN: true`, `cacheMode: CACHE_ALL_STATIC`, and prod responses are `Cache-Control: public, max-age=0, must-revalidate` -> GCP caches nothing for docs or `.md` (`age: 0` on repeat). `CACHE_ALL_STATIC` does not cache `text/html`/`text/markdown` without an explicit positive directive, so every agent `.md` fetch is a full GCP -> Netlify round-trip. (Confirmed GCP does cache on this backend: an immutable asset's `age` climbs across requests.)

`s-maxage=300` gives GCP an explicit directive, so it caches pages and `.md` for 5 min, then revalidates. GCP isn't purged on a Netlify deploy, so post-publish staleness is bounded to ~5 min (`s-maxage`/`must-revalidate` stop Cloud CDN from serving stale past expiry, so the backend's `serveWhileStale: 86400` doesn't extend it). Browsers keep `max-age=0, must-revalidate`.

No `Netlify-CDN-Cache-Control` second layer: the origin is a prebuilt static file, so Netlify serving GCP's 5-min revalidation pulls is already cheap. Chose the static `.md` surface over per-request `Accept: text/markdown` negotiation, which needs an edge function plus `Vary: Accept` and fragments the cache.

## Verify
Post-merge on www.pomerium.com: `curl -sS -D- -o /dev/null <url>` (GET -- Cloud CDN only stores GET) on a docs page and its `.md` twice; request #2 should show a rising `age`. Confirm client-facing `Cache-Control` is `public, max-age=0, s-maxage=300, must-revalidate` and `X-Robots-Tag` is unchanged. (Can't validate on the Netlify preview -- it isn't behind GCP.)

## AI assistance
Claude (Opus 4.8) wrote the `_headers` change and this body. Verified against the live GCP backend (`gcloud compute backend-services describe`) and prod response headers, confirmed `build/docs.md` + `.md` sidecars + `build/llms*.txt` match the globs, and that the diff applies to origin/main. GCP cache-hit on docs is verified post-merge per Verify.
