### PR TITLE
docs: removed experimental mcp messaging

### DIFF
--- a/content/docs/capabilities/mcp/delegate-mcp-to-llm.mdx
+++ b/content/docs/capabilities/mcp/delegate-mcp-to-llm.mdx
@@ -78,9 +78,6 @@ The key insight: your app never calls MCP servers directly. It hands the user's 
 Your deployment needs two types of routes: a **client** route for your chat app and one or more **server** routes for MCP servers.
 
 ```yaml
-runtime_flags:
-  mcp: true
-
 routes:
   # Your chat app (MCP client)
   - from: https://chat-app.your-domain.com
@@ -120,12 +117,6 @@ routes:
           - domain:
               is: company.com
 ```
-
-:::warning Experimental Feature
-
-MCP support is currently an experimental feature only available in the `main` branch or Docker images built from `main`. To enable MCP functionality, you must set `runtime_flags.mcp: true` in your [Pomerium configuration](/docs/internals/configuration).
-
-:::
 
 ## Step-by-step
 

--- a/content/docs/capabilities/mcp/develop-mcp-app.mdx
+++ b/content/docs/capabilities/mcp/develop-mcp-app.mdx
@@ -214,9 +214,6 @@ Inline mode is not needed in production — once deployed to a public URL, hosts
 You need two Pomerium routes — one for the MCP server (auth-gated) and one for the widgets (public):
 
 ```yaml
-runtime_flags:
-  mcp: true
-
 routes:
   # MCP server — fine-grained authorization required for tool calls
   - from: https://my-mcp-app.your-domain.com

--- a/content/docs/capabilities/mcp/mcp-upstream-oauth.mdx
+++ b/content/docs/capabilities/mcp/mcp-upstream-oauth.mdx
@@ -66,9 +66,6 @@ Use static OAuth2 when you have pre-registered OAuth credentials and know the pr
 ### Configuration
 
 ```yaml
-runtime_flags:
-  mcp: true
-
 routes:
   - from: https://github.your-domain.com
     to: http://github-mcp.int:8080/mcp
@@ -96,12 +93,6 @@ routes:
           - mcp_tool:
               starts_with: 'admin_'
 ```
-
-:::warning Experimental Feature
-
-MCP support is currently an experimental feature only available in the `main` branch or Docker images built from `main`. To enable MCP functionality, you must set `runtime_flags.mcp: true` in your [Pomerium configuration](/docs/internals/configuration).
-
-:::
 
 ### Step-by-step
 
@@ -215,9 +206,6 @@ This is the mode to use when connecting to third-party MCP servers where you don
 Auto-discovery requires no upstream OAuth credentials — just define the MCP server route without an `upstream_oauth2` block:
 
 ```yaml
-runtime_flags:
-  mcp: true
-
 routes:
   - from: https://notion.your-domain.com
     to: https://mcp.notion.com

--- a/content/docs/capabilities/mcp/protect-mcp-server.mdx
+++ b/content/docs/capabilities/mcp/protect-mcp-server.mdx
@@ -39,9 +39,6 @@ sequenceDiagram
 ## Configuration
 
 ```yaml
-runtime_flags:
-  mcp: true
-
 routes:
   - from: https://my-mcp-server.your-domain.com
     to: http://my-mcp-server.int:8080/mcp
@@ -59,12 +56,6 @@ routes:
           - mcp_tool:
               starts_with: 'admin_'
 ```
-
-:::warning Experimental Feature
-
-MCP support is currently an experimental feature only available in the `main` branch or Docker images built from `main`. To enable MCP functionality, you must set `runtime_flags.mcp: true` in your [Pomerium configuration](/docs/internals/configuration).
-
-:::
 
 ## Step-by-step
 

--- a/content/docs/capabilities/mcp/reference.mdx
+++ b/content/docs/capabilities/mcp/reference.mdx
@@ -17,17 +17,6 @@ Visit the [MCP landing page](/docs/capabilities/mcp) to find the blueprint that 
 
 This page is the exhaustive reference for Pomerium's Model Context Protocol (MCP) support. It covers every configuration option, token type, security consideration, and observability feature.
 
-:::warning Experimental Feature
-
-MCP support is currently an experimental feature only available in the `main` branch or Docker images built from `main`. To enable MCP functionality, you must set the following feature flag in your [Pomerium configuration](/docs/internals/configuration):
-
-```yaml
-runtime_flags:
-  mcp: true
-```
-
-:::
-
 ## Architecture Overview
 
 Pomerium supports three primary MCP integration patterns. Each pattern has its own dedicated blueprint with step-by-step instructions:

