### PR TITLE
reference.json: update 'ssh-tunneling' link

### DIFF
--- a/content/docs/reference/reference.json
+++ b/content/docs/reference/reference.json
@@ -1722,7 +1722,7 @@
   "ssh-tunneling": {
     "description": "When enabled, this route must be served by one or more SSH reverse tunnel connections. Pomerium will not initiate a direct connection to the 'To' URL.",
     "id": "ssh-tunneling",
-    "path": "/../capabilities/non-http/examples/ssh",
+    "path": "/../capabilities/reverse-tunneling",
     "title": "SSH Tunneling"
   },
   "ssh-user-ca-key": {


### PR DESCRIPTION
## Summary

We have a dedicated [Reverse Tunneling](https://www.pomerium.com/docs/capabilities/reverse-tunneling) docs page now, which provides better context for the SSH reverse tunneling setting.

## Related

https://linear.app/pomerium/issue/ENG-3771/zero-help-icon-for-reverse-tunnel-setting-should-link-to-new

## AI disclosure

none

## Checklist

- [x] reference any related issues
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
