### PR TITLE
remove the path-to-regexp override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15977,6 +15977,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -21250,9 +21256,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
       "license": "MIT"
     },
     "node_modules/path-type": {
@@ -23702,6 +23708,15 @@
         "react": ">=15"
       }
     },
+    "node_modules/react-router/node_modules/path-to-regexp": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
     "node_modules/react-router/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -24838,6 +24853,16 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/rtlcss": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "mdx-mermaid": {
       "unist-util-visit": "$unist-util-visit"
     },
-    "path-to-regexp": "^0.1.13",
     "picomatch": ">=2.3.2",
     "postcss": ">=8.5.10",
     "qs": ">=6.14.1",


### PR DESCRIPTION
## Summary

The docs site dev mode (`npm run start`) was failing with the message
```
[ERROR] TypeError: pathRegexp.match is not a function
```
 (at least on my machine).

I think the overridden `path-to-regexp` version is no longer compatible with the current `express` module version. Let's see if we can remove the `path-to-regexp` override.

## Related

n/a

## AI disclosure

Claude Opus 4.5 suggested removing the `path-to-regexp` override.

## Checklist

- [ ] reference any related issues
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
