### PR TITLE
docs: advertise per-page markdown to LLM agents; fix llms.txt + sidecar 404s

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -38,7 +38,7 @@ const config: Config = {
       tagName: 'link',
       attributes: {
         rel: 'alternate',
-        type: 'text/plain',
+        type: 'text/markdown',
         href: '/llms.txt',
         title: 'LLM-readable documentation',
       },

--- a/plugins/llms-txt-plugin.js
+++ b/plugins/llms-txt-plugin.js
@@ -698,6 +698,16 @@ function buildRouteMarkdownOutputPaths(route, docsRoot) {
       sourceSidecarRoutePath,
     );
     if (sourceSidecarOutputPath) outputPaths.add(sourceSidecarOutputPath);
+
+    // Also emit the flat `.md` for the source-filename path, so URLs guessed
+    // from the source filename resolve when frontmatter `id:` moved the route
+    // (e.g. pass-identity-headers.mdx -> .../pass-identity-headers.md). A future
+    // rename that makes this collide with another route's path fails loud via
+    // validateRouteMarkdownCollisions rather than silently overwriting.
+    const sourceCanonicalOutputPath = buildCanonicalMarkdownOutputPath(
+      sourceSidecarRoutePath,
+    );
+    if (sourceCanonicalOutputPath) outputPaths.add(sourceCanonicalOutputPath);
   }
 
   return [...outputPaths];
@@ -1480,6 +1490,26 @@ async function pluginLlmsTxt(context) {
         );
         await fs.promises.writeFile(
           path.join(outDir, 'llms-index.txt'),
+          finalLlmsIndexTxt,
+          'utf8',
+        );
+
+        // Mirror under /docs/ so the docs-prefixed guess-path resolves too.
+        // Root stays canonical; these inherit the existing /docs/* cache header.
+        const docsDir = path.join(outDir, 'docs');
+        await fs.promises.mkdir(docsDir, {recursive: true});
+        await fs.promises.writeFile(
+          path.join(docsDir, 'llms-full.txt'),
+          finalLlmsFullTxt,
+          'utf8',
+        );
+        await fs.promises.writeFile(
+          path.join(docsDir, 'llms.txt'),
+          finalLlmsTxt,
+          'utf8',
+        );
+        await fs.promises.writeFile(
+          path.join(docsDir, 'llms-index.txt'),
           finalLlmsIndexTxt,
           'utf8',
         );

