### PR TITLE
docs: fix stale version pins and typos

### DIFF
--- a/content/docs/capabilities/getting-users-identity.mdx
+++ b/content/docs/capabilities/getting-users-identity.mdx
@@ -1,5 +1,5 @@
 ---
-# cSpell:ignore ecparam genkey noout pubout secp256r1 QCN7adG2AmIK3UdHJvVJkldsUc6XeBRz83Z4rXX8Va4 ary66nrvA55TpaiWADq8b3O1CYIbvjqIHpXCY envoyproxy Jklds Tpai Ibvjq Lamda
+# cSpell:ignore ecparam genkey noout pubout secp256r1 QCN7adG2AmIK3UdHJvVJkldsUc6XeBRz83Z4rXX8Va4 ary66nrvA55TpaiWADq8b3O1CYIbvjqIHpXCY envoyproxy Jklds Tpai Ibvjq
 
 title: Continuous Identity Verification at the Application Layer
 description: Learn how Pomerium uses JWTs for identity and context verification, how it fits into a zero trust environment, and four ways to validate the JWT in your upstream service.

--- a/content/docs/deploy/k8s/ingress.md
+++ b/content/docs/deploy/k8s/ingress.md
@@ -376,7 +376,7 @@ Each Ingress should be backed by a Service. Pomerium supports certain extensions
 
 ### Native SSH
 
-Pomerium can directly proxy SSH connections. See [Native SSH Access](/docs/capabilities/native-ssh-access) for information about this capabilitiy.
+Pomerium can directly proxy SSH connections. See [Native SSH Access](/docs/capabilities/native-ssh-access) for information about this capability.
 
 To configure a native SSH route, you will need to:
 

--- a/content/docs/deploy/k8s/install.md
+++ b/content/docs/deploy/k8s/install.md
@@ -78,7 +78,7 @@ kustomize build config/default
 
 ```yaml title="kustomization.yaml"
 resources:
-  - https://raw.githubusercontent.com/pomerium/ingress-controller/v0.22.1/deployment.yaml
+  - https://raw.githubusercontent.com/pomerium/ingress-controller/v0.32.0/deployment.yaml
 patches:
   - path: patch-proxy-external-dns.yaml
 ```
@@ -105,7 +105,7 @@ You must configure [storage persistence](/docs/internals/data-storage) in order 
 
 ```yaml title="kustomization.yaml"
 resources:
-  - https://raw.githubusercontent.com/pomerium/ingress-controller/v0.22.1/deployment.yaml
+  - https://raw.githubusercontent.com/pomerium/ingress-controller/v0.32.0/deployment.yaml
 patches:
   - path: deployment.yaml
 ```
@@ -126,7 +126,7 @@ An `IngressClass` may be designated as a [default controller](https://kubernetes
 
 ```yaml title="kustomization.yaml"
 resources:
-  - https://raw.githubusercontent.com/pomerium/ingress-controller/v0.22.0/deployment.yaml
+  - https://raw.githubusercontent.com/pomerium/ingress-controller/v0.32.0/deployment.yaml
 patches:
   - path: patch-proxy-external-dns.yaml
 ```

--- a/content/docs/guides/homelab-pipeline.mdx
+++ b/content/docs/guides/homelab-pipeline.mdx
@@ -1167,7 +1167,7 @@ This example is based on a real lab. At the time of writing, that cluster was ru
 | Talos              | `v1.12.2`                       |
 | Argo CD            | `v3.1.0`                        |
 | Pomerium           | `git-7cb5e0f7`                  |
-| Terraform provider | `pomerium/pomerium v0.32.101`   |
+| Terraform provider | `pomerium/pomerium v0.32.0`     |
 | Nodes              | 9 total (3 CP + 3 HP + 3 Std)   |
 | Control plane VIP  | `192.168.10.10`                 |
 | MetalLB range      | `192.168.10.100-192.168.10.110` |


### PR DESCRIPTION
Anyone copying the External-DNS, multi-replica, or IngressClass examples on the Kubernetes install page gets an ingress-controller pinned to v0.22.x — ten minor versions behind the v0.32.0 install command at the top of the same page. All three kustomization examples now pin v0.32.0.

Two smaller fixes ride along: the homelab pipeline guide listed Terraform provider `pomerium/pomerium v0.32.101`, a version that does not exist — now v0.32.0; and a typo plus a leftover cSpell suppression for a misspelling that no longer exists in the file.

Verified with: `yarn format-check && yarn cspell && yarn build` (all pass; `yarn cspell` runs `cspell --gitignore .`), `curl -sI https://raw.githubusercontent.com/pomerium/ingress-controller/v0.32.0/deployment.yaml` (200), and the Terraform registry versions API (`/v1/providers/pomerium/pomerium/versions` lists no 0.32.101; latest is 0.32.0).

**AI assistance:** AI (Claude) ran the docs-vs-code audit and drafted this diff; the version claims were verified with the commands above. Human review happens in this PR.
