### PR TITLE
docs: fix reference table rendering in dark mode

### DIFF
--- a/src/components/ReferenceTable.js
+++ b/src/components/ReferenceTable.js
@@ -1,8 +1,10 @@
 import {useColorMode} from '@docusaurus/theme-common';
+import {ThemeProvider} from '@mui/material/styles';
 import {DataGrid, GridToolbar} from '@mui/x-data-grid';
-import React, {useState} from 'react';
+import React, {useMemo, useState} from 'react';
 
 import data from '../../content/docs/reference/reference.json';
+import createAppTheme from '../theme/muiTheme';
 import {renderCellExpand} from './RenderCellExpand';
 
 function filterHidden(item) {
@@ -16,6 +18,7 @@ export default function ReferenceTable() {
   });
 
   const {colorMode} = useColorMode();
+  const theme = useMemo(() => createAppTheme(colorMode), [colorMode]);
 
   const references = Object.values(data);
   const columns = [
@@ -60,58 +63,44 @@ export default function ReferenceTable() {
   ];
 
   return (
-    <div style={{width: '100%'}}>
-      <DataGrid
-        initialState={{
-          sorting: {
-            sortModel: [{field: 'title', sort: 'asc'}],
-          },
-        }}
-        disableRowSelectionOnClick
-        autoHeight
-        pageSizeOptions={[5, 10, 25, 50]}
-        pagination
-        paginationModel={paginationModel}
-        onPaginationModelChange={setPaginationModel}
-        showToolbar
-        sx={{
-          color:
-            colorMode === 'dark'
-              ? 'rgba(224,224,224,1);'
-              : 'rgba(0, 0, 0, 0.54);',
-          '& .MuiDataGrid-columnHeader:last-child .MuiDataGrid-columnSeparator--sideRight':
-            {
-              display: 'none',
+    <ThemeProvider theme={theme}>
+      <div style={{width: '100%'}}>
+        <DataGrid
+          initialState={{
+            sorting: {
+              sortModel: [{field: 'title', sort: 'asc'}],
             },
-          '& .MuiDataGrid-sortIcon': {
-            color:
-              colorMode === 'dark'
-                ? 'rgba(224,224,224,1);'
-                : 'rgba(0, 0, 0, 0.54);',
-          },
-          '& .MuiDataGrid-menuIconButton': {
-            color:
-              colorMode === 'dark'
-                ? 'rgba(224,224,224,1);'
-                : 'rgba(0, 0, 0, 0.54);',
-          },
-        }}
-        columns={columns}
-        rows={references.filter(filterHidden)}
-        slots={{
-          toolbar: GridToolbar,
-        }}
-        slotProps={{
-          toolbar: {
-            printOptions: {
-              disableToolbarButton: true,
+          }}
+          disableRowSelectionOnClick
+          autoHeight
+          pageSizeOptions={[5, 10, 25, 50]}
+          pagination
+          paginationModel={paginationModel}
+          onPaginationModelChange={setPaginationModel}
+          showToolbar
+          sx={{
+            '& .MuiDataGrid-columnHeader:last-child .MuiDataGrid-columnSeparator--sideRight':
+              {
+                display: 'none',
+              },
+          }}
+          columns={columns}
+          rows={references.filter(filterHidden)}
+          slots={{
+            toolbar: GridToolbar,
+          }}
+          slotProps={{
+            toolbar: {
+              printOptions: {
+                disableToolbarButton: true,
+              },
+              csvOptions: {
+                disableToolbarButton: true,
+              },
             },
-            csvOptions: {
-              disableToolbarButton: true,
-            },
-          },
-        }}
-      />
-    </div>
+          }}
+        />
+      </div>
+    </ThemeProvider>
   );
 }

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,51 +1,13 @@
-import {ThemeProvider, createTheme} from '@mui/material/styles';
+import {ThemeProvider} from '@mui/material/styles';
 import React from 'react';
 
 import App from '../../src/components/App';
+import createAppTheme from './muiTheme';
 
-const theme = createTheme({
-  palette: {
-    primary: {
-      main: '#6f43e7',
-      light: '#8c69ec',
-      dark: '#5936b9',
-    },
-    secondary: {
-      main: '#49AAA1',
-      light: '#809BD1',
-      dark: '#5176B8',
-    },
-  },
-  components: {
-    MuiDataGrid: {
-      styleOverrides: {
-        root: {
-          '& .MuiDataGrid-toolbarContainer .MuiButtonBase-root': {
-            marginLeft: '8px',
-            padding: '0, 4px, 0, 4px',
-          },
-          '& .MuiDataGrid-iconButtonContainer': {
-            marginLeft: '10px',
-          },
-          '& .MuiDataGrid-cell--textLeft': {
-            paddingLeft: '15px',
-          },
-          '& .MuiDataGrid-columnHeaderTitle': {
-            fontWeight: '600',
-          },
-          '& .MuiTablePagination-selectLabel': {
-            padding: '0px',
-            margin: '0px',
-          },
-          '& .MuiTablePagination-displayedRows': {
-            padding: '0px',
-            margin: '0px',
-          },
-        },
-      },
-    },
-  },
-});
+// Root renders outside Docusaurus' ColorModeProvider, so the color mode isn't
+// readable here. Components that need dark mode (see ReferenceTable) nest their
+// own mode-aware ThemeProvider.
+const theme = createAppTheme('light');
 
 export default function Root({children}) {
   return (

--- a/src/theme/muiTheme.js
+++ b/src/theme/muiTheme.js
@@ -1,0 +1,61 @@
+import {createTheme} from '@mui/material/styles';
+
+// Keep MUI's surfaces and primary color aligned with Infima's, so MUI
+// components blend into the docs theme in both color modes. The values mirror
+// the Infima defaults and the dark `--ifm-color-primary` from src/css/custom.css.
+const paletteByMode = {
+  light: {
+    primary: {main: '#6f43e7', light: '#8c69ec', dark: '#5936b9'},
+    background: {default: '#ffffff', paper: '#ffffff'},
+  },
+  dark: {
+    primary: {main: '#b296ff', light: '#c5b1ff', dark: '#7d56e9'},
+    background: {default: '#1b1b1d', paper: '#242526'},
+  },
+};
+
+export default function createAppTheme(mode = 'light') {
+  const {primary, background} = paletteByMode[mode] ?? paletteByMode.light;
+
+  return createTheme({
+    palette: {
+      mode,
+      primary,
+      background,
+      secondary: {
+        main: '#49AAA1',
+        light: '#809BD1',
+        dark: '#5176B8',
+      },
+    },
+    components: {
+      MuiDataGrid: {
+        styleOverrides: {
+          root: {
+            '& .MuiDataGrid-toolbarContainer .MuiButtonBase-root': {
+              marginLeft: '8px',
+              padding: '0, 4px, 0, 4px',
+            },
+            '& .MuiDataGrid-iconButtonContainer': {
+              marginLeft: '10px',
+            },
+            '& .MuiDataGrid-cell--textLeft': {
+              paddingLeft: '15px',
+            },
+            '& .MuiDataGrid-columnHeaderTitle': {
+              fontWeight: '600',
+            },
+            '& .MuiTablePagination-selectLabel': {
+              padding: '0px',
+              margin: '0px',
+            },
+            '& .MuiTablePagination-displayedRows': {
+              padding: '0px',
+              margin: '0px',
+            },
+          },
+        },
+      },
+    },
+  });
+}


### PR DESCRIPTION
## Summary

The Reference page's config table was unreadable in dark mode: light-gray text on a white grid surface.

The MUI theme in `src/theme/Root.js` was created without `palette.mode`, so every MUI component was permanently light-mode and the DataGrid kept a white background regardless of the site theme. `ReferenceTable.js` papered over this by forcing `rgba(224,224,224,1)` text in dark mode — onto that still-white surface.

`Root` renders outside Docusaurus' `ColorModeProvider` (Docusaurus renders `<Root><ThemeProvider>…`), so `useColorMode()` can't be called there — that's why the workaround existed.

Changes:

- `src/theme/muiTheme.js` (new) — `createAppTheme(mode)` builds the theme for a given color mode. The brand palette and `MuiDataGrid` style overrides moved here from `Root.js`. Dark mode uses the Infima dark primary (`#b296ff`, matching `src/css/custom.css`) and Docusaurus surface colors (`#1b1b1d` / `#242526`) so the grid blends with the page instead of using MUI's default `#121212`.
- `src/components/ReferenceTable.js` — nests its own `ThemeProvider` built from `useColorMode()`, which works there; drops the hardcoded text / sort-icon / menu-icon color overrides. The column-separator rule stays.
- `src/theme/Root.js` — uses the shared factory with an explicit light theme, plus a comment explaining why the mode isn't readable at that level.

Verified with `npm run build` + `docusaurus serve`, screenshotting `/docs/reference` in both modes: dark now has a dark grid surface, readable text, purple links and visible toolbar/sort/menu icons; light is unchanged except body text is full-contrast instead of the old 54%-opacity gray. `npm run format:check` passes.

Follow-up, not in this PR: other MUI consumers (homepage video cards, footer icon button) are still light-only. Fixing those site-wide would mean moving the `ThemeProvider` into a swizzled `Layout` wrapper, which renders inside `ColorModeProvider`.

## Related

n/a

## AI disclosure

Claude Code (Opus 5) diagnosed the root cause, wrote the change, and verified it by building the site and screenshotting both color modes.

## Checklist

- [ ] reference any related issues
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