--- a/content/docs/guides/mcp-bridge.mdx
+++ b/content/docs/guides/mcp-bridge.mdx
@@ -67,6 +67,7 @@ Before you start, confirm all of the following:
 - A Linear workspace, and permission from a Linear admin for members to authorize a third-party OAuth client (the client will be Pomerium). No Linear OAuth application registration is required. Linear's MCP server advertises its own authorization metadata and Pomerium registers itself automatically.
 - An MCP-capable client for testing. This guide uses the [MCP Inspector](https://github.com/modelcontextprotocol/inspector) (`npx @modelcontextprotocol/inspector@latest`) because it exposes the raw OAuth and tool-call steps. Claude Desktop, ChatGPT, VS Code, and Cursor also work once the route is live.
 - DNS for the route's `from` subdomain resolves to your Pomerium Zero cluster. On `*.<your-cluster>.pomerium.app` subdomains this is automatic; for custom domains see [Custom Domains](/docs/capabilities/custom-domains).
+- MCP requires Pomerium v0.33.0 or later, which the default `pomerium/pomerium:latest` image satisfies. On earlier versions, set `runtime_flags.mcp: true` in your [Pomerium configuration](/docs/internals/configuration); it defaults to false before v0.33.0.
 - At least one policy exists in your cluster that you can attach to the Linear MCP route. A route needs a policy to allow anything; if you haven't created any yet, follow [Zero Build Policies](/docs/get-started/fundamentals/zero/zero-build-policies) to create a simple domain-based policy first, or plan to create one inline from the route editor in step 3.
 
 ## Architecture and request flow

--- a/content/docs/guides/mcp-bridge.mdx
+++ b/content/docs/guides/mcp-bridge.mdx
@@ -67,14 +67,7 @@ Before you start, confirm all of the following:
 - A Linear workspace, and permission from a Linear admin for members to authorize a third-party OAuth client (the client will be Pomerium). No Linear OAuth application registration is required. Linear's MCP server advertises its own authorization metadata and Pomerium registers itself automatically.
 - An MCP-capable client for testing. This guide uses the [MCP Inspector](https://github.com/modelcontextprotocol/inspector) (`npx @modelcontextprotocol/inspector@latest`) because it exposes the raw OAuth and tool-call steps. Claude Desktop, ChatGPT, VS Code, and Cursor also work once the route is live.
 - DNS for the route's `from` subdomain resolves to your Pomerium Zero cluster. On `*.<your-cluster>.pomerium.app` subdomains this is automatic; for custom domains see [Custom Domains](/docs/capabilities/custom-domains).
-- The Pomerium replica running on your cluster must be a build that includes MCP. MCP is still experimental and its code paths ship only in images built from the `main` branch: `pomerium/pomerium:main` (nightly) or a custom build from source. The default `pomerium/pomerium:latest` is the most recent stable release and does **not** include MCP support. If you followed the [Pomerium Zero Quickstart](/docs/get-started/quickstart?type=zero), the starter compose file uses `:latest`; swap it for `:main` on any cluster where you plan to configure MCP routes. See [Docker Images](/docs/deploy/core#docker-images) for the full tag taxonomy.
 - At least one policy exists in your cluster that you can attach to the Linear MCP route. A route needs a policy to allow anything; if you haven't created any yet, follow [Zero Build Policies](/docs/get-started/fundamentals/zero/zero-build-policies) to create a simple domain-based policy first, or plan to create one inline from the route editor in step 3.
-
-:::warning Not for regulated production workloads
-
-Do not rely on this guide for regulated production workloads without additional review. See the [MCP Full Reference](/docs/capabilities/mcp/reference) for current status.
-
-:::
 
 ## Architecture and request flow
 

--- a/content/docs/guides/mcp-bridge.mdx
+++ b/content/docs/guides/mcp-bridge.mdx
@@ -67,7 +67,7 @@ Before you start, confirm all of the following:
 - A Linear workspace, and permission from a Linear admin for members to authorize a third-party OAuth client (the client will be Pomerium). No Linear OAuth application registration is required. Linear's MCP server advertises its own authorization metadata and Pomerium registers itself automatically.
 - An MCP-capable client for testing. This guide uses the [MCP Inspector](https://github.com/modelcontextprotocol/inspector) (`npx @modelcontextprotocol/inspector@latest`) because it exposes the raw OAuth and tool-call steps. Claude Desktop, ChatGPT, VS Code, and Cursor also work once the route is live.
 - DNS for the route's `from` subdomain resolves to your Pomerium Zero cluster. On `*.<your-cluster>.pomerium.app` subdomains this is automatic; for custom domains see [Custom Domains](/docs/capabilities/custom-domains).
-- MCP requires Pomerium v0.33.0 or later, which the default `pomerium/pomerium:latest` image satisfies. On earlier versions, set `runtime_flags.mcp: true` in your [Pomerium configuration](/docs/internals/configuration); it defaults to false before v0.33.0.
+- As of v0.33.0, MCP is not experimental and does not require a runtime flag.
 - At least one policy exists in your cluster that you can attach to the Linear MCP route. A route needs a policy to allow anything; if you haven't created any yet, follow [Zero Build Policies](/docs/get-started/fundamentals/zero/zero-build-policies) to create a simple domain-based policy first, or plan to create one inline from the route editor in step 3.
 
 ## Architecture and request flow


### PR DESCRIPTION
## Summary

Removes messaging around MCP support being experimental as it's on by default now as of v0.30 (see https://github.com/pomerium/pomerium/pull/6521).

## Related

Closes [ENG-4296](https://linear.app/pomerium/issue/ENG-4296/remove-experimental-mcp-support-references-from-documentation)
Relates to [ENG-4168](https://linear.app/pomerium/issue/ENG-4168/mcp-split-a-narrow-dcr-feature-flag-enable-the-mcp-runtime-flag-by)

## AI disclosure

Removed the mcp runtime flag references and warnings manually and then had Claude (Sonnet 5) scan the docs repo for mentions of experimental mcp use.

```
runtime_flags:
  mcp: true
```

```
:::warning Experimental Feature

MCP support is currently an experimental feature only available in the `main` branch or Docker images built from `main`. To enable MCP functionality, you must set `runtime_flags.mcp: true` in your [Pomerium configuration](/docs/internals/configuration).

:::
```

## Checklist

- [x] reference any related issues
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