--- a/src/theme/DocItem/Metadata/index.js
+++ b/src/theme/DocItem/Metadata/index.js
@@ -14,11 +14,11 @@ export default function MetadataWrapper(props) {
   const {permalink} = metadata;
   // Advertise the .md twin only where it's a genuine upgrade over the HTML. Skip:
   // - the '/' docs instance (home, /examples): no sidecar generated -> would 404.
-  // - /docs/api/*: ApiItem renders the full OpenAPI schema in HTML; the generated
-  //   sidecar there is a sub-50-byte stub, strictly worse than the page.
-  const advertiseMarkdown =
-    (permalink === '/docs' || permalink.startsWith('/docs/')) &&
-    !permalink.startsWith('/docs/api/');
+  // - the /docs/api tree: ApiItem renders the full OpenAPI schema in HTML; the
+  //   generated sidecars are sub-50-byte stubs, strictly worse than the page.
+  const isDocs = permalink === '/docs' || permalink.startsWith('/docs/');
+  const isApi = permalink === '/docs/api' || permalink.startsWith('/docs/api/');
+  const advertiseMarkdown = isDocs && !isApi;
   return (
     <>
       <Metadata {...props} />

--- a/src/theme/DocItem/Metadata/index.js
+++ b/src/theme/DocItem/Metadata/index.js
@@ -1,0 +1,37 @@
+import Head from '@docusaurus/Head';
+import {useDoc} from '@docusaurus/plugin-content-docs/client';
+import Metadata from '@theme-original/DocItem/Metadata';
+import React from 'react';
+
+// Point LLM agents at this page's clean markdown twin. An agent that lands on
+// the HTML page (via web search) otherwise has no machine-readable pointer to
+// the small, self-contained `.md` and ingests the full HTML instead.
+// Swizzling DocItem/Metadata (not DocItem/Layout) so this fires for every doc
+// page regardless of `docItemComponent` -- ApiItem also renders this component.
+// `${permalink}.md` matches the canonical sidecar emitted by llms-txt-plugin.
+export default function MetadataWrapper(props) {
+  const {metadata} = useDoc();
+  const {permalink} = metadata;
+  // Advertise the .md twin only where it's a genuine upgrade over the HTML. Skip:
+  // - the '/' docs instance (home, /examples): no sidecar generated -> would 404.
+  // - /docs/api/*: ApiItem renders the full OpenAPI schema in HTML; the generated
+  //   sidecar there is a sub-50-byte stub, strictly worse than the page.
+  const advertiseMarkdown =
+    (permalink === '/docs' || permalink.startsWith('/docs/')) &&
+    !permalink.startsWith('/docs/api/');
+  return (
+    <>
+      <Metadata {...props} />
+      {advertiseMarkdown && (
+        <Head>
+          <link
+            rel="alternate"
+            type="text/markdown"
+            href={`${permalink.replace(/\/$/, '')}.md`}
+            title="Markdown version of this page"
+          />
+        </Head>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

LLM agents that land on a docs HTML page (via web search) had no machine-readable pointer to the clean per-page markdown, so they ingest the full HTML (~160KB of nav chrome) instead of the ~8KB `.md`. GCP LB access logs confirm real agent traffic already pulling `.md` (ChatGPT-User, DuckAssistBot) plus `/docs/llms.txt` 404s and slug-mismatched `.md` 404s.

This raises docs "LLM-ability" using **static build output only** — no Netlify redirects or edge functions.

- **Per-page markdown discovery** — new swizzle `src/theme/DocItem/Metadata/index.js` injects `<link rel="alternate" type="text/markdown" href="{page}.md">` into each doc page's `<head>`. Swizzles `DocItem/Metadata` (not `DocItem/Layout`) so it fires under `docItemComponent: '@theme/ApiItem'`. Gated to `/docs` content pages — excludes the `/` docs instance (home, `/examples`; no sidecars) and `/docs/api/*` (OpenAPI pages whose generated sidecars are sub-50-byte stubs, strictly worse than the rendered HTML).
- **`/docs/llms*.txt` copies** — `llms-txt-plugin` also writes `build/docs/llms{,-full,-index}.txt` so the docs-prefixed path resolves; root stays canonical.
- **Slug/id-mismatch sidecars** — emit the flat source-filename `.md` when frontmatter `id`/`slug` remaps a route (e.g. `pass-identity-headers.md`).
- **Global llms link** type `text/plain` → `text/markdown`.

### Validation

- `yarn build` green (node 22.22.2), `yarn format` clean.
- End-to-end over local HTTP serve: `/docs/*` HTML carries the link; advertised `.md` serves `200 text/markdown`; `/docs/llms.txt` `200`; slug-alias `200`; API pages + home carry no per-page link.
- Artifact sweep: 220 advertised links, 0 broken, all targets substantial (one accepted 147B section-landing signpost at `/docs/reference`).

## Related

Docs LLM-serving follow-up to #2273 (static `.md`) and #2291 (CDN caching).

## AI disclosure

Claude Code (Opus 4.8) drafted the swizzle, the `llms-txt-plugin` edits, and the initial 404 triage from access logs. Reviewed by Claude, Codex (high reasoning), and a Docusaurus/React domain agent: Codex caught a home/`/examples` 404 regression and the domain agent caught the `/docs/api/*` stub issue — both fixed; a proposed build-time guard was removed as over-engineered. Build, format, end-to-end HTTP checks, and the artifact sweep were run and confirmed before pushing.

## Checklist

- [ ] reference any related issues
- [x] updated docs
- [ ] updated UPGRADING.md
- [ ] updated CHANGELOG.md
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
