### PR TITLE
docs: resolve all broken links in the settings reference table

### DIFF
--- a/content/docs/reference/_manage-devices.md
+++ b/content/docs/reference/_manage-devices.md
@@ -1,6 +1,0 @@
-From this page, administrators can manage new and existing device enrollments.
-
-Device enrollment lets you create [policies](/docs/internals/ppl#device-matcher) that use [device identity](/docs/integrations/device-context/device-identity).
-
-- Users can [self-enroll](/docs/integrations/device-context/device-identity) devices, which must then be approved in the **Devices List** for policies requiring approved devices.
-- Administrators can use the **New Enrollment** button to create a link for the user to enroll a device as pre-approved. See our [Pre-Approved Device Enrollment](/docs/guides/admin-enroll-device) guide for more information.

--- a/content/docs/reference/_new-enrollment.md
+++ b/content/docs/reference/_new-enrollment.md
@@ -1,3 +1,0 @@
-The **New Enrollment** button allows administrators to create a custom link for a specific user to use to register a new device, which will automatically be approved. This scheme is known as [Trust on First Use (TOFU)](https://en.wikipedia.org/wiki/Trust_on_first_use).
-
-![Example device enrollment](./img/new-enrollment.png)

--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -188,11 +188,13 @@
   "circuit-breaker-thresholds": {
     "description": "Customizes circuit-breaking behavior in Pomerium.",
     "id": "circuit-breaker-thresholds",
+    "path": "/circuit-breaker-thresholds",
     "title": "Circuit Breaker Thresholds"
   },
   "cluster-identity": {
     "description": "The cluster token that associates this cluster with a personal account or organization.",
     "id": "cluster-identity",
+    "path": "/../internals/clusters#cluster-token",
     "title": "Cluster Identity"
   },
   "cluster-name": {
@@ -206,11 +208,13 @@
   "cluster-settings-name": {
     "description": "A customizable name that identifies a cluster. Defaults to the cluster's randomly generated starter domain name.",
     "id": "cluster-settings-name",
+    "path": "/../internals/clusters#cluster-name",
     "title": "Cluster Name"
   },
   "cluster-starter-domain": {
     "description": "The randomly generated starter domain assigned to this cluster. This domain is not changeable, and is designed to be used as a proof of concept.",
     "id": "cluster-starter-domain",
+    "path": "/../internals/clusters#starter-domain",
     "title": "Cluster Starter Domain"
   },
   "codec-type": {
@@ -260,7 +264,7 @@
   },
   "data-broker-service": {
     "id": "data-broker-service",
-    "path": "/databroker#databroker-service",
+    "path": "/databroker",
     "services": ["databroker"],
     "title": "Databroker Service"
   },
@@ -303,7 +307,7 @@
   "default-upstream-timeout": {
     "description": "Sets the default timeout applied to a proxied route when no timeout key is specified by the policy.",
     "id": "default-upstream-timeout",
-    "path": "/default-upstream-timeout",
+    "path": "/global-timeouts",
     "services": [],
     "title": "Default Upstream Timeout",
     "type": ""
@@ -319,13 +323,14 @@
   "detected-ip-address": {
     "description": "The IP address detected for this cluster server.",
     "id": "detected-ip-address",
+    "path": "/../internals/clusters#detected-and-override-ip-address",
     "title": "Detected IP Address"
   },
   "devices": {
     "description": "Introduced in v0.16.0, the Manage Devices page lets administrators manage user devices for policy-based authorization.",
     "enterpriseOnly": true,
     "id": "devices",
-    "path": "/../enterprise/reference/manage#devices",
+    "path": "/../integrations/device-context/webauthn#manage-devices-enterprise",
     "title": "Devices"
   },
   "direct-response": {
@@ -466,15 +471,8 @@
     "description": "Specify if the user can enroll any device identity, or restrict it to a secure enclave.",
     "enterpriseOnly": true,
     "id": "enrollment-type",
-    "path": "/../capabilities/device-identity#new-enrollment",
+    "path": "/../integrations/device-context/webauthn#enroll-devices-as-an-administrator-enterprise",
     "title": "Enrollment Type"
-  },
-  "envoy-bootstrap-options": {
-    "id": "envoy-bootstrap-options",
-    "path": "/envoy-bootstrap-options",
-    "services": [],
-    "title": "Envoy Bootstrap Options",
-    "type": "string"
   },
   "error-message-header": {
     "description": "A paragraph that will appear on all Route Error Pages in the top section.",
@@ -761,7 +759,7 @@
     "description": "Choose from a list of supported IDPs.",
     "enterpriseOnly": true,
     "id": "identity-provider",
-    "path": "/../identity-providers",
+    "path": "/../integrations/user-identity/identity-providers",
     "title": "Identity Provider",
     "type": "string"
   },
@@ -865,7 +863,7 @@
     "description": "Click for information on Auth0",
     "enterpriseOnly": true,
     "id": "idp-options-auth0",
-    "path": "/../integrations/auth0",
+    "path": "/../integrations/user-identity/auth0",
     "title": "Identity Provider Auth0",
     "type": "string"
   },
@@ -873,7 +871,7 @@
     "description": "Click for information on Microsoft Entra ID",
     "enterpriseOnly": true,
     "id": "idp-options-azure",
-    "path": "/../integrations/azure",
+    "path": "/../integrations/user-identity/azure",
     "title": "Identity Provider Microsoft Entra ID",
     "type": "string"
   },
@@ -881,7 +879,7 @@
     "description": "Click for information on Github",
     "enterpriseOnly": true,
     "id": "idp-options-github",
-    "path": "/../integrations/github",
+    "path": "/../integrations/user-identity/github",
     "title": "Identity Provider Github",
     "type": "string"
   },
@@ -889,7 +887,7 @@
     "description": "Click for information on Gitlab",
     "enterpriseOnly": true,
     "id": "idp-options-gitlab",
-    "path": "/../integrations/gitlab",
+    "path": "/../integrations/user-identity/gitlab",
     "title": "Identity Provider Gitlab",
     "type": "string"
   },
