### PR TITLE
docs: add CI check for settings reference table links

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -23,5 +23,6 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn format-check
       - run: yarn cspell
+      - run: yarn test:reference-links
       - run: yarn guide-audit
       - run: yarn test:robots

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
     "write-heading-ids": "docusaurus write-heading-ids",
     "format": "prettier --write .",
     "format-check": "prettier --check .",
-    "check": "npm run format-check && npm run cspell && npm run guide-audit && npm run test:robots",
+    "check": "npm run format-check && npm run cspell && npm run test:reference-links && npm run guide-audit && npm run test:robots",
     "cspell": "cspell --gitignore .",
     "guide-audit": "node scripts/audit-guides.mjs",
     "test:generated-links": "node scripts/test-generated-links.js",
+    "test:reference-links": "node scripts/test-reference-links.js",
     "test:robots": "node --test test/robots-mode.test.js"
   },
   "dependencies": {

--- a/scripts/test-reference-links.js
+++ b/scripts/test-reference-links.js
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const {createSlugger} = require('@docusaurus/utils');
+
+const CONTENT_DOCS_DIR = path.resolve(__dirname, '../content/docs');
+const REFERENCE_FILE = path.join(CONTENT_DOCS_DIR, 'reference/reference.json');
+
+const HEADING_PATTERN = /^(#{1,6})\s+(.+?)\s*#*\s*$/;
+const EXPLICIT_HEADING_ID_PATTERN = /(?:^|\s)\\?\{#([A-Za-z0-9_-]+)\}\s*$/;
+const FENCE_PATTERN = /^\s*(`{3,}|~{3,})/;
+
+function fail(message) {
+  console.error(`reference link check failed: ${message}`);
+  process.exitCode = 1;
+}
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim() !== '';
+}
+
+function splitReferencePath(referencePath) {
+  const fragmentIndex = referencePath.indexOf('#');
+  if (fragmentIndex === -1) {
+    return {pathname: referencePath, fragment: null};
+  }
+
+  return {
+    pathname: referencePath.slice(0, fragmentIndex),
+    fragment: referencePath.slice(fragmentIndex + 1),
+  };
+}
+
+function resolveReferencePath(referencePath) {
+  const {pathname, fragment} = splitReferencePath(referencePath);
+  const resolved = path.posix
+    .normalize(`reference/${pathname}`)
+    .replace(/^\/+/, '');
+
+  return {resolved, fragment};
+}
+
+function targetCandidates(resolvedPath) {
+  const docName = path.posix.basename(resolvedPath.replace(/\/+$/, ''));
+  return [
+    path.join(CONTENT_DOCS_DIR, `${resolvedPath}.mdx`),
+    path.join(CONTENT_DOCS_DIR, `${resolvedPath}.md`),
+    path.join(CONTENT_DOCS_DIR, resolvedPath, 'index.mdx'),
+    path.join(CONTENT_DOCS_DIR, resolvedPath, 'index.md'),
+    path.join(CONTENT_DOCS_DIR, resolvedPath, `${docName}.mdx`),
+    path.join(CONTENT_DOCS_DIR, resolvedPath, `${docName}.md`),
+  ];
+}
+
+function findTargetFile(resolvedPath) {
+  return targetCandidates(resolvedPath).find((candidate) =>
+    fs.existsSync(candidate),
+  );
+}
+
+function stripHeadingMarkdown(heading) {
+  return heading
+    .replace(EXPLICIT_HEADING_ID_PATTERN, '')
+    .replace(/<[^>]+>/g, '')
+    .replace(/!\[([^\]]*)]\([^)]+\)/g, '$1')
+    .replace(/\[([^\]]+)]\([^)]+\)/g, '$1')
+    .replace(/[`*_~]/g, '')
+    .trim();
+}
+
+function collectHeadingAnchors(filePath) {
+  const anchors = new Set();
+  const slugger = createSlugger();
+  const lines = fs.readFileSync(filePath, 'utf8').split(/\r?\n/);
+  let fence = null;
+
+  for (const line of lines) {
+    const fenceMatch = line.match(FENCE_PATTERN);
+    if (fenceMatch) {
+      const marker = fenceMatch[1][0];
+      if (fence === marker) {
+        fence = null;
+      } else if (!fence) {
+        fence = marker;
+      }
+      continue;
+    }
+
+    if (fence) continue;
+
+    const headingMatch = line.match(HEADING_PATTERN);
+    if (!headingMatch) continue;
+
+    const rawHeading = headingMatch[2];
+    const explicitIdMatch = rawHeading.match(EXPLICIT_HEADING_ID_PATTERN);
+    if (explicitIdMatch) {
+      anchors.add(explicitIdMatch[1]);
+      continue;
+    }
+
+    const headingText = stripHeadingMarkdown(rawHeading);
+    if (headingText) {
+      anchors.add(slugger.slug(headingText));
+    }
+  }
+
+  return anchors;
+}
+
+function relativeFile(filePath) {
+  return path.relative(process.cwd(), filePath);
+}
+
+let references;
+try {
+  references = JSON.parse(fs.readFileSync(REFERENCE_FILE, 'utf8'));
+} catch (error) {
+  fail(`could not load ${relativeFile(REFERENCE_FILE)}: ${error.message}`);
+  process.exit(1);
+}
+
+const violations = [];
+const idCounts = new Map();
+let checked = 0;
+let checkedAnchors = 0;
+
+for (const entry of Object.values(references)) {
+  if (!entry || typeof entry !== 'object' || !isNonEmptyString(entry.id)) {
+    continue;
+  }
+
+  idCounts.set(entry.id, (idCounts.get(entry.id) || 0) + 1);
+}
+
+for (const [key, entry] of Object.entries(references)) {
+  const missingFields = [];
+  if (!entry || typeof entry !== 'object') {
+    violations.push({key, error: 'entry must be an object'});
+    continue;
+  }
+  if (!isNonEmptyString(entry.id)) missingFields.push('id');
+  if (!isNonEmptyString(entry.title)) missingFields.push('title');
+  if (!isNonEmptyString(entry.path)) missingFields.push('path');
+  if (missingFields.length > 0) {
+    violations.push({
+      key,
+      id: entry.id,
+      title: entry.title,
+      path: entry.path,
+      error: `missing non-empty ${missingFields.join(', ')}`,
+    });
+  }
+  if (isNonEmptyString(entry.id) && idCounts.get(entry.id) > 1) {
+    violations.push({
+      key,
+      id: entry.id,
+      title: entry.title,
+      path: entry.path,
+      error: 'duplicate entry id',
+    });
+  }
+  if (missingFields.length > 0) continue;
+
+  checked++;
+  const {resolved, fragment} = resolveReferencePath(entry.path);
+  const targetFile = findTargetFile(resolved);
+  if (!targetFile) {
+    violations.push({
+      key,
+      id: entry.id,
+      title: entry.title,
+      path: entry.path,
+      resolved,
+      error: 'target document does not exist',
+      candidates: targetCandidates(resolved).map(relativeFile),
+    });
+    continue;
+  }
+
+  if (!fragment) continue;
+
+  checkedAnchors++;
+  const anchors = collectHeadingAnchors(targetFile);
+  if (!anchors.has(fragment)) {
+    violations.push({
+      key,
+      id: entry.id,
+      title: entry.title,
+      path: entry.path,
+      resolved,
+      fragment,
+      file: relativeFile(targetFile),
+      error: 'target anchor does not exist',
+    });
+  }
+}
+
+if (violations.length > 0) {
+  fail(
+    `found ${violations.length} violation(s):\n${JSON.stringify(
+      violations,
+      null,
+      2,
+    )}`,
+  );
+}
+
+if (process.exitCode) process.exit();
+
+console.log(
+  `reference link check passed: ${checked} reference paths and ${checkedAnchors} anchors resolved locally`,
+);

--- a/scripts/test-reference-links.js
+++ b/scripts/test-reference-links.js
@@ -60,9 +60,14 @@ function findTargetFile(resolvedPath) {
 }
 
 function stripHeadingMarkdown(heading) {
-  return heading
-    .replace(EXPLICIT_HEADING_ID_PATTERN, '')
-    .replace(/<[^>]+>/g, '')
+  let text = heading.replace(EXPLICIT_HEADING_ID_PATTERN, '');
+  // strip tags to a fixpoint so nested fragments like `<<b>script>` cannot survive
+  let previous;
+  do {
+    previous = text;
+    text = text.replace(/<[^>]*>/g, '');
+  } while (text !== previous);
+  return text
     .replace(/!\[([^\]]*)]\([^)]+\)/g, '$1')
     .replace(/\[([^\]]+)]\([^)]+\)/g, '$1')
     .replace(/[`*_~]/g, '')

--- a/scripts/test-reference-links.js
+++ b/scripts/test-reference-links.js
@@ -61,7 +61,7 @@ function findTargetFile(resolvedPath) {
 
 function stripHeadingMarkdown(heading) {
   let text = heading.replace(EXPLICIT_HEADING_ID_PATTERN, '');
-  // strip tags to a fixpoint so nested fragments like `<<b>script>` cannot survive
+  // strip tags until no replacement occurs so nested fragments like `<<b>script>` cannot survive
   let previous;
   do {
     previous = text;

--- a/scripts/test-reference-links.js
+++ b/scripts/test-reference-links.js
@@ -61,7 +61,7 @@ function findTargetFile(resolvedPath) {
 
 function stripHeadingMarkdown(heading) {
   let text = heading.replace(EXPLICIT_HEADING_ID_PATTERN, '');
-  // strip tags until no replacement occurs so nested fragments like `<<b>script>` cannot survive
+  // repeat until stable: a single pass leaves nested fragments like <<b>script>
   let previous;
   do {
     previous = text;
@@ -83,8 +83,10 @@ function collectHeadingAnchors(filePath) {
   for (const line of lines) {
     const fenceMatch = line.match(FENCE_PATTERN);
     if (fenceMatch) {
-      const marker = fenceMatch[1][0];
-      if (fence === marker) {
+      const marker = fenceMatch[1];
+      // CommonMark 4.5: a closing fence uses the same character and is at
+      // least as long as the opening fence
+      if (fence && marker[0] === fence[0] && marker.length >= fence.length) {
         fence = null;
       } else if (!fence) {
         fence = marker;


### PR DESCRIPTION
The settings reference table's links live in `reference.json` and render through the ReferenceTable component, so Docusaurus's broken-link checker never sees them — that's how 34 dead links accumulated silently until #2296. This adds `scripts/test-reference-links.js` to the pre-commit CI job so the next moved page fails the PR that moves it instead of rotting quietly.

The check asserts every entry has `id`, `title`, and `path`; resolves each path the way the browser resolves the rendered href (including `..` segments and Docusaurus's index and same-name-as-folder page conventions); and verifies `#anchors` against the target page's headings using Docusaurus's own slugger plus explicit `{#custom-id}` attributes, skipping fenced code blocks. It reports every violation, not just the first.

Merge order: this depends on #2296 — on main without it the check correctly reports the 35 known violations that PR fixes; against the #2296 tree it passes with 245 paths and 151 anchors resolved. Sanity-checked both directions, plus a corrupt-one-entry test to confirm the failure path names the offending entry.

**AI assistance:** implemented by Codex from a spec, supervised and verified by Claude (script review, red/green runs on both trees, false-positive hunt — the same-name-as-folder case was found and fixed this way). Human review happens in this PR.
