### PR TITLE
chore: add upgrade note for 0.33.0

### DIFF
--- a/content/docs/deploy/upgrading.mdx
+++ b/content/docs/deploy/upgrading.mdx
@@ -25,6 +25,10 @@ Changelog notes for Pomerium Core can be found on [GitHub](https://github.com/po
 
 This page contains the list of deprecations and important or breaking changes for Pomerium Core. Please read it carefully before upgrading.
 
+### 0.33.0
+
+Pomerium no longer ships Darwin x86_64 (Intel macOS) binary builds.
+
 ### 0.32.0
 
 #### Upgrade Enterprise Console before Core


### PR DESCRIPTION
## Summary

Adds an upgrade note for the discontinued darwin x64_64 builds

## Related

N/A

## AI disclosure

none

## Checklist

- [X] reference any related issues
- [X] disclosed AI usage (or wrote "none") per AI_POLICY.md