@@ -897,7 +895,7 @@
     "description": "Click for information on getting a service account from Google.",
     "enterpriseOnly": true,
     "id": "idp-options-google",
-    "path": "/../integrations/google",
+    "path": "/../integrations/user-identity/google",
     "title": "Identity Provider Google",
     "type": "string"
   },
@@ -905,7 +903,7 @@
     "description": "Click for information on Keycloak",
     "enterpriseOnly": true,
     "id": "idp-options-keycloak",
-    "path": "/../integrations/keycloak",
+    "path": "/../integrations/user-identity/keycloak",
     "title": "Identity Provider Keycloak",
     "type": "string"
   },
@@ -913,7 +911,7 @@
     "description": "Click for information on Okta.",
     "enterpriseOnly": true,
     "id": "idp-options-okta",
-    "path": "/../integrations/okta",
+    "path": "/../integrations/user-identity/okta",
     "title": "Identity Provider Okta",
     "type": "string"
   },
@@ -921,7 +919,7 @@
     "description": "Click for information on Onelogin.",
     "enterpriseOnly": true,
     "id": "idp-options-onelogin",
-    "path": "/../integrations/one-login",
+    "path": "/../integrations/user-identity/one-login",
     "title": "Identity Provider Onelogin",
     "type": "string"
   },
@@ -929,7 +927,7 @@
     "description": "Click for information on Ping.",
     "enterpriseOnly": true,
     "id": "idp-options-ping",
-    "path": "/../integrations/ping",
+    "path": "/../integrations/user-identity/ping",
     "title": "Identity Provider Ping",
     "type": "string"
   },
