### PR TITLE
force uuid package >= 11.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "postcss": ">=8.5.10",
     "qs": ">=6.14.1",
     "serialize-javascript": ">=6.0.3",
+    "uuid": ">=11.1.1",
     "webpack": ">=5.104.1",
     "webpack-dev-server": ">=5.2.1",
     "yaml": ">=1.10.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13036,15 +13036,10 @@ utils-merge@1.0.1:
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@8.3.2, uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
-"uuid@^11.1.0 || ^12 || ^13 || ^14.0.0":
-  version "11.1.0"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz"
-  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
+uuid@8.3.2, uuid@>=11.1.1, "uuid@^11.1.0 || ^12 || ^13 || ^14.0.0", uuid@^8.3.2:
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.1.tgz#8a5975b3e038902bfd169a10b5202f5ec0cf3faf"
+  integrity sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==
 
 uvu@^0.5.0:
   version "0.5.6"


### PR DESCRIPTION
## Summary

Force the npm `uuid` package to at least v11.1.1.

## Related

- https://github.com/pomerium/documentation/security/dependabot/151

## AI disclosure

none

## Checklist

- [x] reference any related issues
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
