### PR TITLE
docs: fill empty descriptions in the settings reference table

### DIFF
--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -35,6 +35,7 @@
     "type": "bool"
   },
   "authenticate-internal-service-url": {
+    "description": "Internal URL Pomerium services use to reach the authenticate service in split-service deployments.",
     "id": "authenticate-internal-service-url",
     "path": "/service-urls#authenticate-internal-service-url",
     "services": [],
@@ -51,6 +52,7 @@
     "type": "URL"
   },
   "authorize-internal-service-url": {
+    "description": "Internal URL Pomerium services use to reach the authorize service in split-service deployments.",
     "id": "authorize-internal-service-url",
     "path": "/service-urls#authorize-internal-service-url",
     "services": [],
@@ -129,6 +131,7 @@
     "type": "email"
   },
   "autocert-must-staple": {
+    "description": "Forces Autocert to request certificates with the Must-Staple extension.",
     "id": "autocert-must-staple",
     "path": "/autocert#autocert-must-staple",
     "services": ["authenticate", "proxy"],
@@ -137,6 +140,7 @@
     "type": "bool"
   },
   "autocert-trusted-certificate-authority": {
+    "description": "X.509 CA bundle used to verify TLS connections to the ACME certificate authority.",
     "id": "autocert-trusted-certificate-authority",
     "path": "/autocert#autocert-trusted-certificate-authority",
     "services": ["authenticate", "proxy"],
@@ -163,6 +167,7 @@
     "type": "string"
   },
   "branding-settings": {
+    "description": "Configure Console branding: logo, favicon, and error messages.",
     "id": "branding",
     "path": "/branding",
     "short_description": "",
@@ -178,6 +183,7 @@
     "type": "string"
   },
   "certificates": {
+    "description": "Configure TLS certificate and certificate authority settings.",
     "id": "certificates",
     "path": "/certificates",
     "services": [],
@@ -235,6 +241,7 @@
     "type": "string"
   },
   "cookies-settings": {
+    "description": "Configure session cookie name, secret, domain, expiration, and SameSite settings.",
     "id": "cookies",
     "path": "/cookies",
     "services": [],
@@ -256,6 +263,7 @@
     "title": "Custom Domains"
   },
   "data-broker-internal-service-url": {
+    "description": "Overrides the databroker service URL when determining the TLS certificate for the databroker listener.",
     "id": "data-broker-internal-service-url",
     "path": "/service-urls#databroker-internal-service-url",
     "services": [],
@@ -263,12 +271,15 @@
     "type": "URL"
   },
   "data-broker-service": {
+    "description": "The databroker service manages all persistent state within Pomerium.",
     "id": "data-broker-service",
     "path": "/databroker",
     "services": ["databroker"],
-    "title": "Databroker Service"
+    "title": "Databroker Service",
+    "type": ""
   },
   "data-broker-service-url": {
+    "description": "Sets the URL Pomerium uses to reach the databroker in split-service or remote deployments.",
     "id": "data-broker-service-url",
     "path": "/service-urls#databroker-service-url",
     "services": [],
@@ -284,6 +295,7 @@
     "type": "string"
   },
   "data-broker-storage-type": {
+    "description": "Sets the backend storage type for databroker state.",
     "id": "data-broker-storage-type",
     "path": "/databroker#databroker-storage-type",
     "services": [],
@@ -291,6 +303,7 @@
     "type": "string"
   },
   "databroker-settings": {
+    "description": "Configure databroker storage and clustering settings.",
     "id": "databroker",
     "path": "/databroker",
     "services": ["databroker"],
@@ -493,10 +506,12 @@
     "type": "datetime"
   },
   "ext-data-client-tls-key": {
+    "description": "ID of the TLS key pair presented when connecting to the external data source.",
     "enterpriseOnly": true,
     "id": "ext-data-client-tls-key",
     "path": "/../integrations#client-tls-key",
-    "title": "Client TLS Key"
+    "title": "Client TLS Key",
+    "type": "string"
   },
   "ext-data-foreign-key": {
     "description": "Associates this key from a request to the external data",
@@ -513,16 +528,20 @@
     "title": "External Data Request Headers"
   },
   "ext-data-insecure-tls": {
+    "description": "Skips TLS certificate verification when connecting to the external data source.",
     "enterpriseOnly": true,
     "id": "ext-data-insecure-tls",
     "path": "/../integrations#allow-insecure-tls",
-    "title": "Allow Insecure TLS"
+    "title": "Allow Insecure TLS",
+    "type": "boolean"
   },
   "ext-data-polling": {
+    "description": "Sets the minimum and maximum delay between requests to the external data source.",
     "enterpriseOnly": true,
     "id": "ext-data-polling",
     "path": "/../integrations#polling-minmax-delay",
-    "title": "Polling Min / Max Delay"
+    "title": "Polling Min / Max Delay",
+    "type": "duration"
   },
   "ext-data-record-type": {
     "description": "Overridden by the directory structure of an archive file dataset",
@@ -564,6 +583,7 @@
     "type": ""
   },
   "google-cloud-serverless-authentication-service-account": {
+    "description": "Sets service account credentials for Google Cloud serverless authorization headers.",
     "id": "google-cloud-serverless-authentication-service-account",
     "path": "/google-cloud-serverless-authentication-service-account",
     "services": ["authorize"],
@@ -580,11 +600,12 @@
     "type": "string"
   },
   "grpc-client-timeout": {
+    "description": "Sets the timeout for gRPC client requests made to internal Pomerium services.",
     "id": "grpc-client-timeout",
     "path": "/grpc#grpc-client-timeout",
     "services": [],
     "title": "gRPC Client Timeout",
-    "type": ""
+    "type": "duration"
   },
   "grpc-health-check-authority": {
     "description": "Specifies the ':authority' header value in a gRPC health check request. Optional.",
@@ -617,6 +638,7 @@
     "type": "string"
   },
   "headers-settings": {
+    "description": "Configure route host, request, and response header settings.",
     "id": "headers-settings",
     "path": "/routes/headers",
     "title": "Headers Settings"
@@ -772,6 +794,7 @@
     "type": "string"
   },
   "identity-provider-client-id-per-route": {
+    "description": "Overrides the global identity provider client ID for this route.",
     "id": "identity-provider-client-id-per-route",
     "path": "/routes/identity-provider-client-id-per-route",
     "services": ["proxy"],
@@ -795,6 +818,7 @@
     "type": "string"
   },
   "identity-provider-client-secret-per-route": {
+    "description": "Overrides the global identity provider client secret for this route.",
     "id": "identity-provider-client-secret-per-route",
     "path": "/routes/identity-provider-client-secret-per-route",
     "services": ["proxy"],
@@ -1011,6 +1035,7 @@
     "type": "not currently supported"
   },
   "load-balancing-settings": {
+    "description": "Configure route load balancing policies and health checks.",
     "id": "load-balancing-settings",
     "path": "/routes/load-balancing",
     "title": "Load Balancing Settings"
@@ -1032,6 +1057,7 @@
     "type": "URL"
   },
   "manage-devices": {
+    "description": "Manage device enrollments and device identity for policy-based authorization.",
     "enterpriseOnly": true,
     "id": "manage-devices",
     "path": "/../integrations/device-context/webauthn#manage-devices-enterprise",
@@ -1139,6 +1165,7 @@
     "type": "string"
   },
   "metrics-basic-authentication": {
+    "description": "Requires Basic HTTP Authentication to access the metrics endpoint.",
     "id": "metrics-basic-authentication",
     "path": "/metrics#metrics-basic-authentication",
     "services": [],
@@ -1177,12 +1204,14 @@
     "title": "Migrate Routes"
   },
   "new-enrollment": {
+    "description": "Create enrollment links users can follow to register devices.",
     "enterpriseOnly": true,
     "id": "new-enrollment",
     "path": "/../integrations/device-context/webauthn#new-enrollment-enterprise",
     "title": "New Enrollment"
   },
   "outlier-detection": {
+    "description": "Removes unhealthy upstream hosts from the load balancing set based on outlier detection.",
     "id": "outlier-detection",
     "path": "/routes/outlier-detection",
     "services": ["proxy"],
@@ -1282,6 +1311,7 @@
     "type": "string"
   },
   "policy-inheritance": {
+    "description": "Controls whether child namespaces inherit policies enforced by parent namespaces.",
     "id": "policy-inheritance",
     "path": "/../internals/namespacing#hierarchical-policy-enforcement",
     "services": [],
@@ -1371,6 +1401,7 @@
     "type": "string"
   },
   "programmatic-redirect-domain-whitelist": {
+    "description": "Restricts the allowed redirect URLs for programmatic login.",
     "id": "programmatic-redirect-domain-whitelist",
     "path": "/programmatic-redirect-domain-whitelist",
     "services": [],
@@ -1653,6 +1684,7 @@
     "type": "string"
   },
   "signout-redirect-url": {
+    "description": "Sets the URL users are redirected to after signing out.",
     "id": "signout-redirect-url",
     "path": "/signout-redirect-url",
     "services": ["proxy"],
@@ -1721,6 +1753,7 @@
     "type": "uint32"
   },
   "timeouts": {
+    "description": "Configure route websocket, SPDY, route timeout, and idle timeout settings.",
     "id": "timeouts",
     "path": "/routes/timeouts",
     "title": "Timeouts Settings"
@@ -1741,10 +1774,12 @@
     "title": "TLS Custom Certificate Authority"
   },
   "tls-downstream-client-certificate-authority": {
+    "description": "PEM-encoded X.509 certificates used to verify downstream client certificates for a route.",
     "id": "tls-downstream-client-certificate-authority",
     "path": "/routes/tls#tls-downstream-client-certificate-authority",
     "services": ["proxy"],
-    "title": "TLS Downstream Client Certificate Authority"
+    "title": "TLS Downstream Client Certificate Authority",
+    "type": "string"
   },
   "tls-downstream-server-name": {
     "description": "This server name overrides the Hostname in the 'From:' field, and serves as the Server Name Indication when establishing a TLS connection with Pomerium.",
@@ -1755,6 +1790,7 @@
     "type": "string"
   },
   "tls-settings": {
+    "description": "Configure TLS route certificate authority, server name, verification, and client certificate settings.",
     "id": "tls-settings",
     "path": "/routes/tls",
     "services": ["proxy"],
@@ -1795,6 +1831,7 @@
     "type": "URL(s)"
   },
   "tracing": {
+    "description": "Configure OpenTelemetry tracing for request and authorization flow introspection.",
     "id": "tracing",
     "path": "/tracing",
     "services": [],
@@ -1829,6 +1866,7 @@
     "title": "Tracing Sample Rate"
   },
   "use-proxy-protocol": {
+    "description": "Requires the proxy protocol on incoming connections.",
     "id": "use-proxy-protocol",
     "path": "/use-proxy-protocol",
     "services": [],

--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -263,7 +263,7 @@
     "title": "Custom Domains"
   },
   "data-broker-internal-service-url": {
-    "description": "Overrides the databroker service URL when determining the TLS certificate for the databroker listener.",
+    "description": "Internal URL Pomerium services use to reach the databroker service in split-service deployments.",
     "id": "data-broker-internal-service-url",
     "path": "/service-urls#databroker-internal-service-url",
     "services": [],
@@ -1401,7 +1401,7 @@
     "type": "string"
   },
   "programmatic-redirect-domain-whitelist": {
-    "description": "Restricts the allowed redirect URLs for programmatic login.",
+    "description": "Restricts the allowed redirect domains for programmatic login.",
     "id": "programmatic-redirect-domain-whitelist",
     "path": "/programmatic-redirect-domain-whitelist",
     "services": [],


### PR DESCRIPTION
33 entries in the settings reference table rendered blank Description cells (and several blank Type cells), so the table gave no hint what those settings do. Every entry now carries a one-sentence description grounded in the setting's proto comment or its target docs page, and types where they were missing; each description was re-checked against the code and the linked page before this PR.

To verify: pick any entry in the diff and compare it with the page its `path` links to; `yarn build && yarn cspell` pass; all 245 entries retain `id`, `title`, and `path`.

**AI assistance:** AI-drafted (Claude supervising a Codex worker) from code and docs evidence, then re-verified. Human review happens in this PR.
