### PR TITLE
document pomerium-cli service account flags

### DIFF
--- a/content/docs/deploy/clients/clients.mdx
+++ b/content/docs/deploy/clients/clients.mdx
@@ -343,14 +343,16 @@ pomerium-cli tcp [destination] [flags]
 | <a className="entRef-anchor" id="--browser-cmd">#</a><a href='#--browser-cmd'>--browser-cmd</a> | Custom browser command to run when opening a URL. | string |
 | <a className="entRef-anchor" id="--ca-cert">#</a><a href='#--ca-cert'>--ca-cert</a> | Path to CA certificate to use for HTTP requests. | string |
 | <a className="entRef-anchor" id="--client-cert">#</a><a href='#--client-cert'>--client-cert</a> | (optional) PEM-encoded client certificate. | string |
-| <a className="entRef-anchor" id=" --client-key">#</a><a href='# --client-key'> --client-key</a> | (optional) PEM-encoded client certificate key. | string |
+| <a className="entRef-anchor" id="--client-key">#</a><a href='#--client-key'> --client-key</a> | (optional) PEM-encoded client certificate key. | string |
 | <a className="entRef-anchor" id="--client-cert-from-store">#</a><a href='#--client-cert-from-store'> --client-cert-from-store</a> | (optional) If provided, pomerium-cli will attempt to use a client certificate from the system trust store (macOS and Windows only), searching for a certificate based on the trusted CA names advertised by Pomerium in the TLS handshake. | none |
 | <a className="entRef-anchor" id="--client-cert-issuer">#</a><a href='#--client-cert-issuer'> --client-cert-issuer</a> | (optional) When used in combination with --client-cert-from-store, restricts the client certificate search based on a particular attribute of the certificate's [Issuer name](#certificate-name-filters). | string |
 | <a className="entRef-anchor" id="--client-cert-subject">#</a><a href='#--client-cert-subject'> --client-cert-subject</a> | (optional) When used in combination with --client-cert-from-store, restricts the client certificate search based on a particular attribute of the certificate's [Subject name](#certificate-name-filters). | string |
-| <a className="entRef-anchor" id=" --disable-tls-verification">#</a><a href='# --disable-tls-verification'>--disable-tls-verification</a> | Disables TLS verification. | none |
+| <a className="entRef-anchor" id="--disable-tls-verification">#</a><a href='#--disable-tls-verification'>--disable-tls-verification</a> | Disables TLS verification. | none |
 | <a className="entRef-anchor" id="--help">#</a><a href='#--help'>-h, --help</a> | Help for tcp. | none |
 | <a className="entRef-anchor" id="--listen">#</a><a href='#--listen'>--listen</a> | Local address to start a listener on (default "127.0.0.1:0"). | string |
 | <a className="entRef-anchor" id="--pomerium-url">#</a><a href='#--pomerium-url'>--pomerium-url</a> | The URL of the Pomerium server to connect to. | string |
+| <a className="entRef-anchor" id="--service-account">#</a><a href='#--service-account'>--service-account</a> | Pomerium [service account] token to use for authentication. | string |
+| <a className="entRef-anchor" id="--service-account-file">#</a><a href='#--service-account-file'>--service-account-file</a> | File path to a Pomerium [service account] token to use for authentication. | string |
 | <a className="entRef-anchor" id="--version">#</a><a href='#--version'>-v, --version</a> | Version for pomerium-cli. | none |
 
 #### Certificate name filters
@@ -454,3 +456,5 @@ Then, connect to a TCP route:
 - [Desktop Releases](https://github.com/pomerium/desktop-client/releases)
 
 Pomerium unifies access for HTTP, TCP, and UDP behind a single identity-based control plane. This gives you SSO, granular authorization, and consistent security logs for all your applications and services, without needing a separate VPN or manual tunnels.
+
+[service account]: /docs/capabilities/service-accounts


### PR DESCRIPTION
## Summary

Add the pomerium-cli flags for service account authentication.

Remove a stray space from a couple of the other flag link IDs.

## Related

- Docs for PR https://github.com/pomerium/cli/pull/164

## AI disclosure

none

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated UPGRADING.md
- [ ] updated CHANGELOG.md
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
