### PR TITLE
docs: stop referencing the ingress-controller deployment.yaml

### DIFF
--- a/content/docs/deploy/k8s/gateway-api.mdx
+++ b/content/docs/deploy/k8s/gateway-api.mdx
@@ -69,7 +69,7 @@ To install the Pomerium Ingress Controller with support for Gateway API:
 1. Then install the Pomerium Ingress Controller using the `gateway-api` kustomization:
 
    ```sh
-   kubectl apply -k github.com/pomerium/ingress-controller/config/gateway-api\?ref=0-32-0
+   kubectl apply -k github.com/pomerium/ingress-controller/config/gateway-api\?ref=0-33-0
    ```
 
    This installs and configures the Ingress Controller, and adds a [GatewayClass](https://gateway-api.sigs.k8s.io/concepts/api-overview/#gatewayclass) named `pomerium-gateway` for use with the Gateway API.

--- a/content/docs/deploy/k8s/install.md
+++ b/content/docs/deploy/k8s/install.md
@@ -18,7 +18,7 @@ Use Pomerium as a first-class secure-by-default Ingress Controller. The Pomerium
 ## Deploy
 
 ```console
-kubectl apply -k github.com/pomerium/ingress-controller/config/default\?ref=0-32-0
+kubectl apply -k github.com/pomerium/ingress-controller/config/default\?ref=0-33-0
 ```
 
 The Pomerium Ingress Controller is now installed into your cluster.
@@ -26,6 +26,33 @@ The Pomerium Ingress Controller is now installed into your cluster.
 :::note
 
 You need complete [Global Configuration](./configure) for Pomerium to become fully operational, before you can [configure Ingress](./ingress).
+
+:::
+
+## Deployment variants
+
+`config/default` is the standard install, but it is not the only one. Each path below is a complete kustomization you can apply directly in place of `config/default`, or reference as a base in your own `kustomization.yaml`.
+
+| Path | Description |
+| --- | --- |
+| `config/default` | Controller and Pomerium core, CRDs, RBAC, and the bootstrap secrets job. The standard install. |
+| `config/default-no-crd` | `default` without the CRD definitions, for when the CRDs are installed and owned separately — a dedicated Argo CD Application, Terraform, or a cluster admin — so the two do not compete over the schema. |
+| `config/gateway-api` | `default` plus a `GatewayClass` and the `--experimental-gateway-api` flag. See [Gateway API](./gateway-api). |
+| `config/clustered-databroker` | Replaces the `pomerium` `Deployment` with a `StatefulSet` and adds a `pomerium-headless` `Service`, so the built-in databroker can run clustered across replicas. |
+| `config/clustered-databroker-no-crd` | The clustered databroker variant, without the CRD definitions. |
+| `config/http3-eks` | `default` with the `pomerium-proxy` service configured for HTTP/3 on an AWS Network Load Balancer. |
+| `config/http3-gke` | `default` with the `pomerium-proxy` service configured for HTTP/3 on a GKE regional external load balancer. |
+| `config/ssh` | `default` with the SSH listener enabled on port `4022`. |
+
+For example, to install the Gateway API variant:
+
+```console
+kubectl apply -k github.com/pomerium/ingress-controller/config/gateway-api\?ref=0-33-0
+```
+
+:::note
+
+Always pin `?ref=` to a version branch such as `0-33-0` rather than `main`, so that your installs are reproducible and you upgrade deliberately.
 
 :::
 
@@ -61,13 +88,14 @@ The following resources are created:
 3. `pomerium-proxy` `Service` of type `LoadBalancer`, provisioning an external IP address, that listens on `:80` and `:443` ports. All HTTP requests are upgraded to HTTPS requests.
 4. `pomerium-metrics` `Service` of type `ClusterIP`, accessible from within the cluster, exposing `/metrics` Prometheus-style metrics endpoint.
 5. `pomerium-gen-secrets` one-time `Job` that generates an initial set of bootstrap secrets, and stores them into the `bootstrap` `Secret`.
-6. [Pomerium CRD](./reference) definitions.
-7. RBAC rules.
+6. `pomerium` `IngressClass`, with the `pomerium.io/ingress-controller` controller.
+7. [Pomerium CRD](./reference) definitions.
+8. RBAC rules.
 
-The default manifest may be rebuilt by running the below command in the [`pomerium/ingress-controller`](https://github.com/pomerium/ingress-controller/tree/main/config) repo.
+You may render this set of resources to a flat manifest — to inspect it, to review it in a pull request, or to feed a pipeline that does not run `kustomize` itself — with [`kustomize`](https://kustomize.io/) directly against the [`pomerium/ingress-controller`](https://github.com/pomerium/ingress-controller/tree/main/config) repo:
 
 ```console
-kustomize build config/default
+kustomize build github.com/pomerium/ingress-controller/config/default\?ref=0-33-0
 ```
 
 </details>
@@ -78,7 +106,7 @@ kustomize build config/default
 
 ```yaml title="kustomization.yaml"
 resources:
-  - https://raw.githubusercontent.com/pomerium/ingress-controller/0-32-0/deployment.yaml
+  - github.com/pomerium/ingress-controller/config/default?ref=0-33-0
 patches:
   - path: patch-proxy-external-dns.yaml
 ```
@@ -105,12 +133,12 @@ You must configure [storage persistence](/docs/internals/data-storage) in order 
 
 ```yaml title="kustomization.yaml"
 resources:
-  - https://raw.githubusercontent.com/pomerium/ingress-controller/0-32-0/deployment.yaml
+  - github.com/pomerium/ingress-controller/config/default?ref=0-33-0
 patches:
-  - path: deployment.yaml
+  - path: patch-replicas.yaml
 ```
 
-```yaml title="deployment.yaml"
+```yaml title="patch-replicas.yaml"
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -126,9 +154,9 @@ An `IngressClass` may be designated as a [default controller](https://kubernetes
 
 ```yaml title="kustomization.yaml"
 resources:
-  - https://raw.githubusercontent.com/pomerium/ingress-controller/0-32-0/deployment.yaml
+  - github.com/pomerium/ingress-controller/config/default?ref=0-33-0
 patches:
-  - path: patch-proxy-external-dns.yaml
+  - path: patch-ingress-class.yaml
 ```
 
 ```yaml title="patch-ingress-class.yaml"
@@ -150,7 +178,7 @@ Make sure to always restrict access to the envoy admin interface ingress.
 
 ```yaml title="kustomization.yaml"
 resources:
-  - github.com/pomerium/ingress-controller/config/default?ref=0-32-0
+  - github.com/pomerium/ingress-controller/config/default?ref=0-33-0
   - admin-service.yaml
   - admin-ingress.yaml
 patches:

--- a/content/docs/deploy/k8s/quickstart.mdx
+++ b/content/docs/deploy/k8s/quickstart.mdx
@@ -58,7 +58,7 @@ mkcert "*.localhost.pomerium.io"
 1. Install Pomerium to your cluster:
 
 ```sh
-kubectl apply -k github.com/pomerium/ingress-controller/config/default\?ref=0-32-0
+kubectl apply -k github.com/pomerium/ingress-controller/config/default\?ref=0-33-0
 ```
 
 This will create all the components of Pomerium in the `pomerium` namespace, as well as a bootstrap secret:


### PR DESCRIPTION
Docs side of pomerium/ingress-controller#1500 — pairs with pomerium/ingress-controller#1501, which removes the file.

## Why

The generated `deployment.yaml` at the root of `pomerium/ingress-controller` is being retired. It was the committed output of `kustomize build config/default`, added when `kubectl` had no built-in kustomize support. Three kustomization examples on the k8s install page still referenced it by raw URL.

## Changes

**Replaced the raw-URL references** (`install.md`, 3 occurrences) with the remote-base form the rest of the page already used:

```diff
 resources:
-  - https://raw.githubusercontent.com/pomerium/ingress-controller/0-32-0/deployment.yaml
+  - github.com/pomerium/ingress-controller/config/default?ref=0-33-0
```

**Bumped ingress-controller refs `0-32-0` → `0-33-0`** across the k8s docs: `install.md` (Deploy, Envoy admin), `quickstart.mdx`, `gateway-api.mdx`.

**Added a "Deployment variants" section** to `install.md` — part of the argument for dropping `deployment.yaml` is that a single flat manifest could only ever represent `config/default`, while `config/` offers eight installable kustomizations. The table lists them with what each one changes.

**Rewrote the `kustomize build` note** in the base-installation summary. It previously told you to run `kustomize build config/default` "in the repo", which assumed a local clone; it now builds against the remote ref, so it works standalone and still serves anyone who genuinely needs a flat manifest.

## Two pre-existing bugs fixed along the way

Both surfaced while verifying the examples actually build:

- The **default-`IngressClass`** snippet listed `patches: - path: patch-proxy-external-dns.yaml` while displaying a `patch-ingress-class.yaml` file — copy/paste from the section above. Following it as written applied the external-DNS annotation instead of the default-class annotation.
- The **base installation summary** enumerated 7 created resources but omitted the `pomerium` `IngressClass` — despite a later section on making it the cluster default.

I also renamed the Multiple Replicas patch file from `deployment.yaml` to `patch-replicas.yaml`, matching the `patch-*.yaml` convention used by the neighbouring examples (and no longer colliding in name with the file being retired).

## Verification

Every kustomization example on the page was built with kustomize v5.8.1 against `ref=0-33-0`, and the resulting objects checked — not just eyeballed:

| Example | Result |
| --- | --- |
| Base `config/default` | builds; 18 objects |
| External-DNS | `external-dns.alpha.kubernetes.io/hostname` present on `pomerium-proxy` |
| Multiple Replicas | `replicas: 2` on the `pomerium` Deployment |
| Default `IngressClass` | `is-default-class: "true"` present (confirmed the base emits `IngressClass` with no namespace, so matching on name alone is correct) |
| Expose Envoy Admin | `--debug-admin-addr=localhost:9901` appended to args |

All eight variants in the new table build at `ref=0-33-0`, and each claim was checked against the output: `default-no-crd`/`clustered-databroker-no-crd` emit 0 CRDs, `gateway-api` emits a `GatewayClass` plus `--experimental-gateway-api`, `clustered-databroker` emits a `StatefulSet` and `pomerium-headless` Service and no Deployment, `ssh` emits `--ssh-addr=:4022` and container port 4022, and both http3 variants emit a UDP `quic` port with the expected `loadBalancerClass`. `gateway-api.mdx`'s claim that the GatewayClass is named `pomerium-gateway` also still holds at 0-33-0.

`oxfmt --check` passes on all three files.

## Notes for the reviewer

- `content/docs/deploy/k8s/sync-api.mdx:47` and `k8s/core/kustomization.yaml:5` pin the ingress-controller to `?ref=main`. I left both alone since `main` may be deliberate there, but they're inconsistent with the pinning advice this page now gives.
- `content/docs/deploy/enterprise/install.mdx` still pins `pomerium/documentation` overlays to `0-31-0`. Unrelated to the ingress-controller, so out of scope here.
- Unrelated to this PR, but worth flagging upstream: `config/gateway-api` emits `namespace: pomerium` on the cluster-scoped `GatewayClass`. Harmless — the API server ignores it — but `IngressClass` correctly has no namespace, because kustomize knows that type is cluster-scoped and cannot know the same about a CRD.