### PR TITLE
docs(ssh): link reverse tunneling interactive tutorial

### DIFF
--- a/content/docs/capabilities/mcp/tunnel-to-chatgpt.mdx
+++ b/content/docs/capabilities/mcp/tunnel-to-chatgpt.mdx
@@ -95,6 +95,8 @@ The TUI panes show:
 - **Port Forward Status** — status of tunnels into your local machine
 - **Logs** — events from the Pomerium proxy server
 
+`ssh -R 0 pom.run` is the `-R` reverse tunneling feature described in [Reverse Tunneling](/docs/capabilities/reverse-tunneling), applied to a single-command `pom.run` shortcut. See that page for the full `-R` syntax reference, static vs. dynamic port forwarding, high availability, and troubleshooting.
+
 ### 4. Create a ChatGPT App
 
 Sign in to your ChatGPT Plus account. Go to **Settings → Apps → Advanced settings**, enable **Developer mode**, then click **Create app**.

--- a/content/docs/capabilities/mcp/tunnel-to-chatgpt.mdx
+++ b/content/docs/capabilities/mcp/tunnel-to-chatgpt.mdx
@@ -95,7 +95,7 @@ The TUI panes show:
 - **Port Forward Status** — status of tunnels into your local machine
 - **Logs** — events from the Pomerium proxy server
 
-`ssh -R 0 pom.run` is the `-R` reverse tunneling feature described in [Reverse Tunneling](/docs/capabilities/reverse-tunneling), applied to a single-command `pom.run` shortcut. See that page for the full `-R` syntax reference, static vs. dynamic port forwarding, high availability, and troubleshooting.
+`pom.run` is Pomerium's hosted reverse-tunnel endpoint; `ssh -R 0 pom.run` uses the same `-R` reverse tunneling feature described in [Reverse Tunneling](/docs/capabilities/reverse-tunneling). See that page for the full `-R` syntax reference, static vs. dynamic port forwarding, high availability, and troubleshooting.
 
 ### 4. Create a ChatGPT App
 

--- a/content/docs/capabilities/reverse-tunneling.mdx
+++ b/content/docs/capabilities/reverse-tunneling.mdx
@@ -23,6 +23,12 @@ import CodeBlock from '@theme/CodeBlock';
 
 ![Diagram](./img/ssh/reverse-tunnel.svg)
 
+:::tip Interactive Tutorial
+
+Try the [**Native SSH Reverse Tunneling with Pomerium**](https://usepom.link/reverse-ssh) interactive tutorial on iximiuz labs for a hands-on walkthrough. It's free to use, but you'll need to create an account.
+
+:::
+
 Any HTTP or SSH route can be configured to route upstream traffic through authenticated SSH clients using reverse port-forwarding.
 
 When a route is in this mode, Pomerium will not route traffic for that route directly to upstream servers. Instead, SSH clients can connect to Pomerium and register themselves as upstream endpoints for the route (for as long as they remain connected and authenticated). Then, when a downstream client connects to the route, Pomerium will tell a connected SSH client to open a connection to the "real" upstream server via reverse port-forward.


### PR DESCRIPTION
## Summary

- Add the Native SSH Reverse Tunneling interactive tutorial (`usepom.link/reverse-ssh`) to the Reverse Tunneling capability doc, matching the existing tutorial callout on the Native SSH Access page.
- Cross-link the MCP tunnel-to-ChatGPT walkthrough to the full Reverse Tunneling reference doc for the complete `-R` syntax, HA, and troubleshooting details.

## Related

Closes [ENG-4131](https://linear.app/pomerium/issue/ENG-4131/add-interactive-reverse-ssh-tunneling-guide-to-reverse-tunnelling)

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated UPGRADING.md
- [ ] updated CHANGELOG.md

## AI Disclosure

Sonnet 5 and Claude Code made the changes and I suggested some revisions.