### PR TITLE
docs: fix Homebrew 6 install commands

### DIFF
--- a/content/docs/deploy/clients/clients.mdx
+++ b/content/docs/deploy/clients/clients.mdx
@@ -117,9 +117,10 @@ pkg_gpgcheck=1
 <TabItem value="homebrew" label="Homebrew (macOS)">
 
 ```bash
-brew tap pomerium/tap
-brew install pomerium-cli
+brew install pomerium/tap/pomerium-cli
 ```
+
+Homebrew 6 and later refuse packages from untrusted third-party taps. A fully-qualified install automatically trusts only Pomerium CLI, not the entire tap. If an existing install fails with `Refusing to load formula ... from untrusted tap`, upgrade with `brew upgrade pomerium/tap/pomerium-cli`.
 
 </TabItem>
 
@@ -155,9 +156,10 @@ Run the installer. Right-click the tray icon to manage connections.
 <TabItem value="macos" label="macOS">
 
 ```bash
-brew tap pomerium/tap
-brew install pomerium-desktop
+brew install --cask pomerium/tap/pomerium-desktop
 ```
+
+Homebrew 6 and later refuse packages from untrusted third-party taps. A fully-qualified install automatically trusts only Pomerium Desktop, not the entire tap. If an existing install fails with `Refusing to load cask ... from untrusted tap`, upgrade with `brew upgrade --cask pomerium/tap/pomerium-desktop`.
 
 Or download the `.dmg` and drag it into Applications. Interact with it via the menu bar icon.
 


### PR DESCRIPTION
## Summary

Homebrew 6 refuses to load untrusted third-party formulae and casks, so the documented `brew tap pomerium/tap` followed by a short-name install now fails before Homebrew can load the Pomerium package.

Install by fully-qualified name instead. Homebrew taps the repository and trusts only the named Pomerium formula or cask, avoiding a broader trust grant for everything in the tap. Each tab also gives existing users the fully-qualified upgrade command that resolves the same refusal.

## Related

- [ENG-4286](https://linear.app/pomerium/issue/ENG-4286/homebrew-repair-homebrew-6-install-and-desktop-release-updates)
- [Homebrew tap trust model](https://docs.brew.sh/Tap-Trust)

## Testing

- `yarn format-check`
- `yarn cspell`
- `yarn build`

The CLI and Desktop install commands were tested with Homebrew 6.0.13 from a clean, untrusted state. Both trusted only the named package and proceeded successfully. Homebrew 6.0.13's `cmd/upgrade.rb` routes fully-qualified upgrade arguments through the same item-specific trust path. The local trust store was restored after testing.

## AI disclosure

Claude Code diagnosed the trust-gate failure and drafted the initial edits. Codex verified the Homebrew behavior, refined the wording, and ran the final repository checks.

## Checklist

- [x] reference any related issues
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md