### PR TITLE
fix a policy annotation syntax example

### DIFF
--- a/content/docs/reference/routes/allow-any-authenticated-user.mdx
+++ b/content/docs/reference/routes/allow-any-authenticated-user.mdx
@@ -55,7 +55,7 @@ Enable **Any Authenticated User** in the **Policy Builder** in the Console:
 ### Examples
 
 ```yaml
-ingress.pomerium.io/allow_any_authenticated_user: true
+ingress.pomerium.io/allow_any_authenticated_user: 'true'
 ```
 
 </TabItem>


### PR DESCRIPTION
## Summary

All the k8s object annotation values need to be strings, so we have to quote `'true'` so it doesn't parse as a boolean.

I searched for other cases where we had an `ingress.pomerium.io/` annotation with an unquoted `true` but didn't find any.

## Related

## AI disclosure

none

## Checklist

- [ ] reference any related issues
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
