### PR TITLE
docs: document health check address, HTTP/3 advertise port, and SSH settings

### DIFF
--- a/content/docs/capabilities/native-ssh-access.mdx
+++ b/content/docs/capabilities/native-ssh-access.mdx
@@ -288,6 +288,19 @@ This feature is disabled by default, and can be enabled using a runtime flag ([s
 | `ssh_user_ca_key_file` | Path to the User CA private key file (if no ssh_user_ca_key is provided) |
 | `ssh_host_keys` | List of SSH private key files to use as Pomerium's host keys |
 | `ssh_host_key_files` | List of SSH private keys to use as Pomerium's host keys |
+| `ssh_rls_enabled` | Enables the Envoy rate-limit service for SSH connections |
+| `ssh_rls_additional_entries` | Additional `key`/`value` descriptor entries for SSH rate limiting, using Envoy substitution formatting |
+
+### SSH Rate Limit Service
+
+The SSH rate-limit service is disabled by default. Set `ssh_rls_enabled` to `true` to add Envoy's rate-limit filter to inbound SSH connections, and use `ssh_rls_additional_entries` to append extra substitution-format descriptor entries to the built-in SSH rate-limit descriptor:
+
+```yaml
+ssh_rls_enabled: true
+ssh_rls_additional_entries:
+  - key: client_address
+    value: '%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%'
+```
 
 ### SSH Route Configuration
 

--- a/content/docs/capabilities/reverse-tunneling.mdx
+++ b/content/docs/capabilities/reverse-tunneling.mdx
@@ -37,7 +37,18 @@ Suppose Alice is running a web server locally, and wants to allow Bob to connect
 
 Instead, Alice can configure the Pomerium route with the `upstream_tunnel` option. Here, a second Pomerium policy must be configured, `ssh_policy`. This second policy controls who can connect as an upstream for this route. Standard SSH policy rules can be used here; see [SSH Policy Criteria](/docs/capabilities/native-ssh-access#ssh-policy-criteria) for details.
 
-For Rego-based tunnel authorization at the same point, set `ssh_policy_rego` under `upstream_tunnel` with raw Rego policy text. Pomerium evaluates those Rego rules before opening the SSH tunnel to the upstream; see [Rego](/docs/internals/ppl#rego) for policy outputs and inputs.
+For Rego-based tunnel authorization at the same point, set `ssh_policy_rego` under `upstream_tunnel` with a list of raw Rego policies. Pomerium evaluates those Rego rules before opening the SSH tunnel to the upstream; see [Rego](/docs/internals/ppl#rego) for policy outputs and inputs. Note the nesting — `ssh_policy_rego` belongs inside the `upstream_tunnel` block, not at the route level:
+
+```yaml
+routes:
+  - from: ssh://tunnel.example.com
+    to: ssh://localhost:8080
+    upstream_tunnel:
+      ssh_policy_rego:
+        - |
+          # a policy that always allows access
+          allow := true
+```
 
 Once the route is configured, Alice connects to the Pomerium server via SSH and enables reverse port-forwarding with the `-R` flag (e.g. `ssh -R 0 pomerium.example.com`, assuming standard OpenSSH) and authenticates successfully. Then, Bob connects to the route. Pomerium will request that Alice's SSH client open a connection on `localhost:8080`. The SSH client can reach the local web server, so the connection can be established.
 

--- a/content/docs/capabilities/reverse-tunneling.mdx
+++ b/content/docs/capabilities/reverse-tunneling.mdx
@@ -37,6 +37,8 @@ Suppose Alice is running a web server locally, and wants to allow Bob to connect
 
 Instead, Alice can configure the Pomerium route with the `upstream_tunnel` option. Here, a second Pomerium policy must be configured, `ssh_policy`. This second policy controls who can connect as an upstream for this route. Standard SSH policy rules can be used here; see [SSH Policy Criteria](/docs/capabilities/native-ssh-access#ssh-policy-criteria) for details.
 
+For Rego-based tunnel authorization at the same point, set `ssh_policy_rego` under `upstream_tunnel` with raw Rego policy text. Pomerium evaluates those Rego rules before opening the SSH tunnel to the upstream; see [Rego](/docs/internals/ppl#rego) for policy outputs and inputs.
+
 Once the route is configured, Alice connects to the Pomerium server via SSH and enables reverse port-forwarding with the `-R` flag (e.g. `ssh -R 0 pomerium.example.com`, assuming standard OpenSSH) and authenticates successfully. Then, Bob connects to the route. Pomerium will request that Alice's SSH client open a connection on `localhost:8080`. The SSH client can reach the local web server, so the connection can be established.
 
 &nbsp; &nbsp; &nbsp; ![Scenario 1b](./img/ssh/reverse-tunnel-scenario-1-b.svg)

--- a/content/docs/internals/connection.mdx
+++ b/content/docs/internals/connection.mdx
@@ -135,6 +135,8 @@ Primary secure listener. Terminates TLS and forwards to appropriate upstream clu
 
 Enables HTTP/3 over QUIC for improved performance (reduced latency, better performance on lossy networks). Requires UDP port open and [`codec_type: http3`](../reference/codec-type).
 
+When HTTP/3 is enabled, Pomerium adds an `Alt-Svc` response header on the non-QUIC listener so clients can upgrade to QUIC. The `http3_advertise_port` settings field overrides the port Pomerium derives from `address` for that advertised value; it is only settable through the settings API, not as a config-file key or environment variable.
+
 #### gRPC Ingress (`grpc-ingress`)
 
 Internal gRPC server endpoint used by other Pomerium services. TLS terminated unless `grpc_insecure` is set.

--- a/content/docs/internals/health-checks.mdx
+++ b/content/docs/internals/health-checks.mdx
@@ -40,7 +40,7 @@ HTTP health checks may not suit all environments. For instance, in environments 
 
 Pomerium exposes http probe endpoints on `127.0.0.1:28080` by default. This server exposes `/status`, `/startupz`, `/readyz` and `/healthz` for consumption by container orchestration frameworks, like Kubernetes.
 
-Set the Core `health_check_addr` configuration key, or the `HEALTH_CHECK_ADDR` environment variable, to bind this server to a different address. The default is `127.0.0.1:28080`; when you change it, pass the same address to the CLI probe with `pomerium health --health-addr`.
+Set `health_check_addr` in the configuration file, or the `HEALTH_CHECK_ADDR` environment variable, to bind this server to a different address. The default is `127.0.0.1:28080`; when you change it, pass the same address to the CLI probe with `pomerium health --health-addr`, and update the probe `port` values in manifests like the example below to match.
 
 For an overview on how probes work with Kubernetes see the [upstream documentation](https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/) and [their configuration options](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/).
 

--- a/content/docs/internals/health-checks.mdx
+++ b/content/docs/internals/health-checks.mdx
@@ -40,6 +40,8 @@ HTTP health checks may not suit all environments. For instance, in environments 
 
 Pomerium exposes http probe endpoints on `127.0.0.1:28080` by default. This server exposes `/status`, `/startupz`, `/readyz` and `/healthz` for consumption by container orchestration frameworks, like Kubernetes.
 
+Set the Core `health_check_addr` configuration key, or the `HEALTH_CHECK_ADDR` environment variable, to bind this server to a different address. The default is `127.0.0.1:28080`; when you change it, pass the same address to the CLI probe with `pomerium health --health-addr`.
+
 For an overview on how probes work with Kubernetes see the [upstream documentation](https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/) and [their configuration options](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/).
 
 To configure these for automatic checks in kubernetes on your pomerium instance you can add to your deployment manifest:


### PR DESCRIPTION
Five settings existed in code but nowhere in the docs. The health-checks page now documents `health_check_addr` (bind address for the probe endpoints, default `127.0.0.1:28080`, matching the CLI's `--health-addr`). The connection internals page notes `http3_advertise_port`, which overrides the port advertised in the `Alt-Svc` header — documented as a settings field, not a YAML key, because the option is deliberately excluded from file config. The native SSH page gains the rate-limit pair (`ssh_rls_enabled`, `ssh_rls_additional_entries`), and the reverse-tunneling page documents `ssh_policy_rego` as the raw-Rego alternative to `ssh_policy`.

To verify: each claim's source is one hop away — `config/options.go` for the health/SSH options (including the `mapstructure:"-"` exclusion on the HTTP/3 field), `config/envoyconfig/quic.go` for Alt-Svc behavior, `config/policy.go` for `ssh_policy_rego`; `yarn build && yarn cspell` pass.

**AI assistance:** AI (Claude supervising a Codex worker) drafted the additions; the worker itself corrected two facts during grounding (the HTTP/3 port is not a YAML option, and its zero-value disable comment does not match current builder behavior), and the supervisor re-verified. Human review happens in this PR.
