### PR TITLE
docs: document directory sync configuration for the Enterprise Console

### DIFF
--- a/content/docs/deploy/enterprise/configure.mdx
+++ b/content/docs/deploy/enterprise/configure.mdx
@@ -29,6 +29,18 @@ Pomerium Enterprise Console may require outbound HTTPS (TCP 443) access to:
 - `analytics.pomerium.com` for Pomerium usage analytics.
 - `sentry.io` for Sentry error reporting - see https://docs.sentry.io/security-legal-pii/security/ip-ranges/
 
+## Directory sync
+
+Directory sync enumerates users and groups from a directory provider so Pomerium Core can use directory-backed identity data. In the Console, go to **Settings** > **Directory Sync**. The tab shows **Identity Provider**, **Polling Min Delay**, and **Polling Max Delay**. **Identity Provider** renders a provider selector with **None** as the empty value; leaving it empty disables directory sync. When a provider is selected, the Console shows provider-specific options below the selector.
+
+When the Console exports settings to Core, **Identity Provider** maps to `directory_provider`, the provider-specific values map to `directory_provider_options`, **Polling Min Delay** maps to `directory_provider_refresh_interval`, and **Polling Max Delay** maps to `directory_provider_refresh_timeout`. Core uses these settings to choose the directory provider, store provider options as a generic JSON object, refresh the directory cache, and limit a single refresh attempt.
+
+You can seed the same persisted Console settings at startup with `directory_provider`, `directory_provider_options`, `directory_provider_refresh_interval`, and `directory_provider_refresh_timeout` in `config.yaml`, or with the matching environment variables in the table below. If unset, the directory polling delays use `10m`.
+
+## Auto-apply changesets
+
+`auto_apply_changesets` controls whether configuration changesets apply automatically (`true`) or wait for an administrator to apply them (`false`). The Enterprise Console has no UI control for it; set it through the settings API. Pomerium Zero exposes it as the **Auto-apply changesets** toggle under **Settings** > **Advanced**.
+
 ## Variables
 
 The keys listed below can be applied in Pomerium Console's `config.yaml` file or as environment variables.
@@ -53,6 +65,10 @@ All values are case sensitive unless otherwise noted.
 | <a className="entRef-anchor" id="database-url">#</a><a href='#database-url'>DATABASE_URL</a> | The database Pomerium Enterprise Console will use. | `postgresql://pomerium:pomerium`<br/>`@localhost:5432/dashboard?sslmode=disable` |
 | <a className="entRef-anchor" id="databroker-service-url">#</a><a href='#databroker-service-url'>DATABROKER_SERVICE_URL</a> | Databroker service URL for Console to reach Core. Leave unset in the default single-process deployment (Console uses `http://localhost:5443`). Set only when the databroker runs on another host/port or Core is split/remote. | `http://localhost:5443` |
 | <a className="entRef-anchor" id="debug-config-dump">#</a><a href='#debug-config-dump'>DEBUG_CONFIG_DUMP</a> | Dumps the Databroker configuration. This is a debug option to be used only when specified by Pomerium Support. | `false` |
+| <a className="entRef-anchor" id="directory-provider">#</a><a href='#directory-provider'>DIRECTORY_PROVIDER</a> | Directory-sync provider Pomerium uses to enumerate users and groups. Empty disables directory sync. | none |
+| <a className="entRef-anchor" id="directory-provider-options">#</a><a href='#directory-provider-options'>DIRECTORY_PROVIDER_OPTIONS</a> | Provider-specific options for the directory provider, as a JSON object. | none |
+| <a className="entRef-anchor" id="directory-provider-refresh-interval">#</a><a href='#directory-provider-refresh-interval'>DIRECTORY_PROVIDER_REFRESH_INTERVAL</a> | How often Pomerium refreshes the directory cache. | `10m` |
+| <a className="entRef-anchor" id="directory-provider-refresh-timeout">#</a><a href='#directory-provider-refresh-timeout'>DIRECTORY_PROVIDER_REFRESH_TIMEOUT</a> | Per-attempt timeout for a single directory refresh cycle. | `10m` |
 | <a className="entRef-anchor" id="disable-feedback-widget">#</a><a href='#disable-feedback-widget'>DISABLE_FEEDBACK_WIDGET</a> | Disables third-party feedback widget and removes it from the Enterprise Console. | `false` |
 | <a className="entRef-anchor" id="disable-remote-diagnostics">#</a><a href='#disable-remote-diagnostics'>DISABLE_REMOTE_DIAGNOSTICS</a> | Disable remote diagnostics. | `true` |
 | <a className="entRef-anchor" id="disable-validation">#</a><a href='#disable-validation'>DISABLE_VALIDATION</a> | (deprecated, please update your configuration to set `VALIDATION_MODE=none` instead) Disable config validation. | `false` |
