### PR TITLE
set console to v0.33.2

### DIFF
--- a/k8s/console/deployment/image.yaml
+++ b/k8s/console/deployment/image.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: pomerium-console
-          image: docker.cloudsmith.io/pomerium/enterprise/pomerium-console:v0.33.0
+          image: docker.cloudsmith.io/pomerium/enterprise/pomerium-console:v0.33.2
           imagePullPolicy: IfNotPresent
       imagePullSecrets:
         - name: pomerium-enterprise-docker


### PR DESCRIPTION
Bumps the Console image in `k8s/console/deployment/image.yaml` to v0.33.2.