### PR TITLE
docs: update ingress-controller install refs to v0.33.0

### DIFF
--- a/content/docs/deploy/k8s/gateway-api.mdx
+++ b/content/docs/deploy/k8s/gateway-api.mdx
@@ -69,7 +69,7 @@ To install the Pomerium Ingress Controller with support for Gateway API:
 1. Then install the Pomerium Ingress Controller using the `gateway-api` kustomization:
 
    ```sh
-   kubectl apply -k github.com/pomerium/ingress-controller/config/gateway-api\?ref=0-32-0
+   kubectl apply -k github.com/pomerium/ingress-controller/config/gateway-api\?ref=v0.33.0
    ```
 
    This installs and configures the Ingress Controller, and adds a [GatewayClass](https://gateway-api.sigs.k8s.io/concepts/api-overview/#gatewayclass) named `pomerium-gateway` for use with the Gateway API.

--- a/content/docs/deploy/k8s/install.md
+++ b/content/docs/deploy/k8s/install.md
@@ -18,7 +18,7 @@ Use Pomerium as a first-class secure-by-default Ingress Controller. The Pomerium
 ## Deploy
 
 ```console
-kubectl apply -k github.com/pomerium/ingress-controller/config/default\?ref=0-32-0
+kubectl apply -k github.com/pomerium/ingress-controller/config/default\?ref=v0.33.0
 ```
 
 The Pomerium Ingress Controller is now installed into your cluster.
@@ -78,7 +78,7 @@ kustomize build config/default
 
 ```yaml title="kustomization.yaml"
 resources:
-  - https://raw.githubusercontent.com/pomerium/ingress-controller/0-32-0/deployment.yaml
+  - https://raw.githubusercontent.com/pomerium/ingress-controller/v0.33.0/deployment.yaml
 patches:
   - path: patch-proxy-external-dns.yaml
 ```
@@ -105,7 +105,7 @@ You must configure [storage persistence](/docs/internals/data-storage) in order 
 
 ```yaml title="kustomization.yaml"
 resources:
-  - https://raw.githubusercontent.com/pomerium/ingress-controller/0-32-0/deployment.yaml
+  - https://raw.githubusercontent.com/pomerium/ingress-controller/v0.33.0/deployment.yaml
 patches:
   - path: deployment.yaml
 ```
@@ -126,7 +126,7 @@ An `IngressClass` may be designated as a [default controller](https://kubernetes
 
 ```yaml title="kustomization.yaml"
 resources:
-  - https://raw.githubusercontent.com/pomerium/ingress-controller/0-32-0/deployment.yaml
+  - https://raw.githubusercontent.com/pomerium/ingress-controller/v0.33.0/deployment.yaml
 patches:
   - path: patch-proxy-external-dns.yaml
 ```
@@ -150,7 +150,7 @@ Make sure to always restrict access to the envoy admin interface ingress.
 
 ```yaml title="kustomization.yaml"
 resources:
-  - github.com/pomerium/ingress-controller/config/default?ref=0-32-0
+  - github.com/pomerium/ingress-controller/config/default?ref=v0.33.0
   - admin-service.yaml
   - admin-ingress.yaml
 patches:

--- a/content/docs/deploy/k8s/quickstart.mdx
+++ b/content/docs/deploy/k8s/quickstart.mdx
@@ -58,7 +58,7 @@ mkcert "*.localhost.pomerium.io"
 1. Install Pomerium to your cluster:
 
 ```sh
-kubectl apply -k github.com/pomerium/ingress-controller/config/default\?ref=0-32-0
+kubectl apply -k github.com/pomerium/ingress-controller/config/default\?ref=v0.33.0
 ```
 
 This will create all the components of Pomerium in the `pomerium` namespace, as well as a bootstrap secret:


### PR DESCRIPTION
## Summary

Update the Ingress Controller install references in the Deploy → Kubernetes docs from `0-32-0` to the `v0.33.0` tag. Covers the main install command, the External-DNS / Multiple Replicas / IngressClass / Envoy Admin kustomize snippets, the quickstart install step, and the gateway-api kustomization.

Verified the `v0.33.0` tag exists in `pomerium/ingress-controller`.

## Related

<!-- none -->

## AI disclosure

Claude Code made the edits and drafted this description; I reviewed and confirmed the tag exists.

## Checklist

- [ ] reference any related issues
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
