### PR TITLE
docs: standardize PROXY protocol capitalization

### DIFF
--- a/content/docs/deploy/k8s/reference.md
+++ b/content/docs/deploy/k8s/reference.md
@@ -354,7 +354,7 @@ PomeriumSpec defines Pomerium-specific configuration parameters.
                     <strong>boolean</strong>&#160;
                 </p>
                 <p>
-                    UseProxyProtocol enables <a href="https://www.pomerium.com/docs/reference/use-proxy-protocol">Proxy Protocol</a> support.
+                    UseProxyProtocol enables <a href="https://www.pomerium.com/docs/reference/use-proxy-protocol">PROXY protocol</a> support.
                 </p>
             </td>
         </tr>

--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -1866,11 +1866,11 @@
     "title": "Tracing Sample Rate"
   },
   "use-proxy-protocol": {
-    "description": "Requires the proxy protocol on incoming connections.",
+    "description": "Requires the PROXY protocol on incoming connections.",
     "id": "use-proxy-protocol",
     "path": "/use-proxy-protocol",
     "services": [],
-    "title": "Use Proxy Protocol",
+    "title": "Use PROXY Protocol",
     "type": "bool"
   },
   "websocket-connections": {

--- a/content/docs/reference/use-proxy-protocol.mdx
+++ b/content/docs/reference/use-proxy-protocol.mdx
@@ -1,9 +1,9 @@
 ---
 id: use-proxy-protocol
-title: Use Proxy Protocol
+title: Use PROXY Protocol
 keywords:
   - reference
-  - Use Proxy Protocol
+  - Use PROXY Protocol
 pagination_prev: null
 pagination_next: null
 toc_max_heading_level: 2
@@ -12,15 +12,15 @@ toc_max_heading_level: 2
 import TabItem from '@theme/TabItem';
 import Tabs from '@theme/Tabs';
 
-# Use Proxy Protocol
+# Use PROXY Protocol
 
 ## Summary
 
-Setting **Use Proxy Protocol** will configure Pomerium to require the [HAProxy proxy protocol](https://www.haproxy.org/download/1.9/doc/proxy-protocol.txt) on incoming connections. Versions 1 and 2 of the protocol are supported.
+Setting **Use PROXY Protocol** configures Pomerium to require the [PROXY protocol](https://www.haproxy.org/download/1.9/doc/proxy-protocol.txt) on incoming connections. Versions 1 and 2 of the protocol are supported.
 
 :::caution
 
-Proxy protocol is not currently compatible with http/3 and will be disabled on the QUIC UDP listener.
+PROXY protocol is not currently compatible with HTTP/3 and will be disabled on the QUIC UDP listener.
 
 :::
 


### PR DESCRIPTION
## Summary
- Standardize the user-facing setting page and reference table to `PROXY protocol` for the named wire protocol.
- Keep docs title case on page/table titles as `Use PROXY Protocol`.
- Sync the copied Kubernetes reference output with pomerium/ingress-controller#1464.

Follow-up to the capitalization discussion on #2299.

## Validation
- `yarn install --frozen-lockfile`
- `yarn run check`
- `yarn build` (passes with existing MUI X license and unrelated broken-anchor warnings)
- `yarn test:generated-links`
- `git diff --check`
- Targeted stale-term search for `Proxy Protocol`, `proxy protocol`, and `http/3` in touched files
- Compared the copied Kubernetes reference snippet against ingress-controller `reference.md`

## AI Assistance
AI drafted the terminology cleanup, checked the protocol spelling against upstream/ecosystem docs, and ran validation. I reviewed the final diffs and adopted reviewer feedback to also correct `http/3` to `HTTP/3` in the touched caution.
