### PR TITLE
docs: track release branches for k8s install references

### DIFF
--- a/content/docs/deploy/cloud/install.mdx
+++ b/content/docs/deploy/cloud/install.mdx
@@ -145,7 +145,7 @@ In v0.27, we updated the Kubernetes installation manifest to use a Deployment in
 To update Pomerium in Kubernetes, run the following command:
 
 ```bash
-$ kubectl apply -k github.com/pomerium/pomerium/k8s/zero\?ref=v0.32.0
+$ kubectl apply -k github.com/pomerium/pomerium/k8s/zero\?ref=0-32-0
 ```
 
 </TabItem>

--- a/content/docs/deploy/k8s/gateway-api.mdx
+++ b/content/docs/deploy/k8s/gateway-api.mdx
@@ -63,13 +63,13 @@ To install the Pomerium Ingress Controller with support for Gateway API:
 1. First install the Gateway API CRDs:
 
    ```sh
-   kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
+   kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
    ```
 
 1. Then install the Pomerium Ingress Controller using the `gateway-api` kustomization:
 
    ```sh
-   kubectl apply -k github.com/pomerium/ingress-controller/config/gateway-api\?ref=v0.32.0
+   kubectl apply -k github.com/pomerium/ingress-controller/config/gateway-api\?ref=0-32-0
    ```
 
    This installs and configures the Ingress Controller, and adds a [GatewayClass](https://gateway-api.sigs.k8s.io/concepts/api-overview/#gatewayclass) named `pomerium-gateway` for use with the Gateway API.

--- a/content/docs/deploy/k8s/install.md
+++ b/content/docs/deploy/k8s/install.md
@@ -18,7 +18,7 @@ Use Pomerium as a first-class secure-by-default Ingress Controller. The Pomerium
 ## Deploy
 
 ```console
-kubectl apply -k github.com/pomerium/ingress-controller/config/default\?ref=v0.32.9
+kubectl apply -k github.com/pomerium/ingress-controller/config/default\?ref=0-32-0
 ```
 
 The Pomerium Ingress Controller is now installed into your cluster.
@@ -78,7 +78,7 @@ kustomize build config/default
 
 ```yaml title="kustomization.yaml"
 resources:
-  - https://raw.githubusercontent.com/pomerium/ingress-controller/v0.32.9/deployment.yaml
+  - https://raw.githubusercontent.com/pomerium/ingress-controller/0-32-0/deployment.yaml
 patches:
   - path: patch-proxy-external-dns.yaml
 ```
@@ -105,7 +105,7 @@ You must configure [storage persistence](/docs/internals/data-storage) in order 
 
 ```yaml title="kustomization.yaml"
 resources:
-  - https://raw.githubusercontent.com/pomerium/ingress-controller/v0.32.9/deployment.yaml
+  - https://raw.githubusercontent.com/pomerium/ingress-controller/0-32-0/deployment.yaml
 patches:
   - path: deployment.yaml
 ```
@@ -126,7 +126,7 @@ An `IngressClass` may be designated as a [default controller](https://kubernetes
 
 ```yaml title="kustomization.yaml"
 resources:
-  - https://raw.githubusercontent.com/pomerium/ingress-controller/v0.32.9/deployment.yaml
+  - https://raw.githubusercontent.com/pomerium/ingress-controller/0-32-0/deployment.yaml
 patches:
   - path: patch-proxy-external-dns.yaml
 ```
@@ -150,7 +150,7 @@ Make sure to always restrict access to the envoy admin interface ingress.
 
 ```yaml title="kustomization.yaml"
 resources:
-  - github.com/pomerium/ingress-controller/config/default?ref=v0.32.9
+  - github.com/pomerium/ingress-controller/config/default?ref=0-32-0
   - admin-service.yaml
   - admin-ingress.yaml
 patches:

--- a/content/docs/deploy/k8s/install.md
+++ b/content/docs/deploy/k8s/install.md
@@ -18,7 +18,7 @@ Use Pomerium as a first-class secure-by-default Ingress Controller. The Pomerium
 ## Deploy
 
 ```console
-kubectl apply -k github.com/pomerium/ingress-controller/config/default\?ref=v0.32.0
+kubectl apply -k github.com/pomerium/ingress-controller/config/default\?ref=v0.32.9
 ```
 
 The Pomerium Ingress Controller is now installed into your cluster.
@@ -78,7 +78,7 @@ kustomize build config/default
 
 ```yaml title="kustomization.yaml"
 resources:
-  - https://raw.githubusercontent.com/pomerium/ingress-controller/v0.32.0/deployment.yaml
+  - https://raw.githubusercontent.com/pomerium/ingress-controller/v0.32.9/deployment.yaml
 patches:
   - path: patch-proxy-external-dns.yaml
 ```
@@ -105,7 +105,7 @@ You must configure [storage persistence](/docs/internals/data-storage) in order 
 
 ```yaml title="kustomization.yaml"
 resources:
-  - https://raw.githubusercontent.com/pomerium/ingress-controller/v0.32.0/deployment.yaml
+  - https://raw.githubusercontent.com/pomerium/ingress-controller/v0.32.9/deployment.yaml
 patches:
   - path: deployment.yaml
 ```
@@ -126,7 +126,7 @@ An `IngressClass` may be designated as a [default controller](https://kubernetes
 
 ```yaml title="kustomization.yaml"
 resources:
-  - https://raw.githubusercontent.com/pomerium/ingress-controller/v0.32.0/deployment.yaml
+  - https://raw.githubusercontent.com/pomerium/ingress-controller/v0.32.9/deployment.yaml
 patches:
   - path: patch-proxy-external-dns.yaml
 ```
@@ -150,7 +150,7 @@ Make sure to always restrict access to the envoy admin interface ingress.
 
 ```yaml title="kustomization.yaml"
 resources:
-  - github.com/pomerium/ingress-controller/config/default?ref=v0.32.0
+  - github.com/pomerium/ingress-controller/config/default?ref=v0.32.9
   - admin-service.yaml
   - admin-ingress.yaml
 patches:

--- a/content/docs/deploy/k8s/quickstart.mdx
+++ b/content/docs/deploy/k8s/quickstart.mdx
@@ -58,7 +58,7 @@ mkcert "*.localhost.pomerium.io"
 1. Install Pomerium to your cluster:
 
 ```sh
-kubectl apply -k github.com/pomerium/ingress-controller/config/default\?ref=v0.32.0
+kubectl apply -k github.com/pomerium/ingress-controller/config/default\?ref=0-32-0
 ```
 
 This will create all the components of Pomerium in the `pomerium` namespace, as well as a bootstrap secret:


### PR DESCRIPTION
Follow-up to #2295, where @kenjenkins asked whether the kustomization examples should track the latest patch release. This goes one step further than a patch bump: since the docs on main are evergreen, all install references now point at the `0-32-0` release branches (ingress-controller and core `k8s/zero`) instead of a pinned patch tag. The branch tip is currently identical to v0.32.9 and floats over future patch releases automatically, so this page stops rotting every patch; it only needs an update at minor release cuts. Also bumps the Gateway API CRD install from v1.2.0 to v1.4.1, matching the version the controller is built against (its go.mod), rather than latest (v1.6.0), which is ahead of what the controller supports.

Backport note: the same branch refs are correct on the 0-32-0 docs line, so this carries the backport label.

One upstream observation while verifying: the released ingress-controller `deployment.yaml` (both the v0.32.9 tag and the branch tip) pins the `pomerium-gen-secrets` Job image to `:main`. Known behavior, tracked internally; not addressable from docs.

**AI assistance:** AI-drafted; branch/tag equivalence, manifest URLs, kustomize paths, and the gateway-api support version were verified against the ingress-controller and core repos. Human review happens in this PR.