@@ -99,6 +115,10 @@ All values are case sensitive unless otherwise noted.
 | <a className="entRef-anchor" id="database-url">#</a><a href='#database-url'>database_url</a> | The database Pomerium Enterprise Console will use. | `postgresql://pomerium:pomerium`<br/>`@localhost:5432/dashboard?sslmode=disable` |
 | <a className="entRef-anchor" id="databroker-service-url">#</a><a href='#databroker-service-url'>databroker_service_url</a> | Databroker service URL for Console to reach Core. Leave unset in the default single-process deployment (Console uses `http://localhost:5443`). Set only when the databroker runs on another host/port or Core is split/remote. | `http://localhost:5443` |
 | <a className="entRef-anchor" id="debug-config-dump">#</a><a href='#debug-config-dump'>debug_config_dump</a> | Dumps the Databroker configuration. This is a debug option to be used only when specified by Pomerium Support. | `false` |
+| <a className="entRef-anchor" id="directory-provider">#</a><a href='#directory-provider'>directory_provider</a> | Directory-sync provider Pomerium uses to enumerate users and groups. Empty disables directory sync. | none |
+| <a className="entRef-anchor" id="directory-provider-options">#</a><a href='#directory-provider-options'>directory_provider_options</a> | Provider-specific options for the directory provider, as a JSON object. | none |
+| <a className="entRef-anchor" id="directory-provider-refresh-interval">#</a><a href='#directory-provider-refresh-interval'>directory_provider_refresh_interval</a> | How often Pomerium refreshes the directory cache. | `10m` |
+| <a className="entRef-anchor" id="directory-provider-refresh-timeout">#</a><a href='#directory-provider-refresh-timeout'>directory_provider_refresh_timeout</a> | Per-attempt timeout for a single directory refresh cycle. | `10m` |
 | <a className="entRef-anchor" id="disable-feedback-widget">#</a><a href='#disable-feedback-widget'>disable_feedback_widget</a> | Disables third-party feedback widget and removes it from the Enterprise Console. | `false` |
 | <a className="entRef-anchor" id="disable-remote-diagnostics">#</a><a href='#disable-remote-diagnostics'>disable_remote_diagnostics</a> | Disable remote diagnostics. | `true` |
 | <a className="entRef-anchor" id="disable-validation">#</a><a href='#disable-validation'>disable_validation</a> | (deprecated, please update your configuration to set `validation_mode=none` instead) Disable config validation. | `false` |

--- a/content/docs/deploy/enterprise/configure.mdx
+++ b/content/docs/deploy/enterprise/configure.mdx
@@ -35,11 +35,11 @@ Directory sync enumerates users and groups from a directory provider so Pomerium
 
 When the Console exports settings to Core, **Identity Provider** maps to `directory_provider`, the provider-specific values map to `directory_provider_options`, **Polling Min Delay** maps to `directory_provider_refresh_interval`, and **Polling Max Delay** maps to `directory_provider_refresh_timeout`. Core uses these settings to choose the directory provider, store provider options as a generic JSON object, refresh the directory cache, and limit a single refresh attempt.
 
-You can seed the same persisted Console settings at startup with `directory_provider`, `directory_provider_options`, `directory_provider_refresh_interval`, and `directory_provider_refresh_timeout` in `config.yaml`, or with the matching environment variables in the table below. If unset, the directory polling delays use `10m`.
+You can seed the same persisted Console settings at startup with `directory_provider`, `directory_provider_options`, `directory_provider_refresh_interval`, and `directory_provider_refresh_timeout` in `config.yaml`, or with the matching environment variables in the table below. If unset, `directory_provider_refresh_interval` defaults to `10m`, and `directory_provider_refresh_timeout` — the deadline for a single refresh attempt — also defaults to `10m`.
 
 ## Auto-apply changesets
 
-`auto_apply_changesets` controls whether configuration changesets apply automatically (`true`) or wait for an administrator to apply them (`false`). The Enterprise Console has no UI control for it; set it through the settings API. Pomerium Zero exposes it as the **Auto-apply changesets** toggle under **Settings** > **Advanced**.
+`auto_apply_changesets` controls whether configuration changesets apply automatically (`true`) or wait for an administrator to apply them (`false`). The Enterprise Console has no UI control for it; set it through the [Console management API](/docs/internals/management-api-enterprise). Pomerium Zero exposes it as the **Auto-apply changesets** toggle under **Settings** > **Advanced**.
 
 ## Variables
 


### PR DESCRIPTION
Directory sync had no configuration documentation: the Console's **Settings** > **Directory Sync** tab, the four underlying settings (`directory_provider`, `directory_provider_options`, `directory_provider_refresh_interval`, `directory_provider_refresh_timeout`), and the fact that the Console's **Polling Min Delay** / **Polling Max Delay** fields map onto the refresh interval/timeout were all undocumented. This adds a Directory sync section describing the UI (labels verified against the Console renderer source), the Console-to-Core settings mapping (verified against the converter), and how to seed the same settings at startup via the Console's `config.yaml` or environment variables (real bootstrap options on the Console binary, verified in `serve.go`), with the four entries added to the variables tables. Also documents `auto_apply_changesets`: a persisted settings field with no Console UI control, currently used by Pomerium Zero where it surfaces as the Auto-apply changesets toggle.

To verify: field labels against `useSettingsConfig.ts`, the mapping against `console_to_core.go`, the flags against `cmd/pomerium-console/serve.go`; `yarn build && yarn cspell` pass.

**AI assistance:** AI (Claude supervising a Codex worker) wrote the section; every UI label, mapping, default, and flag was verified in console/core source by both the worker and the supervisor. Human review happens in this PR.