@@ -991,7 +989,7 @@
   "kubernetes-service-account-token-file": {
     "description": "File location containing a Kubernetes bearer token.",
     "id": "kubernetes-service-account-token-file",
-    "path": "/routes/kubernetes-service-account-token-file",
+    "path": "/routes/kubernetes-service-account-token",
     "services": ["proxy"],
     "title": "Kubernetes Service Account Token File",
     "type": "string"
@@ -1036,7 +1034,7 @@
   "manage-devices": {
     "enterpriseOnly": true,
     "id": "manage-devices",
-    "path": "/../capabilities/device-identity",
+    "path": "/../integrations/device-context/webauthn#manage-devices-enterprise",
     "title": "Manage Devices"
   },
   "mcp-allowed-as-metadata-domains": {
@@ -1175,12 +1173,13 @@
     "description": "A way to migrate routes from an existing Open Source Pomerium config file. You probably only want to do this once.",
     "enterpriseOnly": true,
     "id": "migrate-routes",
+    "path": "/../capabilities/routing",
     "title": "Migrate Routes"
   },
   "new-enrollment": {
     "enterpriseOnly": true,
     "id": "new-enrollment",
-    "path": "/../capabilities/device-identity#new-enrollment",
+    "path": "/../integrations/device-context/webauthn#new-enrollment-enterprise",
     "title": "New Enrollment"
   },
   "outlier-detection": {
@@ -1201,6 +1200,7 @@
   "override-ip-address": {
     "description": "Manually sets the IP address of this cluster and overrides the detected IP. Use this setting if Pomerium can't connect to cluster over detected IP.",
     "id": "override-ip-address",
+    "path": "/../internals/clusters#detected-and-override-ip-address",
     "title": "Override IP Address"
   },
   "pass-identity-headers": {
@@ -1215,7 +1215,7 @@
   "pass-identity-headers-per-route": {
     "description": "If applied, passes X-Pomerium-Jwt-Assertion header and JWT Claims Headers to the upstream application.",
     "id": "pass-identity-headers-per-route",
-    "path": "/routes/pass-identity-headers-per-route",
+    "path": "/routes/pass-identity-headers",
     "services": ["proxy"],
     "short_description": "",
     "title": "Pass Identity Headers (per route)",
@@ -1256,6 +1256,7 @@
   "policy-definition": {
     "description": "Adds the explanation presented to an unauthorized user when they access a route with this policy. Optional.",
     "id": "policy-definition",
+    "path": "/../capabilities/self-remediation",
     "services": [],
     "title": "Definition",
     "type": "string"
@@ -1263,23 +1264,26 @@
   "policy-description": {
     "description": "Adds an optional description for this policy.",
     "id": "policy-description",
+    "path": "/../capabilities/authorization",
     "title": "Policy Description"
   },
   "policy-enforcement": {
     "description": "Determines if a policy applies to all routes or can be applied optionally to a given route.",
     "id": "policy-enforcement",
+    "path": "/../internals/namespacing#hierarchical-policy-enforcement",
     "title": "Policy Enforcement"
   },
   "policy-explanation": {
     "description": "Adds the explanation presented to an unauthorized user when they access a route with this policy. Optional.",
     "id": "policy-explanation",
+    "path": "/../capabilities/self-remediation",
     "services": [],
     "title": "Explanation",
     "type": "string"
   },
   "policy-inheritance": {
     "id": "policy-inheritance",
-    "path": "/../capabilities/namespacing#hierarchical-policy-enforcement",
+    "path": "/../internals/namespacing#hierarchical-policy-enforcement",
     "services": [],
     "title": "Enforcement",
     "type": "string"
@@ -1288,6 +1292,7 @@
     "description": "Adds the message, warning, or instructions presented to an unauthorized user to help them self-remediate. Optional.",
     "enterpriseOnly": "true",
     "id": "policy-remediation",
+    "path": "/../capabilities/self-remediation",
     "services": [],
     "title": "Remediation",
     "type": "string"
@@ -1409,7 +1414,7 @@
     "description": "Optional: The URL the user will be taken to after device enrollment is successful.",
     "enterpriseOnly": true,
     "id": "redirect-url",
-    "path": "/../capabilities/device-identity#create-an-enrollment-link",
+    "path": "/../integrations/device-context/webauthn#enroll-devices-as-an-administrator-enterprise",
     "title": "Redirect URL"
   },
   "regex": {
@@ -1533,7 +1538,7 @@
     "description": "New Enrollment URLs are only valid for the specified user.",
     "enterpriseOnly": true,
     "id": "search-users",
-    "path": "/../capabilities/device-identity#new-enrollment",
+    "path": "/../integrations/device-context/webauthn#enroll-devices-as-an-administrator-enterprise",
     "title": "Search Users"
   },
   "secondary-color": {
@@ -1737,7 +1742,7 @@
   },
   "tls-downstream-client-certificate-authority": {
     "id": "tls-downstream-client-certificate-authority",
-    "path": "/tls#tls-downstream-client-certificate-authority",
+    "path": "/routes/tls#tls-downstream-client-certificate-authority",
     "services": ["proxy"],
     "title": "TLS Downstream Client Certificate Authority"
   },


### PR DESCRIPTION
The settings reference table at /docs/reference has accumulated 34 dead links: 12 entries have no `path` at all (their table rows render `href="/docs/referenceundefined"`), 9 IdP entries still point at pre-reorg `/docs/integrations/<idp>` URLs, 6 device-management entries point at pages deleted in an earlier restructure, and 7 more have mispathed pages or anchors. Docusaurus's broken-link checker never sees these because they live in `reference.json` and render through the ReferenceTable component, so nothing failed when the target pages moved.

This PR points every entry at its current home, removes the `envoy-bootstrap-options` entry — there is no such setting; the name is a comment grouping the `envoy_admin_*`/`envoy_bind_config_*` options in core — and deletes two partials (`_manage-devices.md`, `_new-enrollment.md`) that no page imports since their content moved into `webauthn.mdx`.

One tradeoff to know about: `enrollment-type`, `redirect-url`, and `search-users` all land on the "Enroll Devices as an Administrator" section of the WebAuthn page, because that section documents those three fields as bullets under a single heading — no finer anchors exist.

Verified with: `yarn format-check && yarn cspell && yarn build` (all pass); a resolver that normalizes each `path` the way the browser resolves the rendered `href` and asserts the target file exists reports 0 unresolved entries; every `#anchor` was checked against the target page's generated heading slugs and explicit `{#custom-id}` attributes; `grep -c 'capabilities/device-identity' content/docs/reference/reference.json` returns 0; `grep -rn '_manage-devices\|_new-enrollment' content src` returns no imports; all 245 remaining entries carry `id`, `title`, and `path`.

**AI assistance:** AI (Claude) ran the audit, built the retarget map, and drafted this diff; targets were verified with the checks above plus a second reviewer model, which caught one dead anchor before posting (`data-broker-service` now points at the page top since its `#databroker-service` anchor never existed). Human review happens in this PR.
